### PR TITLE
Fix the crash/alert on "get extension" page

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -42257,7 +42257,17 @@
 								});
 							}
 							else{
-								lib.init.js(extensionURL.replace(/raw\.githubusercontent\.com/,'rawgit.com')+'catalog.js',null,loaded,function(){
+								lib.init.req(extensionURL.replace(/raw\.githubusercontent\.com/,'rawgit.com')+'catalog.js',function(){
+									try{
+										eval(this.responseText);
+									}
+									catch(e){
+										delete window.extension;
+										loading.innerHTML='连接失败';
+										return;
+									}
+									loaded();
+								},function(){
 									delete window.extension;
 									loading.innerHTML='连接失败';
 								});


### PR DESCRIPTION
# Issue

## Product
noname (source code version)

## Version
main/79f93bed23346b12d66a06d9feff87987bea8813

## Component
Extensions

## Platform
Chromium/Chrome/Firefox/Safari

## OS
MacOS Monterey 12.5.1

## Priority
P5

## Severity
Trivial

## Summary
When click on "Get Extension", an alert pops up showing an unhelpful message

## Description

### Reproduce Steps
1. Check out the main branch.
1. Open the `index.html`.
1. Go to "Extension"/"Get Extension".

Expected Result:
No alerts appears

Actual Result:
Get crash/alert after the extension server responds with the following data.
```
{"msg":{"user_not_login":"用户未登录"},"data":{"account_type":"0"},"code":1000}
```

# PR

## Root Cause
When using the source version of the game, the game is trying to request `catagory.js` with `lib.init.js`, which does not catch exceptions when the response is not a valid JS code. (In this case, a JSON indicating an error)

## Fix
By replacing `lib.init.js` with `lib.init.req` and handle the exception explicitly, (like what is done if the game is downloaded version) the crash disappears and a normal "failed to connect" message shows on the page.