### PR TITLE
chooseTarget选择目标时加隐藏目标的设定，戏志才先辅时不在目标上播放动画，防止暴露先辅目标。

### DIFF
--- a/character/sp.js
+++ b/character/sp.js
@@ -3307,7 +3307,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						if(att>0) return att+1;
 						if(att==0) return Math.random();
 						return att;
-					});
+					}).set('hideTarget',true);
 					'step 1'
 					if(result.bool){
 						var target=result.targets[0];

--- a/game/game.js
+++ b/game/game.js
@@ -12777,7 +12777,7 @@
 							ui.click.cancel();
 						}
 					}
-					if(event.result.bool){
+					if(event.result.bool && event.hideTarget !== true){
 						for(var i=0;i<event.result.targets.length;i++){
 							event.result.targets[i].animate('target');
 						}


### PR DESCRIPTION
chooseTarget选择目标时加隐藏目标的设定，戏志才先辅时不在目标上播放动画，防止暴露先辅目标。
目前戏志才通过先辅选择的目标会闪一下红色边框，暴露实际目标。在chooseTarget事件中新增一个表示是否隐藏目标的选项。