### PR TITLE
国战bug修复+南华老仙珠联璧合+十常侍bug修复

### DIFF
--- a/character/mobile.js
+++ b/character/mobile.js
@@ -504,8 +504,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							var names=map[first];
 							return !names.contains(changshi);
 						});
-						if(list.length==0) return others.randomGets(1);
-						return list;
+						return list.length?list:others;
 					}());
 					next.set('ai',button=>{
 						if(button.link=='scs_gaowang') return 10;
@@ -543,8 +542,13 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						},chosen);
 						if(skills.length){
 							player.addAdditionalSkill('mbdanggu',skills);
-							game.log(player,'获得了技能','#g'+get.translation(skills));
-							player.popup(skills);
+							var str='';
+							for(var i of skills){
+								str+='【'+get.translation(i)+'】、';
+								player.popup(i);
+							}
+							str=str.slice(0,-1);
+							game.log(player,'获得了技能','#g'+str);
 						}
 					}
 				},
@@ -1492,7 +1496,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						wuxie:function(){
 							'step 0'
 							var trigger=event.getParent().getTrigger();
-							var target=trigger.respondTo[0];
+							var target=trigger.getParent(2).player;
 							event.target=target;
 							if(!target||!target.countGainableCards(player,player==target?'e':'he')) event._result={bool:false};
 							else player.chooseBool(get.prompt('scsanruo_effect',target),'获得该角色的一张牌').set('ai',()=>{

--- a/character/sp2.js
+++ b/character/sp2.js
@@ -10018,7 +10018,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				return str;
 			},
 		},
-		perfectPair:{},
+		perfectPair:{
+			nanhualaoxian:['zuoci','yuji'],
+		},
 		characterReplace:{
 			lijue:['lijue','ns_lijue'],
 			fanchou:['fanchou','tw_fanchou','ns_fanchou'],

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -525,7 +525,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				gz_miheng:['male','qun',3,['gzrekuangcai','gzshejian'],['gzskin']],
 				gz_fengxi:['male','wu',3,['gzyusui','gzboyan'],['gzskin']],
 				gz_dengzhi:['male','shu',3,['gzjianliang','gzweimeng'],['gzskin']],
-				gz_re_nanhualaoxian:['male','qun',4,['gzgongxiu','gztaidan','gzrejinghe']],
+				gz_re_nanhualaoxian:['male','qun',3,['gzgongxiu','gztaidan','gzrejinghe']],
 				gz_zhouyi:['female','wu',3,['gzzhukou','gzduannian','gzlianyou']],
 				gz_re_xunchen:['male','qun',3,['gzfenglve','gzanyong']],
 				gz_lvlingqi:['female','qun',4,['guowu','gzshenwei','gzzhuangrong'],['gzskin']],
@@ -661,7 +661,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					return event.player.isFriendOf(player)&&event.targets.some(target=>target.isMajor());
 				},
 				check:function(event,player){
-					var num=0,targets=event.targets.some(target=>target.isMajor());
+					var num=0,targets=event.targets.filter(target=>target.isMajor());
 					for(var target of targets) num+=get.sgn(get.attitude(player,target)*get.effect(target,event.card,event.player,player));
 					return num>=0;
 				},
@@ -7619,6 +7619,137 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					},
 				},
 			},
+			yigui_gzshan:{
+				enable:'chooseToUse',
+				filter:function(event,player){
+					if(event.type!='respondShan'||!event.filterCard({name:'shan'},player,event)) return false;
+					var storage=player.storage.yigui,target=event.getParent().player;
+					if(!storage||!target||!storage.character.length||storage.used.contains('shan')) return false;
+					var identity=target.identity;
+					return ['unknown','ye'].contains(identity)||storage.character.some(function(i){
+						var double=get.is.double(i,true);
+						var groups=(double?double:[lib.character[i][1]]);
+						return groups.contains(identity);
+					});
+				},
+				chooseButton:{
+					dialog:function(event,player){
+						var dialog=ui.create.dialog('役鬼','hidden');
+						dialog.add([player.storage.yigui.character,'character']);
+						return dialog;
+					},
+					filter:function(button,player){
+						var evt=_status.event.getParent('chooseToUse');
+						var target=evt.getParent().player,identity=target.identity;
+						if(['unknown','ye'].contains(identity)) return true;
+						var double=get.is.double(button.link,true);
+						var groups=(double?double:[lib.character[button.link][1]]);
+						return groups.contains(identity);
+					},
+					check:function(button){
+						return 1/(1+game.countPlayer(function(current){
+							return current.identity==button.link;
+						}));
+					},
+					backup:function(links,player){
+						var character=links[0];
+						var next={
+							character:character,
+							filterCard:()=>false,
+							selectCard:-1,
+							complexCard:true,
+							check:()=>1,
+							popname:true,
+							audio:'yigui',
+							viewAs:{name:'shan',isCard:true},
+							onuse:function(result,player){
+								player.logSkill('yigui');
+								var character=lib.skill.yigui_gzshan_backup.character;
+								player.flashAvatar('yigui',character);
+								player.storage.yigui.character.remove(character);
+								_status.characterlist.add(character);
+								game.log(player,'从「魂」中移除了','#g'+get.translation(character));
+								player.syncStorage('yigui');
+								player.updateMarks('yigui');
+								player.storage.yigui.used.add(result.card.name);
+							},
+						};
+						return next;
+					},
+				},
+				ai:{
+					respondShan:true,
+					skillTagFilter:function(player){
+						var storage=player.storage.yigui;
+						if(!storage||!storage.character.length||storage.used.contains('shan')) return false;
+					},
+					order:0.1,
+					result:{player:1},
+				},
+			},
+			yigui_gzwuxie:{
+				enable:'chooseToUse',
+				filter:function(event,player){
+					if(event.type!='wuxie'||!event.filterCard({name:'wuxie'},player,event)) return false;
+					var storage=player.storage.yigui,target=event.getParent(2).player;
+					if(!storage||!target||!storage.character.length||storage.used.contains('wuxie')) return false;
+					var identity=target.identity;
+					return ['unknown','ye'].contains(identity)||storage.character.some(function(i){
+						var double=get.is.double(i,true);
+						var groups=(double?double:[lib.character[i][1]]);
+						return groups.contains(identity);
+					});
+				},
+				chooseButton:{
+					dialog:function(event,player){
+						var dialog=ui.create.dialog('役鬼','hidden');
+						dialog.add([player.storage.yigui.character,'character']);
+						return dialog;
+					},
+					filter:function(button,player){
+						var evt=_status.event.getParent('chooseToUse');
+						var target=evt.getParent(2).player,identity=target.identity;
+						if(['unknown','ye'].contains(identity)) return true;
+						var double=get.is.double(button.link,true);
+						var groups=(double?double:[lib.character[button.link][1]]);
+						return groups.contains(identity);
+					},
+					check:function(button){
+						return 1/(1+game.countPlayer(function(current){
+							return current.identity==button.link;
+						}));
+					},
+					backup:function(links,player){
+						var character=links[0];
+						var next={
+							character:character,
+							filterCard:()=>false,
+							selectCard:-1,
+							complexCard:true,
+							check:()=>1,
+							popname:true,
+							audio:'yigui',
+							viewAs:{name:'wuxie',isCard:true},
+							onuse:function(result,player){
+								player.logSkill('yigui');
+								var character=lib.skill.yigui_gzwuxie_backup.character;
+								player.flashAvatar('yigui',character);
+								player.storage.yigui.character.remove(character);
+								_status.characterlist.add(character);
+								game.log(player,'从「魂」中移除了','#g'+get.translation(character));
+								player.syncStorage('yigui');
+								player.updateMarks('yigui');
+								player.storage.yigui.used.add(result.card.name);
+							},
+						};
+						return next;
+					},
+				},
+				ai:{
+					order:0.1,
+					result:{player:1},
+				},
+			},
 			jihun:{
 				trigger:{
 					player:'damageEnd',
@@ -14409,15 +14540,17 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 			gzzongyu_info:'当【六龙骖驾】进入其他角色的装备区后，你可以将你装备区内所有坐骑牌（至少一张）与【六龙骖驾】交换位置。锁定技，当你使用坐骑牌后，若场上或弃牌堆中有【六龙骖驾】，则将【六龙骖驾】置入你的装备区。',
 			
 			yigui:"役鬼",
-			"yigui_info":"当你首次明置此武将牌时，你将剩余武将牌堆的两张牌扣置于游戏外，称为“魂”；你可以展示一张“魂”并将其置入剩余武将牌堆，视为使用了一张本回合内未以此法使用过的基本牌或普通锦囊牌。（此牌需指定目标，且目标须为未确定势力的角色或野心家或与此“魂”势力相同的角色）",
+			"yigui_info":"当你首次明置此武将牌时，你将剩余武将牌堆的两张牌置于武将牌上，称为“魂”；你可以展示一张武将牌上的“魂”并将其置入剩余武将牌堆，视为使用一张本回合内未以此法使用过的基本牌或普通锦囊牌。（此牌须指定目标，且目标须为未确定势力的角色或野心家或与此“魂”势力相同的角色）",
 			"yigui_init":"役鬼",
 			"yigui_init_info":"",
 			"yigui_refrain":"役鬼",
 			"yigui_refrain_info":"",
 			yigui_shan:'役鬼',
 			yigui_wuxie:'役鬼',
+			yigui_gzshan:'役鬼',
+			yigui_gzwuxie:'役鬼',
 			jihun:"汲魂",
-			jihun_info:"当你受到伤害后，或与你势力不同的角色脱离濒死状态后，你可以将剩余武将牌堆的一张牌当做“魂”扣置于游戏外。",
+			jihun_info:"当你受到伤害后，或与你势力不同的角色脱离濒死状态后，你可以将剩余武将牌堆的一张牌置于武将牌上，称为“魂”。",
 			
 			_guozhan_marks:'标记',
 			_guozhan_marks_backup:'标记',
@@ -15892,14 +16025,12 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					if(name2.indexOf('gz_shibing')==0) return false;
 					if(get.is.jun(this.name1)) return true;
 					if(choosing&&lib.character[name1][1]!='ye'&&lib.character[name2][1]!='ye'&&lib.character[name1][1]!=lib.character[name2][1]) return false;
-					var list=['re','diy','sp','jsp','shen','jg','xin','old','ol','sb','sc','gz'];
-					for(var i=0;i<list.length;i++){
-						if(name1.indexOf(list[i]+'_')==0){
-							name1=name1.slice(list[i].length+1);
-						}
-						if(name2.indexOf(list[i]+'_')==0){
-							name2=name2.slice(list[i].length+1);
-						}
+					//同时给两个名称删前缀，取消以前的前缀特殊性筛选
+					while(name1.indexOf('_')!=-1&&!lib.perfectPair[name1]){
+						name1=name1.slice(name1.indexOf('_')+1);
+					}
+					while(name2.indexOf('_')!=-1&&!lib.perfectPair[name2]){
+						name2=name2.slice(name2.indexOf('_')+1);
 					}
 					if(lib.perfectPair[name1]&&lib.perfectPair[name1].contains(name2)){
 						return true;


### PR DESCRIPTION
修复南华老仙体力值多出0.5阴阳鱼的bug
修复徐庶未引用技能【谦策】ai check的弹窗bug
修复珠联璧合只能筛选特定前缀的bug，改为同时删去双名前缀直到无前缀或者有珠联璧合
添加南华老仙的珠联璧合（左慈，于吉[汉末三仙]）
修复十常侍“结党”在无符合常侍结党的情况下只能选择系统随机挑选的一个的bug（改为可挑选四张常侍中的任意牌）
修复高望【安弱】转化无懈可击响应自己的延时锦囊报错的bug