### PR TITLE
Add lib.element.player.getHp and change lib.element.player.getDamagedHp.

### DIFF
--- a/card/standard.js
+++ b/card/standard.js
@@ -3244,7 +3244,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 			wuxie_info:'一张锦囊牌生效前，对此牌使用。抵消此牌对一名角色产生的效果，或抵消另一张【无懈可击】产生的效果。',
 			lebu_info:'出牌阶段，对一名其他角色使用。若判定结果不为红桃，跳过其出牌阶段。',
 			shandian_info:'出牌阶段，对自己使用。若判定结果为黑桃2~9，则目标角色受到3点雷电伤害。若判定不为黑桃2~9，将之移动到下家的判定区里。',
-			icesha_skill:'冰杀',
+			icesha_skill:'冰冻',
 			icesha_skill_info:'防止即将造成的伤害，改为依次弃置其两张牌。',
 			qinggang2:'破防',
 		},

--- a/character/mobile.js
+++ b/character/mobile.js
@@ -1704,7 +1704,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						event._result={bool:false};
 					}
 					else{
-						trigger.player.chooseToDiscard(num,'弃置'+get.cnNumber(num)+'张手牌，或令杀的伤害+1').set('ai',function(card){
+						trigger.player.chooseToDiscard(num,'弃置'+get.cnNumber(num)+'张手牌，或令'+get.translation(player)+'对你造成的此伤害+1').set('ai',function(card){
 							var player=_status.event.player;
 							if(player.hp==1){
 								if(get.type(card)=='basic'){

--- a/game/game.js
+++ b/game/game.js
@@ -18468,8 +18468,11 @@
 				inRangeOf:function(source){
 					return source.inRange(this);
 				},
+				getHp:function(){
+					return Math.max(0,this.hp);
+				},
 				getDamagedHp:function(){
-					return this.maxHp-Math.max(0,this.hp);
+					return this.maxHp-this.getHp();
 				},
 				changeGroup:function(group,log,broadcast){
 					var next=game.createEvent('changeGroup');


### PR DESCRIPTION
新增`lib.element.player.getHp`，用来获取在规则集上定义的一名角色的体力值（至少为0），并且因此同时修改了用来获取一名角色已损失的体力值`lib.element.player.getDamagedHp`。
同时，定义一个关于`lib.element.player.hp`的获取器有助于代码封装。
顺便根据官方的描述规范公告修改名称为〖冰冻〗，以及修复手杀曹休〖倾袭〗中的`chooseToDiscard`的提示错误。