### PR TITLE
fix: adjust the edit box style to fix the text overflow problem 🐛

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -38452,6 +38452,9 @@
 							input.style.webkitUserSelect='text';
 						}
 						input.style.minWidth='10px';
+                        input.style.maxWidth='60%';
+						input.style.overflow='hidden';
+                        input.style.whiteSpace='nowrap';
 						input.onkeydown=function(e){
 							if(e.keyCode==13){
 								e.preventDefault();

--- a/mode/connect.js
+++ b/mode/connect.js
@@ -39,6 +39,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				node.contentEditable=true;
 				node.style.webkitUserSelect='text';
 				node.style.textAlign='center';
+                node.style.overflow='hidden';
 
 				var connect=function(e){
 					event.textnode.innerHTML='正在连接...';


### PR DESCRIPTION
# 调整编辑框样式修复编辑框文本溢出情况

## 环境
noname verison: commit id [7327225](https://github.com/libccy/noname/commit/73272251af93b27c1816d5b90c23a9036f0e9b0c)
Chrome: 114.0.5735.133 (x86_64)

## 重现
进入联机，输入较长的联机服务器地址如 `wss://127.0.0.1:8080/ws/servers/0001000001/aaaa/`，会触发文本溢出，在设置选项中也是如此，如下图所示

<img width="1470" alt="image01" src="https://github.com/libccy/noname/assets/39079814/3ac2e7f7-0d4a-4e7d-8824-924a4f2cb185">


## 预期
文本输入正常，文本样式正常，无溢出行为

## 方案
限制输入框最大宽度，禁止内容换行，修复设置项中内容溢出问题
[commit bfb2063](https://github.com/PBK-B/game-noname/commit/bfb20634e8886d715ea45dc865070e611219a954#diff-254305d27f3c2d679dc0a57c9ef67925ec61ba2ea25101cfc0379faca44dd435)

隐藏溢出内容，修复内容溢出问题
[commit bfb2063](https://github.com/PBK-B/game-noname/commit/bfb20634e8886d715ea45dc865070e611219a954#diff-88f050735a0f13ebebac53db3767075ff91ae9c6d8341dd9f6441624c8061f83)

<img width="1486" alt="image02" src="https://github.com/libccy/noname/assets/39079814/cc2dbb77-9aaf-4ad2-a199-240fd476bd96">


Source: [lzc-app 应用移植上游代码回馈计划](https://gitee.com/runui/lzc-game-noname)

