### PR TITLE
Normalize vertical text using writing-mode.

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -26903,7 +26903,6 @@
 					if(card[0]=='heart'||card[0]=='diamond'){
 						this.node.info.classList.add('red');
 					}
-					this.node.name.innerHTML='';
 					this.node.image.className='image';
 					var name=get.translation(card[2]);
 					if(card[2]=='sha'){
@@ -26927,9 +26926,7 @@
 							name='刺'+name;
 						}
 					}
-					for(var i=0;i<name.length;i++){
-						this.node.name.innerHTML+=name[i]+'<br/>';
-					}
+					this.node.name.innerHTML=name;
 					if(name.length>=5){
 						this.node.name.classList.add('long');
 						if(name.length>=7){
@@ -54133,22 +54130,7 @@
 		},
 		verticalStr:function(str,sp){
 			if(typeof str!='string') return '';
-			str=str.toUpperCase();
-			var str2='';
-			var nobreak=false;
-			for(var i=0;i<str.length;i++){
-				if(str[i]=='`'){
-					nobreak=!nobreak;continue;
-				}
-				str2+=str[i];
-				if(nobreak) continue;
-				if(sp&&str[i]=='S'&&str[i+1]=='P') continue;
-				if(/[0-9]/.test(str[i])&&/[0-9]/.test(str[i+1])) continue;
-				if(i<str.length-1){
-					str2+='<br>';
-				}
-			}
-			return str2;
+			return str.split('').filter(value=>value!='`').join('');
 		},
 		numStr:function(num,method){
 			if(num==Infinity){

--- a/layout/default/layout.css
+++ b/layout/default/layout.css
@@ -387,6 +387,9 @@ table {
 	right: 7px;
 	bottom: 7px;
 	z-index: 1;
+	white-space: nowrap;
+	writing-mode: vertical-rl;
+	-webkit-writing-mode: vertical-rl;
 }
 #splash>div>.avatar {
 	width: 86px;
@@ -1319,6 +1322,9 @@ body>.background.land {
 	top: 9px;
 	left: 6px;
 	text-align: center;
+	white-space: nowrap;
+	writing-mode: vertical-rl;
+	-webkit-writing-mode: vertical-rl;
 }
 .card.fullimage>.name.long {
 	top: 6px;
@@ -1937,6 +1943,9 @@ div:not(.handcards)>.card>.info>span,
 	top: 22px;
 	max-height: 68px;
 	overflow: hidden;
+	white-space: nowrap;
+	writing-mode: vertical-rl;
+	-webkit-writing-mode: vertical-rl;
 }
 .button.character>.hp {
 	left: 5px;
@@ -2170,6 +2179,9 @@ div:not(.handcards)>.card>.info>span,
 	top: 24px;
 	font-size: 20px;
 	font-family: 'xinwei';
+	white-space: nowrap;
+	writing-mode: vertical-rl;
+	-webkit-writing-mode: vertical-rl;
 }
 .player>.name.name2 {
 	left: 81px
@@ -2201,7 +2213,7 @@ div:not(.handcards)>.card>.info>span,
 }
 
 .button.character>.name {
-	font-family: 'xinwei'
+	font-family: 'xinwei';
 }
 .player>.intro {
 	top: 87px;
@@ -2230,6 +2242,9 @@ div:not(.handcards)>.card>.info>span,
 	top:calc(50% - 50px);
     width: 100%;
     left: 0;
+	white-space: nowrap;
+	writing-mode: vertical-rl;
+	-webkit-writing-mode: vertical-rl;
 }
 .player>.chain{
 	top: calc(50% - 10px);
@@ -2829,6 +2844,9 @@ div:not(.handcards)>.card>.info>span,
 
 .player>.name_seat {
 	opacity: 0;
+	white-space: nowrap;
+	writing-mode: vertical-rl;
+	-webkit-writing-mode: vertical-rl;
 }
 .player:not([data-position='0']).unseen.unseen2>.name_seat,
 .player:not([data-position='0']):not(.fullskin2).unseen>.name_seat {
@@ -3765,6 +3783,9 @@ div:hover>.intro {
 #window>.choosedouble.character>.name {
 	left: 6%;
 	top: 8%;
+	white-space: nowrap;
+	writing-mode: vertical-rl;
+	-webkit-writing-mode: vertical-rl;
 }
 
 .hrefnode{
@@ -4211,10 +4232,8 @@ div[data-decoration="bronze"]::after{
 	left: 7px;
 	/*border:1px solid #631515;*/
 	border-radius: 4px;
-	padding-top: 2px;
-	padding-bottom: 2px;
-	padding-left: 1px;
-	padding-right: 1px;
+	padding-top: 3px;
+	padding-bottom: 3px;
 	/*color:#631515;*/
 	border: 1px solid rgb(74, 29, 1);
 	color: rgb(74, 29, 1);
@@ -4454,7 +4473,6 @@ div[data-decoration="bronze"]::after{
 }
 .coin_menu .content>.caption>.coin_buy>.menubutton {
 	width: auto;
-	display: inline-block;
 	position: relative;
 	float: right;
 	padding-left: 5px;

--- a/mode/versus.js
+++ b/mode/versus.js
@@ -278,7 +278,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					game.players[i].setIdentity(list[i]);
 					game.players[i].node.identity.style.display='none';
 					game.players[i].getId();
-					game.players[i].node.action.innerHTML='获即<br>胜将';
+					game.players[i].node.action.innerHTML='即将<br>获胜';
 					game.players[i].node.action.style.letterSpacing='0px';
 					game.players[i].node.action.style.lineHeight='22px';
 					game.players[i].node.action.style.top='3px';


### PR DESCRIPTION
使用`writing-mode`（兼容版使用`-webkit-writing-mode`）规范化竖排文本，从此以后的竖排文本不再需要使用`<br>`模拟，且完美支持拉丁字母书写体系（英文等），例如武将牌上的武将名。
以及修复小部分不规范的CSS。