### PR TITLE
Add Docker support for server deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,27 @@ GitHub： https://github.com/libccy/noname/releases/tag/SSS
 Coding： https://nakamurayuri.coding.net/p/noname/d/noname/git/releases/SSS
 
 网页端推荐使用Chrome系内核浏览器游玩，不推荐使用Firefox浏览器
+
+
+## 使用docker部署noname服务器
+
+## 前置条件
+在开始之前，请确保你已经安装了 Docker。你可以从官方网站下载安装包并按照说明进行安装。
+
+## 使用预先构建好的Docker容器镜像
+
+`docker run -p 8080:8080 -d cloudtom/noname-server:latest`
+
+## 自行构建镜像
+
+1.从 Github 上将项目克隆或下载到本地
+
+2.进入项目目录，并使用以下命令构建 Docker 镜像：
+
+`docker build -t <YOUR_IMAGE_NAME> .`
+
+3.使用以下命令启动 Docker 容器
+
+`docker run -p 8080:8080 -d <YOUR_IMAGE_NAME>`
+
+

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,16 @@
+# 使用官方 Node.js 镜像作为基础镜像
+FROM node:lts-alpine3.17
+
+# 将node_modules文件夹复制到 Docker 容器中的 /app 目录下
+COPY ./node_modules /app/node_modules
+# 将game/server.js 复制到 Docker 容器中的 /app 目录下
+COPY game/server.js /app
+
+# 切换工作目录到 /app
+WORKDIR /app
+
+# 对外暴露的端口
+EXPOSE 8080
+
+# 在容器启动时运行的命令
+CMD ["node", "server.js"]


### PR DESCRIPTION
为无名杀服务器部署添加Docker支持。添加了一个Dockerfile，可以用来构建一个包含无名杀服务端（server.js）的Docker容器。Docker容器包括Node.js和运行服务端代码的必要依赖。

增加Docker支持可以简化无名杀服务器的部署过程，提高服务器应用程序的可移植性。通过Docker，服务端代码可以很容易地部署到不同的环境中，而不必担心依赖性冲突或环境配置问题。