### PR TITLE
Fix "game.getDB", "game. deleteDB" and "game.playAudio"

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -37155,7 +37155,7 @@
 		},
 		getDB:function(type,id,callback){
 			if(!lib.db){
-				callback(null);
+				if(callback) callback(null);
 				return;
 			}
 			if(!callback) return;
@@ -37192,7 +37192,7 @@
 		},
 		deleteDB:function(type,id,callback){
 			if(!lib.db){
-				callback(false);
+				if(callback) callback(false);
 				return;
 			}
 			if(lib.status.reload){

--- a/game/game.js
+++ b/game/game.js
@@ -31024,6 +31024,9 @@
 					this._changed=true;
 				}
 			};
+			audio.oncanplay=function(){
+				this.play();
+			};
 			ui.window.appendChild(audio);
 			return audio;
 		},


### PR DESCRIPTION
Fix the issue of "game.getDB" and "game. deleteDB" reporting errors without "lib.db".

Some browsers do not support "autoplay", so "onconplay" listening has been added.