### PR TITLE
修改lib.init.parsex函数

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -9537,24 +9537,23 @@
 						//正则表达式
 						var reg=new RegExp(`['"]step ${k}['"]`);
 						var result=str.slice(skip).match(reg);
-						if(result == null) break;
+						if(result==null) break;
+						var insertStr;
 						if(k==0){
-							var insertStr=`switch(step){case 0:`;
-							str=str.slice(0, result.index)+insertStr+str.slice(result.index+result[0].length);
-							skip+=result.index+insertStr.length;
+							insertStr=`switch(step){case 0:`;
 						}else{
-							var insertStr=`break;case ${k}:`;
-							var copy=str;
-							copy=copy.slice(0,skip+result.index)+insertStr+copy.slice(skip+result.index+result[0].length);
-							//测试是否有错误
-							try{
-								new Function(copy);
-								str=copy;
-								skip+=result.index+insertStr.length;
-							}catch(error){
-								k--;
-								skip+=result.index+result[0].length;
-							}
+							insertStr=`break;case ${k}:`;
+						}
+						var copy=str;
+						copy=copy.slice(0,skip+result.index)+insertStr+copy.slice(skip+result.index+result[0].length);
+						//测试是否有错误
+						try{
+							new Function(copy);
+							str=copy;
+							skip+=result.index+insertStr.length;
+						}catch(error){
+							k--;
+							skip+=result.index+result[0].length;
 						}
 					}
 					str=`if(event.step==${k}){event.finish();return;}`+str;


### PR DESCRIPTION
修改lib.init.parsex函数，使其可以解析“step”嵌套“step”的函数。示例代码如下：
```
lib.skill._test = {
    trigger: {
        player: "phaseBegin"
    },
    content: function () {
        game.log('step 0');
        'step 0'
        player.draw();
        'step 1'
        var next = game.createEvent('test');
        next.player = player;
        next.setContent(function () {
            'step 0'
            game.log('step 1-0');
            'step 1'
            game.log('step 1-1');
            'step 2'
            game.log('step 1-2');
            player.draw(2);
        });
        game.log('step 2');
        'step 2'
        player.damage(2);
        game.log('step 3');
        'step 3'
        var next = game.createEvent('test');
        next.player = player;
        next.setContent(function () {
            'step 0'
            game.log('step 3-0');
            'step 1'
            game.log('step 3-1');
            player.draw(2);
        });
    }
};

game.addGlobalSkill('_test');
```