### PR TITLE
Recast.

### DIFF
--- a/card/mtg.js
+++ b/card/mtg.js
@@ -484,36 +484,31 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 			},
 			mtg_yixialan_skill:{
 				enable:'phaseUse',
-				filter:function(event,player){
-					return player.countCards('h',{type:'basic'})>0;
-				},
-				filterCard:{type:'basic'},
-				prepare:function(cards,player){
-					player.$throw(cards,1000);
-				},
+				filter:(event,player)=>player.hasCard(card=>lib.skill.mtg_yixialan_skill.filterCard(card,player),'h'),
+				filterCard:(card,player)=>get.type(card)=='basic'&&player.canRecast(card),
 				discard:false,
-				delay:0.5,
+				lose:false,
 				check:function(card){
 					return 7-get.value(card);
 				},
 				usable:1,
 				content:function(){
-					var card=get.cardPile(function(card){
-						return get.type(card,'trick')=='trick'
+					player.recast(cards,null,(player,cards)=>{
+						const cardsToGain=[];
+						for(let repetition=0;repetition<cards.length;repetition++){
+							const card=get.cardPile(card=>get.type(card,'trick')=='trick');
+							if(card) cardsToGain.push(card);
+						}
+						if(cardsToGain.length) player.gain(cardsToGain,'draw');
+						if(cards.length-cardsToGain.length) player.draw(cards.length-cardsToGain.length).log=false;
 					});
-					if(card){
-						player.gain(card,'draw');
-					}
-					else{
-						player.draw();
-					}
 				},
 				ai:{
 					mapValue:2,
 					order:1,
 					result:{
-						player:1,
-					},
+						player:1
+					}
 				}
 			},
 			mtg_shuimomuxue_skill:{

--- a/card/yingbian.js
+++ b/card/yingbian.js
@@ -450,7 +450,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					'step 0'
-					player.chooseCard('h','是否发动【太公阴符】重铸一张手牌？').set('ai',function(card){
+					player.chooseCard('h','是否发动【太公阴符】重铸一张手牌？',lib.filter.cardRecastable).set('ai',function(card){
 						return 5-get.value(card);
 					});
 					'step 1'

--- a/character/ddd.js
+++ b/character/ddd.js
@@ -117,8 +117,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						target.useCard(result.targets,card,event.links);
 					}
 					else{
-						game.cardsDiscard(event.links);
-						target.draw(event.links.length);
+						target.recast(event.links,(player,cards)=>game.cardsDiscard(cards));
 					}
 					'step 4'
 					for(var card of cards){

--- a/character/diy.js
+++ b/character/diy.js
@@ -4919,34 +4919,25 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				audio:2,
 				enable:"phaseUse",
 				position:'he',
-				filter:function(event,player){
-					return player.countCards('he',{type:'equip'})>0;
-				},
-				filterCard:function(card){
-					return get.type(card)=='equip';
-				},
+				filter:(event,player)=>player.hasCard(card=>lib.skill.chihaya_huairou.filterCard(card,player),lib.skill.chihaya_huairou.position),
+				filterCard:(card,player)=>get.type(card)=='equip'&&player.canRecast(card),
 				check:function(card){
 					if(!_status.event.player.hasEquipableSlot(get.subtype(card))) return 5;
 					return 3-get.value(card);
 				},
 				content:function(){
-					player.draw();
+					player.recast(cards);
 				},
 				discard:false,
-				visible:true,
-				loseTo:'discardPile',
+				lose:false,
+				delay:false,
 				prompt:"将一张装备牌置入弃牌堆并摸一张牌",
-				delay:0.5,
-				prepare:function(cards,player){
-					player.$throw(cards,1000);
-					game.log(player,'将',cards,'置入了弃牌堆');
-				},
 				ai:{
 					order:10,
 					result:{
-						player:1,
-					},
-				},
+						player:1
+					}
+				}
 			},
 			chihaya_youfeng:{
 				enable:'chooseToUse',
@@ -16588,11 +16579,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			},
 			diyjuntun:{
 				enable:'phaseUse',
-				filter:function(event,player){
-					return player.countCards('he',{type:'equip'})>0;
-				},
+				filter:(event,player)=>player.hasCard(card=>lib.skill.diyjuntun.filterCard(card,player),'he'),
 				position:'he',
-				filterCard:{type:'equip'},
+				filterCard:(card,player)=>get.type(card)=='equip'&&player.canRecast(card),
 				check:function(card){
 					var player=_status.event.player;
 					var he=player.getCards('he');
@@ -16609,23 +16598,19 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					return 0;
 				},
 				content:function(){
-					player.draw();
+					player.recast(cards);
 				},
 				discard:false,
+				lose:false,
+				delay:false,
 				prompt:'将一张装备牌置入弃牌堆并摸一张牌',
-				delay:0.5,
-				loseTo:'discardPile',
-				prepare:function(cards,player){
-					player.$throw(cards,1000);
-					game.log(player,'将',cards,'置入了弃牌堆');
-				},
 				ai:{
 					basic:{
 						order:8.5
 					},
 					result:{
-						player:1,
-					},
+						player:1
+					}
 				}
 			},
 			choudu:{

--- a/character/diy.js
+++ b/character/diy.js
@@ -6035,12 +6035,12 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				trigger:{player:'phaseDiscardBegin'},
 				forced:true,
 				filter:function(event,player){
-					return (player.isDamaged()||player.countCards('h')-player.hp>1);
+					return (player.getDamagedHp()>1||player.countCards('h')-player.getHp()>1);
 				},
 				content:function(){
 					var num=0;
-					if(player.isDamaged()) num++;
-					if(player.countCards('h')-player.hp>1) num++;
+					if(player.getDamagedHp()>1) num++;
+					if(player.countCards('h')-player.getHp()>1) num++;
 					player.addMark('kotori_qunxin_temp',num,false);
 					player.addTempSkill('kotori_qunxin_temp','phaseDiscardEnd');
 				},

--- a/character/gwent.js
+++ b/character/gwent.js
@@ -484,12 +484,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					'step 0'
-					var hs=player.getCards('h');
-					event.num=hs.length;
-					player.lose(hs,ui.discardPile);
+					player.recast(player.getCards('h',lib.filter.cardRecastable));
 					'step 1'
-					player.draw(event.num,'nodelay');
-					'step 2'
 					var targets=player.getEnemies();
 					if(targets.length){
 						player.useCard({name:'sha'},targets.randomGet(),false);
@@ -1376,29 +1372,16 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			yangfan:{
 				trigger:{player:'useCard'},
 				forced:true,
-				filter:function(event,player){
-					return get.type(event.card)!='equip'&&player.countCards('h',{color:get.color(event.card)})>0;
-				},
+				filter:(event,player)=>get.type(event.card)!='equip'&&player.hasCard(card=>get.color(card)==get.color(trigger.card)&&player.canRecast(card),'h'),
 				content:function(){
 					'step 0'
-					var cards=player.getCards('h',{suit:get.suit(trigger.card)});
-					if(!cards.length){
-						cards=player.getCards('h',{color:get.color(trigger.card)});
-					}
+					let cards=player.getCards('h',card=>get.suit(card)==get.suit(trigger.card)&&player.canRecast(card));
+					if(!cards.length) cards=player.getCards('h',card=>get.color(card)==get.color(trigger.card)&&player.canRecast(card));
 					if(!cards.length){
 						event.finish();
 						return;
 					}
-					event.chosen=cards.randomGet();
-					game.delay(0.5)
-					'step 1'
-					var card=event.chosen;
-					player.lose(card,ui.discardPile);
-					player.$throw(card,1000);
-					game.delay(0.5);
-					game.log(player,'重铸了',card);
-					'step 2'
-					player.draw().log=false;
+					player.recast(cards.randomGet());
 				},
 				ai:{
 					pretao:true

--- a/character/hearth.js
+++ b/character/hearth.js
@@ -8466,27 +8466,27 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				filterTarget:true,
 				content:function(){
 					'step 0'
-					target.chooseCard('h',true,'重铸一张手牌');
+					target.chooseCard('h',true,'重铸一张手牌',lib.filter.cardRecastable);
 					'step 1'
 					if(result.bool&&result.cards.length){
-						target.$throw(result.cards);
-						target.lose(result.cards,ui.discardPile);
-						var type=get.type(result.cards[0],'trick');
-						var name=result.cards[0].name;
-						var card2=get.cardPile(function(card){
-							return get.type(card,'trick')==type&&card.name!=name;
-						});
-						if(!card2){
-							card2=get.cardPile(function(card){
-								return get.type(card,'trick')==type;
+						target.recast(result.cards,null,(player,cards)=>{
+							var type=get.type(result.cards[0],'trick');
+							var name=result.cards[0].name;
+							var card2=get.cardPile(function(card){
+								return get.type(card,'trick')==type&&card.name!=name;
 							});
-						}
-						if(card2){
-							target.gain(card2,'draw');
-						}
-						else{
-							target.draw();
-						}
+							if(!card2){
+								card2=get.cardPile(function(card){
+									return get.type(card,'trick')==type;
+								});
+							}
+							if(card2){
+								target.gain(card2,'draw');
+							}
+							else{
+								target.draw().log=false;
+							}
+						});
 						var clone=game.createCard(card);
 						player.gain(clone,'gain2');
 						clone.classList.add('glow');

--- a/character/huicui.js
+++ b/character/huicui.js
@@ -571,10 +571,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					'step 0'
-					player.chooseCard(get.prompt2('dcjini'),[1,player.maxHp-player.countMark('dcjini_counted')],(card,player,target)=>{
-						var mod=game.checkMod(card,player,'unchanged','cardChongzhuable',player);
-						return mod=='unchanged';
-					}).set('ai',card=>{
+					player.chooseCard(get.prompt2('dcjini'),[1,player.maxHp-player.countMark('dcjini_counted')],lib.filter.cardRecastable).set('ai',card=>{
 						return 6-get.value(card);
 					});
 					'step 1'
@@ -583,8 +580,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.logSkill('dcjini');
 						player.addTempSkill('dcjini_counted');
 						player.addMark('dcjini_counted',cards.length,false);
-						player.loseToDiscardpile(cards);
-						player.draw(cards.length);
+						player.recast(cards);
 					}
 					else event.finish();
 					'step 2'
@@ -2557,10 +2553,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					'step 0'
 					var str='，若重铸的牌中没有'+get.translation(get.type2(trigger.card))+'牌，你于'+get.translation(trigger.cards)+'进入弃牌堆后获得之';
-					player.chooseCard(get.prompt('dcqianzheng'),'重铸两张牌'+(trigger.cards.length?str:'')+'。',2,'he',(card,player,target)=>{
-						var mod=game.checkMod(card,player,'unchanged','cardChongzhuable',player);
-						return mod=='unchanged';
-					}).set('ai',card=>{
+					player.chooseCard(get.prompt('dcqianzheng'),'重铸两张牌'+(trigger.cards.length?str:'')+'。',2,'he',lib.filter.cardRecastable).set('ai',card=>{
 						var val=get.value(card);
 						if(get.type2(card)==_status.event.type) val+=0.5;
 						return 6-val;
@@ -2569,8 +2562,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(result.bool){
 						var cards=result.cards;
 						player.logSkill('dcqianzheng');
-						player.loseToDiscardpile(cards);
-						player.draw(cards.length);
+						player.recast(cards);
 						if(cards.every(card=>get.type2(card)!=get.type2(trigger.card))){
 							trigger.getParent().dcqianzheng=true;
 							player.addTempSkill('dcqianzheng_gain');
@@ -3809,21 +3801,14 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					'step 0'
 					player.choosePlayerCard(target,'he',true).set('filterButton',function(button){
-						var player=_status.event.player,card=button.link;
-						if(get.owner(card)==player){
-							var mod=game.checkMod(card,player,'unchanged','cardChongzhuable',player);
-							if(mod!='unchanged') return mod;
-						}
-						return true;
+						var card=button.link,owner=get.owner(card);
+						return !owner||owner.canRecast(card,_status.event.player);
 					}).set('ai',function(card){
 						if(get.attitude(_status.event.player,_status.event.getParent().target)>=0) return -get.buttonValue(card);
 						return get.buttonValue(card);
 					});
 					'step 1'
-					if(result.bool){
-						target.loseToDiscardpile(result.links);
-						target.draw();
-					}
+					if(result.bool) target.recast(result.links);
 				},
 				ai:{
 					expose:0.1,
@@ -6874,9 +6859,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 6'
 					if(event.goon1&&event.goon2){
 						if(player.countMark('chenjian')<2) player.addMark('chenjian',1,false);
-						var cards=player.getCards('h');
-						player.loseToDiscardpile(cards);
-						player.draw(cards.length);
+						player.recast(player.getCards('h',lib.filter.cardRecastable));
 					}
 				},
 				marktext:'见',

--- a/character/mobile.js
+++ b/character/mobile.js
@@ -8759,7 +8759,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					'step 0'
-					player.chooseCard('he',get.prompt2('duoduan')).set('ai',function(card){
+					player.chooseCard('he',get.prompt2('duoduan'),lib.filter.cardRecastable).set('ai',function(card){
 						if(_status.event.goon) return 8-get.value(card);
 						return 0;
 					}).set('goon',function(){
@@ -8771,12 +8771,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 1'
 					if(result.bool){
 						player.addTempSkill('duoduan_im');
-						var card=result.cards[0];
 						player.logSkill('duoduan',trigger.player);
-						player.lose(card,ui.discardPile,'visible');
-						player.$throw(card,1000);
-						game.log(player,'将',card,'置入弃牌堆');
-						player.draw();
+						player.recast(result.cards);
 					}
 					else event.finish();
 					'step 2'
@@ -11854,31 +11850,19 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				prompt:"重铸一张防具牌，然后将体力回复至1点。",
 				audio:'xinfu_jingxie',
 				enable:"chooseToUse",
-				filterCard:function(card){
-					return get.subtype(card)=='equip2';
-				},
-				filter:function(event,player){
-					if(event.type=='dying'){
-						if(player!=event.dying) return false;
-						return player.countCards('he',function(card){
-							return get.subtype(card)=='equip2';
-						})>0;
-					}
-					return false;
-				},
-				check:function(){
-					return 1;
+				filterCard:(card,player)=>get.subtype(card)=='equip2'&&player.canRecast(card),
+				filter:(event,player)=>{
+					if(event.type!='dying') return false;
+					if(player!=event.dying) return false;
+					return player.hasCard(card=>lib.skill.xinfu_jingxie2.filterCard(card,player),lib.skill.xinfu_jingxie2.position);
 				},
 				position:"he",
 				discard:false,
-				loseTo:'discardPile',
-				prepare:function(cards,player){
-					player.$throw(cards,1000);
-					game.log(player,'将',cards,'置入了弃牌堆')
-				},
+				lose:false,
+				delay:false,
 				content:function(){
 					'step 0'
-					player.draw();
+					player.recast(cards);
 					'step 1'
 					var num=1-player.hp;
 					if(num) player.recover(num);
@@ -11887,18 +11871,15 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					order:0.5,
 					skillTagFilter:function(player,arg,target){
 						if(player!=target) return false;
-						return player.countCards('he',function(card){
-							if(_status.connectMode&&get.position(card)=='h') return true;
-							return get.subtype(card)=='equip2';
-						})>0;
+						return player.hasCard(card=>_status.connectMode&&get.position(card)=='h'||get.subtype(card)=='equip2'&&player.canRecast(card),'he');
 					},
 					save:true,
 					result:{
 						player:function(player){
 							return 10;
-						},
-					},
-				},
+						}
+					}
+				}
 			},
 			"xinfu_qiaosi":{
 				enable:"phaseUse",

--- a/character/refresh.js
+++ b/character/refresh.js
@@ -574,19 +574,14 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					'step 6'
 					if(event.h&&event.hp&&event.e){
-						player.chooseCard('安国：是否重铸任意张牌？',[1,Infinity],(card,player)=>{
-							var mod=game.checkMod(card,player,'unchanged','cardChongzhuable',player);
-							if(mod!='unchanged') return mod;
-							return true;
-						},'he').set('ai',card=>{
+						player.chooseCard('安国：是否重铸任意张牌？',[1,Infinity],lib.filter.cardRecastable,'he').set('ai',card=>{
 							return 6-get.value(card);
 						});
 					}
 					else event.finish();
 					'step 7'
 					if(result.bool){
-						player.loseToDiscardpile(result.cards);
-						player.draw(result.cards.length);
+						player.recast(result.cards);
 					}
 				},
 				ai:{
@@ -4042,27 +4037,22 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				audio:2,
 				enable:'phaseUse',
 				filter:function(event,player){
-					return player.countCards('h','sha')>0;
+					return player.hasCard(card=>lib.skill.reyanyu.filterCard(card,player),'h');
 				},
-				filterCard:{name:'sha'},
-				prepare:function(cards,player){
-					player.$throw(cards,1000);
-					game.log(player,'将',cards,'置入了弃牌堆');
-				},
+				filterCard:(card,player)=>get.name(card)=='sha'&&player.canRecast(card),
 				discard:false,
-				loseTo:'discardPile',
-				visible:true,
-				delay:0.5,
+				lose:false,
+				delay:false,
 				content:function(){
-					player.draw();
+					player.recast(cards);
 				},
 				ai:{
 					basic:{
 						order:1
 					},
 					result:{
-						player:1,
-					},
+						player:1
+					}
 				},
 				group:'reyanyu2'
 			},

--- a/character/refresh.js
+++ b/character/refresh.js
@@ -8868,7 +8868,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				enable:'chooseToUse',
 				mark:true,
 				skillAnimation:true,
-				animationStr:'涅盘',
 				limited:true,
 				animationColor:'orange',
 				init:function(player){

--- a/character/sb.js
+++ b/character/sb.js
@@ -932,15 +932,14 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				audio:2,
 				enable:'phaseUse',
 				filterCard:{suit:'club'},
-				filter:function(event,player){
-					return player.countCards('hes',{suit:'club'});
-				},
+				filter:(event,player)=>player.hasCard(card=>lib.skill.sblianhuan.filterCard(card,player),lib.skill.sblianhuan.position),
 				filterTarget:function(card,player,target){
 					if(player.hasSkill('sblianhuan_blocker')) return false;
 					if(!ui.selected.cards.length) return false;
 					card=get.autoViewAs({name:'tiesuo'},[ui.selected.cards[0]]);
 					return player.canUse(card,target);
 				},
+				filterCard:(card,player)=>get.suit(card)=='club'&&(!player.hasSkill('sblianhuan_blocker')||player.canRecast(card)),
 				selectCard:1,
 				position:'hs',
 				derivation:'sblianhuan_lv2',

--- a/character/sb.js
+++ b/character/sb.js
@@ -1093,7 +1093,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				enable:'chooseToUse',
 				mark:true,
 				skillAnimation:true,
-				//animationStr:'涅盘',
 				limited:true,
 				animationColor:'orange',
 				filter:function(event,player){

--- a/character/shenhua.js
+++ b/character/shenhua.js
@@ -1103,34 +1103,25 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				audio:2,
 				enable:"phaseUse",
 				position:'he',
-				filter:function(event,player){
-					return player.countCards('he',{type:'equip'})>0;
-				},
-				filterCard:function(card){
-					return get.type(card)=='equip';
-				},
+				filter:(event,player)=>player.hasCard(card=>lib.skill.drlt_huairou.filterCard(card,player),lib.skill.drlt_huairou.position),
+				filterCard:(card,player)=>get.type(card)=='equip'&&player.canRecast(card),
 				check:function(card){
 					if(!_status.event.player.canEquip(card)) return 5;
 					return 3-get.value(card);
 				},
 				content:function(){
-					player.draw();
+					player.recast(cards);
 				},
 				discard:false,
-				visible:true,
-				loseTo:'discardPile',
+				lose:false,
+				delay:false,
 				prompt:"将一张装备牌置入弃牌堆并摸一张牌",
-				delay:0.5,
-				prepare:function(cards,player){
-					player.$throw(cards,1000);
-					game.log(player,'将',cards,'置入了弃牌堆');
-				},
 				ai:{
 					order:10,
 					result:{
-						player:1,
-					},
-				},
+						player:1
+					}
+				}
 			},
 			"drlt_yongsi":{
 				audio:2,
@@ -5495,34 +5486,25 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				audio:2,
 				popup:'lianhuan',
 				enable:'phaseUse',
-				filter:function(event,player){
-					return player.countCards('h',{suit:'club'})>0;
-				},
-				filterCard:function(card){
-					return get.suit(card)=='club';
-				},
+				filter:(event,player)=>player.hasCard(card=>lib.skill.lianhuan2.filterCard(card,player),'h'),
+				filterCard:(card,player)=>get.suit(card)=='club'&&player.canRecast(card),
 				check:function(card){
 					return 5-get.useful(card);
 				},
 				content:function(){
-					player.draw();
+					player.recast(cards);
 				},
 				discard:false,
-				visible:true,
-				loseTo:'discardPile',
+				lose:false,
+				delay:false,
 				prompt:'将一张梅花牌置入弃牌堆并摸一张牌',
-				delay:0.5,
-				prepare:function(cards,player){
-					player.$throw(cards,1000);
-					game.log(player,'将',cards,'置入了弃牌堆');
-				},
 				ai:{
 					basic:{
 						order:1
 					},
 					result:{
-						player:1,
-					},
+						player:1
+					}
 				}
 			},
 			niepan:{
@@ -8008,7 +7990,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			huoji_info:'出牌阶段，你可以将你的任意一张红色手牌当作【火攻】使用。',
 			bazhen_info:'锁定技，若你的防具栏内没有牌且没有被废除，则你视为装备着【八卦阵】。',
 			kanpo_info:'你可以将你的任意一张黑色手牌当做【无懈可击】使用。',
-			lianhuan_info:'出牌阶段，你可以将一张梅花手牌当做【铁索连环】使用或重铸。',
+			lianhuan_info:'出牌阶段，你可以将一张♣手牌当做【铁索连环】使用或重铸。',
 			niepan_info:'限定技，出牌阶段或当你处于濒死状态时，你可以弃置你区域内的所有牌并复原你的武将牌，然后摸三张牌并将体力回复至3点。',
 			oldniepan_info:'限定技，当你处于濒死状态时，你可以弃置你区域内的所有牌并复原你的武将牌，然后摸三张牌并将体力回复至3点。',
 			quhu_info:'出牌阶段限一次，你可以与一名体力值大于你的角色拼点，若你赢，则该角色对其攻击范围内另一名由你指定的角色造成1点伤害。若你没赢，该角色对你造成一点伤害。',

--- a/character/shenhua.js
+++ b/character/shenhua.js
@@ -4218,7 +4218,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 									dialog.buttons[i].node.group.remove();
 									dialog.buttons[i].node.hp.remove();
 									dialog.buttons[i].node.intro.remove();
-									dialog.buttons[i].node.name.innerHTML='未<br>知';
+									dialog.buttons[i].node.name.innerHTML=get.verticalStr('未知');
 									dialog.buttons[i].node.name.dataset.nature='';
 									dialog.buttons[i].style.background='';
 									dialog.buttons[i]._nointro=true;

--- a/character/shenhua.js
+++ b/character/shenhua.js
@@ -5515,7 +5515,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				mark:true,
 				limited:true,
 				skillAnimation:true,
-				//animationStr:'涅盘',
 				animationColor:'fire',
 				init:function(player){
 					player.storage.niepan=false;
@@ -5574,7 +5573,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				enable:'chooseToUse',
 				mark:true,
 				skillAnimation:true,
-				//animationStr:'涅盘',
 				limited:true,
 				animationColor:'orange',
 				init:function(player){

--- a/character/shiji.js
+++ b/character/shiji.js
@@ -130,9 +130,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					'step 0'
 					player.chooseTarget(get.prompt('tongduo'),'令一名角色重铸一张牌',function(card,player,target){
-						return target.countCards('he')>0;
+						return target.hasCard(lib.filter.cardRecastable,'he');
 					}).set('ai',function(target){
-						return get.attitude(_status.event.player,target)*Math.min(3,Math.floor(target.countCards('h')/2));
+						return get.attitude(_status.event.player,target)*Math.min(3,Math.floor(target.countCards('h',lib.filter.cardRecastable)/2));
 					});
 					'step 1'
 					if(result.bool){
@@ -142,11 +142,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					else event.finish();
 					'step 2'
-					if(target.countCards('he')==0) event.finish();
-					else target.chooseCard('he',true,'请重铸一张牌');
+					if(!target.hasCard(lib.filter.cardRecastable,'he')) event.finish();
+					else target.chooseCard('he',true,'请重铸一张牌',lib.filter.cardRecastable);
 					'step 3'
-					target.loseToDiscardpile(result.cards);
-					target.draw();
+					target.recast(result.cards);
 				},
 			},
 			//朱儁

--- a/character/sp2.js
+++ b/character/sp2.js
@@ -9216,16 +9216,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						forced:true,
 						charlotte:true,
 						filter:function(event,player){
-							return player.getCards('h',function(card){
-								return card.hasGaintag('xinfu_bijing');
-							}).length>0;
+							return player.hasCard(card=>card.hasGaintag('xinfu_bijing')&&player.canRecast(card),'h');
 						},
 						content:function(){
-							var cards=player.getCards('h',function(card){
-								return card.hasGaintag('xinfu_bijing');
-							});
-							player.loseToDiscardpile(cards);
-							player.draw(cards.length);
+							player.recast(player.getCards('h',card=>card.hasGaintag('xinfu_bijing')&&player.canRecast(card)));
 						},
 						sub:true,
 					},

--- a/character/tw.js
+++ b/character/tw.js
@@ -1282,16 +1282,15 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				group:'twqingtao_jieshu',
 				content:function(){
 					'step 0'
-					player.chooseCard(get.prompt2('twqingtao'),'he').set('ai',function(card){
+					player.chooseCard(get.prompt2('twqingtao'),'he',lib.filter.cardRecastable).set('ai',function(card){
 						if(card.name=='jiu'||get.type(card)!='basic') return 10-get.value(card);
 						return 6-get.value(card);
 					});
 					'step 1'
 					if(result.bool){
 						player.logSkill('twqingtao');
-						player.loseToDiscardpile(result.cards);
-						player.draw();
-						if(result.cards[0].name=='jiu'||get.type(result.cards[0],false,player)!='basic') player.draw();
+						player.recast(result.cards);
+						if(get.name(result.cards[0])=='jiu'||get.type(result.cards[0],false,player)!='basic') player.draw();
 					}
 				},
 				subSkill:{
@@ -11174,14 +11173,13 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					'step 0'
 					if(!event.isMine()&&!event.isOnline()) game.delayx();
-					player.chooseCard('是否发动【革制】重铸一张牌？').set('ai',function(card){
+					player.chooseCard('是否发动【革制】重铸一张牌？',lib.filter.cardRecastable).set('ai',function(card){
 						return 5.5-get.value(card);
 					});
 					'step 1'
 					if(result.bool){
 						player.logSkill('twgezhi');
-						player.loseToDiscardpile(result.cards);
-						player.draw();
+						player.recast(result.cards);
 					}
 				},
 				group:'twgezhi_buff',

--- a/character/xiake.js
+++ b/character/xiake.js
@@ -34,12 +34,13 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				enable:'phaseUse',
 				position:'e',
 				filter:function(event,player){
-					return player.countCards('e')>0;
+					return player.hasCard(card=>lib.skill.rouquan.filterCard(card,player),lib.skill.rouquan.position);
 				},
-				filterCard:true,
+				filterCard:lib.filter.cardRecastable,
 				prompt:'将要重铸的牌置入弃牌堆并摸一张牌',
 				discard:false,
-				delay:0.5,
+				lose:false,
+				delay:false,
 				check:function(card,player){
 					var val=get.equipValue(card);
 					var player=_status.event.player;
@@ -51,16 +52,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					return 0;
 				},
-				prepare:function(cards,player){
-					player.$throw(cards,1000);
-				},
 				content:function(){
-					"step 0"
-					player.draw();
-					"step 1"
-					for(var i=0;i<cards.length;i++){
-						cards[i].discard();
-					}
+					player.recast(cards);
 				},
 				ai:{
 					order:9.5,

--- a/character/xianding.js
+++ b/character/xianding.js
@@ -1684,27 +1684,19 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				audio:2,
 				enable:'phaseUse',
 				usable:1,
-				filterCard:function(card,player,target){
-					var mod=game.checkMod(card,player,'unchanged','cardChongzhuable',player);
-					return mod=='unchanged';
-				},
+				filterCard:lib.filter.cardRecastable,
 				selectCard:function(){
 					return Math.ceil(_status.event.player.countCards('h')/2);
 				},
 				check:function(card){
 					return 6.5-get.value(card);
 				},
-				prepare:function(cards,player){
-					player.$throw(cards,1000);
-					game.log(player,'将',cards,'置入了弃牌堆');
-				},
 				discard:false,
-				loseTo:'discardPile',
-				visible:true,
-				delay:0.5,
+				lose:false,
+				delay:false,
 				content:function(){
 					'step 0'
-					player.draw(cards.length);
+					player.recast(cards);
 					'step 1'
 					player.addTempSkill('dcctjiuxian_help');
 					player.chooseUseTarget({
@@ -1715,7 +1707,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				ai:{
 					order:5.5,
-					result:{player:1},
+					result:{player:1}
 				},
 				subSkill:{
 					help:{

--- a/character/yijiang.js
+++ b/character/yijiang.js
@@ -9174,27 +9174,22 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				audio:2,
 				enable:'phaseUse',
 				filter:function(event,player){
-					return player.countCards('h','sha')>0;
+					return player.hasCard(card=>lib.skill.yanyu.filterCard(card,player),'h');
 				},
-				filterCard:{name:'sha'},
-				prepare:function(cards,player){
-					player.$throw(cards,1000);
-					game.log(player,'将',cards,'置入了弃牌堆');
-				},
+				filterCard:(card,player)=>get.name(card)=='sha'&&player.canRecast(card),
 				discard:false,
-				loseTo:'discardPile',
-				visible:true,
-				delay:0.5,
+				lose:false,
+				delay:false,
 				content:function(){
-					player.draw();
+					player.recast(cards);
 				},
 				ai:{
 					basic:{
 						order:1
 					},
 					result:{
-						player:1,
-					},
+						player:1
+					}
 				},
 				group:'yanyu2'
 			},

--- a/character/yingbian.js
+++ b/character/yingbian.js
@@ -682,17 +682,15 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				position:'he',
 				content:function(){
 					'step 0'
-					player.loseToDiscardpile(cards);
-					player.draw();
+					player.recast(cards);
 					'step 1'
 					if(target.countCards('he')>0){
-						target.chooseCard('he',true,'请重铸一张牌');
+						target.chooseCard('he',true,'请重铸一张牌',lib.filter.cardRecastable);
 					}
 					else event.finish();
 					'step 2'
 					if(result.bool){
-						target.loseToDiscardpile(result.cards);
-						target.draw();
+						target.recast(result.cards);
 					}
 				},
 				ai:{

--- a/game/game.js
+++ b/game/game.js
@@ -19047,11 +19047,11 @@
 				inRangeOf:function(source){
 					return source.inRange(this);
 				},
-				getHp:function(){
-					return Math.max(0,this.hp);
+				getHp:function(raw){
+					return raw?this.hp:Math.max(0,this.hp);
 				},
-				getDamagedHp:function(){
-					return this.maxHp-this.getHp();
+				getDamagedHp:function(raw){
+					return this.maxHp-this.getHp(raw);
 				},
 				changeGroup:function(group,log,broadcast){
 					var next=game.createEvent('changeGroup');
@@ -24832,109 +24832,61 @@
 					return this.hp<this.maxHp&&!this.storage.nohp;
 				},
 				isHealthy:function(){
-					return this.hp==this.maxHp||this.storage.nohp;
+					return this.hp>=this.maxHp||this.storage.nohp;
 				},
-				isMaxHp:function(equal){
-					for(var i=0;i<game.players.length;i++){
-						if(game.players[i].isOut()||game.players[i]==this) continue;
-						if(equal){
-							if(game.players[i].hp>=this.hp) return false;
-						}
-						else{
-							if(game.players[i].hp>this.hp) return false;
-						}
-					}
-					return true;
+				isMaxHp:function(only,raw){
+					return game.players.every(value=>{
+						if(value.isOut()||value==this) return true;
+						return only?value.getHp(raw)<this.getHp(raw):value.getHp(raw)<=this.getHp(raw);
+					});
 				},
-				isMinHp:function(equal){
-					for(var i=0;i<game.players.length;i++){
-						if(game.players[i].isOut()||game.players[i]==this) continue;
-						if(equal){
-							if(game.players[i].hp<=this.hp) return false;
-						}
-						else{
-							if(game.players[i].hp<this.hp) return false;
-						}
-					}
-					return true;
+				isMinHp:function(only,raw){
+					return game.players.every(value=>{
+						if(value.isOut()||value==this) return true;
+						return only?value.getHp(raw)>this.getHp(raw):value.getHp(raw)>=this.getHp(raw);
+					});
 				},
-				isMaxCard:function(equal){
-					var nh=this.countCards('he');
-					for(var i=0;i<game.players.length;i++){
-						if(game.players[i].isOut()||game.players[i]==this) continue;
-						if(equal){
-							if(game.players[i].countCards('he')>=nh) return false;
-						}
-						else{
-							if(game.players[i].countCards('he')>nh) return false;
-						}
-					}
-					return true;
+				isMaxCard:function(only){
+					const numberOfCards=this.countCards('he');
+					return game.players.every(value=>{
+						if(value.isOut()||value==this) return true;
+						return only?value.countCards('he')<numberOfCards:value.countCards('he')<=numberOfCards;
+					});
 				},
-				isMinCard:function(equal){
-					var nh=this.countCards('he');
-					for(var i=0;i<game.players.length;i++){
-						if(game.players[i].isOut()||game.players[i]==this) continue;
-						if(equal){
-							if(game.players[i].countCards('he')<=nh) return false;
-						}
-						else{
-							if(game.players[i].countCards('he')<nh) return false;
-						}
-					}
-					return true;
+				isMinCard:function(only){
+					const numberOfCards=this.countCards('he');
+					return game.players.every(value=>{
+						if(value.isOut()||value==this) return true;
+						return only?value.countCards('he')>numberOfCards:value.countCards('he')>=numberOfCards;
+					});
 				},
-				isMaxHandcard:function(equal){
-					var nh=this.countCards('h');
-					for(var i=0;i<game.players.length;i++){
-						if(game.players[i].isOut()||game.players[i]==this) continue;
-						if(equal){
-							if(game.players[i].countCards('h')>=nh) return false;
-						}
-						else{
-							if(game.players[i].countCards('h')>nh) return false;
-						}
-					}
-					return true;
+				isMaxHandcard:function(only){
+					const numberOfHandCards=this.countCards('h');
+					return game.players.every(value=>{
+						if(value.isOut()||value==this) return true;
+						return only?value.countCards('h')<numberOfHandCards:value.countCards('h')<=numberOfHandCards;
+					});
 				},
-				isMinHandcard:function(equal){
-					var nh=this.countCards('h');
-					for(var i=0;i<game.players.length;i++){
-						if(game.players[i].isOut()||game.players[i]==this) continue;
-						if(equal){
-							if(game.players[i].countCards('h')<=nh) return false;
-						}
-						else{
-							if(game.players[i].countCards('h')<nh) return false;
-						}
-					}
-					return true;
+				isMinHandcard:function(only){
+					const numberOfHandCards=this.countCards('h');
+					return game.players.every(value=>{
+						if(value.isOut()||value==this) return true;
+						return only?value.countCards('h')>numberOfHandCards:value.countCards('h')>=numberOfHandCards;
+					});
 				},
-				isMaxEquip:function(equal){
-					var nh=this.countCards('e');
-					for(var i=0;i<game.players.length;i++){
-						if(game.players[i].isOut()||game.players[i]==this) continue;
-						if(equal){
-							if(game.players[i].countCards('e')>=nh) return false;
-						}
-						else{
-							if(game.players[i].countCards('e')>nh) return false;
-						}
-					}
-					return true;
+				isMaxEquip:function(only){
+					const numberOfEquipAreaCards=this.countCards('e');
+					return game.players.every(value=>{
+						if(value.isOut()||value==this) return true;
+						return only?value.countCards('e')<numberOfEquipAreaCards:value.countCards('e')<=numberOfEquipAreaCards;
+					});
 				},
-				isMinEquip:function(equal){
-					var nh=this.countCards('e');
-					for(var i=0;i<game.players.length;i++){
-						if(game.players[i].isOut()||game.players[i]==this) continue;
-						if(equal){
-							if(game.players[i].countCards('e')<=nh) return false;
-						}
-						else{
-							if(game.players[i].countCards('e')<nh) return false;
-						}
-					}
-					return true;
+				isMinEquip:function(only){
+					const numberOfEquipAreaCards=this.countCards('e');
+					return game.players.every(value=>{
+						if(value.isOut()||value==this) return true;
+						return only?value.countCards('e')>numberOfEquipAreaCards:value.countCards('e')>=numberOfEquipAreaCards;
+					});
 				},
 				isLinked:function(){
 					if(get.is.linked2(this)){

--- a/game/game.js
+++ b/game/game.js
@@ -10698,6 +10698,17 @@
 				emptyEvent:function(){
 					event.trigger(event.name);
 				},
+				//Recast
+				//重铸
+				recast:()=>{
+					'step 0'
+					game.log(player,'重铸了',cards);
+					if(typeof event.recastingLose=='function') event.recastingLose(player,cards);
+					'step 1'
+					event.trigger('recast');
+					'step 2'
+					if(typeof event.recastingGain=='function') event.recastingGain(player,cards);
+				},
 				//装备栏相关
 				disableEquip:function(){
 					'step 0'
@@ -10879,7 +10890,7 @@
 					var next=game.createEvent('replaceEquip');
 					next.player=player;
 					next.card=card;
-					next.setContent(info.replaceEquip||'replaceEquip')
+					next.setContent(info.replaceEquip||'replaceEquip');
 					"step 4"
 					var info=get.info(card,false);
 					if(get.itemtype(result)=='cards'){
@@ -16739,7 +16750,7 @@
 				},
 				loseToDiscardpile:function(){
 					"step 0"
-					game.log(player,'将',cards,'置入了弃牌堆');
+					if(event.log!=false) game.log(player,'将',cards,'置入了弃牌堆');
 					event.done=player.lose(cards,event.position,'visible');
 					event.done.type='loseToDiscardpile';
 					"step 1"
@@ -18240,6 +18251,31 @@
 			},
 			player:{
 				//新函数
+				//Recast
+				//重铸
+				recast:function(cards,recastingLose,recastingGain){
+					const recast=game.createEvent('recast');
+					recast.player=this;
+					if(get.itemtype(cards)=='card') recast.cards=[cards];
+					else if(get.itemtype(cards)=='cards'&&cards.length) recast.cards=cards;
+					else _status.event.next.remove(recast);
+					if(typeof recastingLose!='function') recastingLose=(player,cards)=>player.loseToDiscardpile(cards).log=false;
+					recast.recastingLose=recastingLose;
+					if(typeof recastingGain!='function') recastingGain=(player,cards)=>player.draw(cards.length).log=false;
+					recast.recastingGain=recastingGain;
+					recast.setContent('recast');
+					recast._args=Array.from(arguments);
+					return recast;
+				},
+				//Check if the player can recast the card
+				//检查角色是否能重铸此牌
+				canRecast:function(card,source,strict){
+					const cardRecastable=lib.filter.cardRecastable(card,this,source,strict);
+					if(cardRecastable!='unchanged') return cardRecastable;
+					if(get.position(card)!='h') return false;
+					const info=get.info(card);
+					return typeof info.chongzhu=='function'?info.chongzhu(event,player):info.chongzhu;
+				},
 				//装备栏相关
 				//判断一名角色的某个区域是否被废除
 				//type为要判断的区域 若为空 则判断玩家是否有任意一个被废除的区域
@@ -19047,9 +19083,13 @@
 				inRangeOf:function(source){
 					return source.inRange(this);
 				},
+				//Get the player's HP not less than 0. Set “raw” to true to get the player's raw HP instead.
+				//获取角色的体力值。设置“raw”为true以获取角色的体力。
 				getHp:function(raw){
 					return raw?this.hp:Math.max(0,this.hp);
 				},
+				//Set “raw” to true to get the player's raw damaged HP instead.
+				//设置“raw”为true以获取角色已损失的体力。
 				getDamagedHp:function(raw){
 					return this.maxHp-this.getHp(raw);
 				},
@@ -28264,6 +28304,12 @@
 			all:function(){
 				return true;
 			},
+			//Check if the card is recastable
+			//检查此牌是否可重铸
+			cardRecastable:(card,player,source,strict)=>{
+				if(typeof player=='undefined') player=get.owner(card);
+				return game.checkMod(card,player,source,!strict||'unchanged','cardRecastable',player);
+			},
 			//装备栏相关
 			canBeReplaced:function(card,player){
 				var mod=game.checkMod(card,player,'unchanged','canBeReplaced',player);
@@ -29885,78 +29931,47 @@
 				logv:false,
 				visible:true,
 				prompt:'将要重铸的牌置入弃牌堆并摸一张牌',
-				filter:function(event,player){
-					return player.hasCard(function(card){
-						return lib.skill._chongzhu.filterCard(card,player);
-					});
-				},
-				filterCard:function(card,player){
-					var mod=game.checkMod(card,player,'unchanged','cardChongzhuable',player);
-					if(mod!='unchanged') return mod;
-					var info=get.info(card);
-					if(typeof info.chongzhu=='function'){
-						return info.chongzhu(event,player);
-					}
-					return info.chongzhu;
-				},
-				prepare:function(cards,player){
-					player.$throw(cards,1000);
-					game.log(player,'将',cards,'置入了弃牌堆');
-				},
-				check:function(card){
-					// if(get.type(card)=='stonecharacter'&&_status.event.player.countCards('h',{type:'stonecharacter'})<=1){
-					// 	return 0;
-					// }
-					return 1;
-				},
+				filter:(event,player)=>player.hasCard(card=>lib.skill._chongzhu.filterCard(card,player),'he'),
+				position:'he',
+				filterCard:(card,player)=>player.canRecast(card,null,true),
 				discard:false,
-				loseTo:'discardPile',
-				delay:0.5,
+				lose:false,
+				delay:false,
 				content:function(){
-					"step 0"
-					if(lib.config.mode=='stone'&&_status.mode=='deck'&&
-					!player.isMin()&&get.type(cards[0]).indexOf('stone')==0){
-						var list=get.stonecard(1,player.career);
-						if(list.length){
-							player.gain(game.createCard(list.randomGet()),'draw');
-						}
-						else{
-							player.draw({drawDeck:1})
-						}
-					}
-					else if(get.subtype(cards[0])=='spell_gold'){
-						var list=get.libCard(function(info){
-							return info.subtype=='spell_silver';
+					player.recast(cards,null,(player,cards)=>{
+						let numberOfCardsToDraw=cards.length;
+						cards.forEach(value=>{
+							if(lib.config.mode=='stone'&&_status.mode=='deck'&&!player.isMin()&&get.type(value).indexOf('stone')==0){
+								const stonecard=get.stonecard(1,player.career);
+								numberOfCardsToDraw--;
+								if(stonecard.length) player.gain(game.createCard(stonecard.randomGet()),'draw');
+								else player.draw({
+									drawDeck:1
+								}).log=false;
+							}
+							else if(get.subtype(value)=='spell_gold'){
+								const libCard=get.libCard(info=>info.subtype=='spell_silver');
+								if(!libCard.length) return;
+								numberOfCardsToDraw--;
+								player.gain(game.createCard(libCard.randomGet()),'draw');
+							}
+							else if(get.subtype(value)=='spell_silver'){
+								const libCard=get.libCard(info=>info.subtype=='spell_bronze');
+								if(!libCard.length) return;
+								numberOfCardsToDraw--;
+								player.gain(game.createCard(libCard.randomGet()),'draw');
+							}
 						});
-						if(list.length){
-							player.gain(game.createCard(list.randomGet()),'draw');
-						}
-						else{
-							player.draw();
-						}
-					}
-					else if(get.subtype(cards[0])=='spell_silver'){
-						var list=get.libCard(function(info){
-							return info.subtype=='spell_bronze';
-						});
-						if(list.length){
-							player.gain(game.createCard(list.randomGet()),'draw');
-						}
-						else{
-							player.draw();
-						}
-					}
-					else{
-						player.draw();
-					}
+						if(numberOfCardsToDraw) player.draw(numberOfCardsToDraw).log=false;
+					});
 				},
 				ai:{
 					basic:{
 						order:6
 					},
 					result:{
-						player:1,
-					},
+						player:1
+					}
 				}
 			},
 			_lianhuan:{
@@ -38643,36 +38658,15 @@
 			}
 			return num;
 		},
-		filterPlayer:function(func,list,includeOut){
-			if(!Array.isArray(list)){
-				list=[];
-			}
-			if(typeof func!='function'){
-				func=lib.filter.all;
-			}
-			for(var i=0;i<game.players.length;i++){
-				if(!includeOut&&game.players[i].isOut()) continue;
-				if(func(game.players[i])){
-					list.add(game.players[i]);
-				}
-			}
-			return list;
+		filterPlayer:(func,list,includeOut)=>{
+			if(!Array.isArray(list)) list=[];
+			if(typeof func!='function') func=lib.filter.all;
+			return list.addArray(game.players.filter(value=>(includeOut||!value.isOut())&&func(value)));
 		},
-		filterPlayer2:function(func,list,includeOut){
-			if(!Array.isArray(list)){
-				list=[];
-			}
-			if(typeof func!='function'){
-				func=lib.filter.all;
-			}
-			var players=game.players.slice(0).concat(game.dead);
-			for(var i=0;i<players.length;i++){
-				if(!includeOut&&players[i].isOut()) continue;
-				if(func(players[i])){
-					list.add(players[i]);
-				}
-			}
-			return list;
+		filterPlayer2:(func,list,includeOut)=>{
+			if(!Array.isArray(list)) list=[];
+			if(typeof func!='function') func=lib.filter.all;
+			return list.addArray(game.players.concat(game.dead).filter(value=>(includeOut||!value.isOut())&&func(value)));
 		},
 		findPlayer:function(func,includeOut){
 			for(var i=0;i<game.players.length;i++){

--- a/game/game.js
+++ b/game/game.js
@@ -17189,7 +17189,7 @@
 					}
 					if(event.animate=='draw'){
 						player.$draw(cards.length);
-						game.log(player,'将',get.cnNumber(cards.length),'张牌置于了武将牌上');
+						if(event.log) game.log(player,'将',get.cnNumber(cards.length),'张牌置于了武将牌上');
 						game.pause();
 						setTimeout(function(){
 							player.$addToExpansion(cards,null,event.gaintag);
@@ -17223,8 +17223,8 @@
 						if(event.animate=='give'){
 							for(var i in evtmap){
 								var source=(_status.connectMode?lib.playerOL:game.playerMap)[i];
-								source.$give(evtmap[i][0],player);
-								game.log(player,'将',get.cnNumber(evtmap[i][0]),'置于了武将牌上');
+								source.$give(evtmap[i][0],player,false);
+								if(event.log) game.log(player,'将',evtmap[i][0],'置于了武将牌上');
 							}
 						}
 						else{
@@ -17232,11 +17232,11 @@
 								var source=(_status.connectMode?lib.playerOL:game.playerMap)[i];
 								if(evtmap[i][1].length){
 									source.$giveAuto(evtmap[i][1],player,false);
-									game.log(player,'将',get.cnNumber(evtmap[i][1].length),'张牌置于了武将牌上');
+									if(event.log) game.log(player,'将',get.cnNumber(evtmap[i][1].length),'张牌置于了武将牌上');
 								}
 								if(evtmap[i][2].length){
 									source.$give(evtmap[i][2],player,false);
-									game.log(player,'将',get.cnNumber(evtmap[i][2]),'置于了武将牌上');
+									if(event.log) game.log(player,'将',evtmap[i][2],'置于了武将牌上');
 								}
 							}
 						}
@@ -17260,9 +17260,6 @@
 						player.$addToExpansion(cards,null,event.gaintag);
 						for(var i of event.gaintag) player.markSkill(i);
 						event.finish();
-					}
-					if(event.log){
-						game.log(player,'将',cards,'置于了武将牌上');
 					}
 					"step 4"
 					game.delayx();

--- a/game/game.js
+++ b/game/game.js
@@ -48207,7 +48207,7 @@
 				node.node={
 					avatar:ui.create.div('.avatar',node,ui.click.avatar).hide(),
 					avatar2:ui.create.div('.avatar2',node,ui.click.avatar2).hide(),
-					turnedover:ui.create.div('.turned','<div>翻<br>面<div>',node),
+					turnedover:ui.create.div('.turned','<div>'+get.verticalStr('翻面')+'<div>',node),
 					framebg:ui.create.div('.framebg',node),
 					intro:ui.create.div('.intro',node),
 					identity:ui.create.div('.identity',node),

--- a/game/game.js
+++ b/game/game.js
@@ -28303,9 +28303,9 @@
 			},
 			//Check if the card is recastable
 			//检查此牌是否可重铸
-			cardRecastable:(card,player,source,strict)=>{
+			cardRecastable:(card,player,source,raw)=>{
 				if(typeof player=='undefined') player=get.owner(card);
-				return game.checkMod(card,player,source,!strict||'unchanged','cardRecastable',player);
+				return game.checkMod(card,player,source,!raw||'unchanged','cardRecastable',player);
 			},
 			//装备栏相关
 			canBeReplaced:function(card,player){

--- a/layout/default/layout.css
+++ b/layout/default/layout.css
@@ -2239,9 +2239,8 @@ div:not(.handcards)>.card>.info>span,
 	text-shadow: none;
 }
 .player>.turned>div{
-	top:calc(50% - 50px);
-    width: 100%;
-    left: 0;
+	top: calc(50% - 50px);
+    left: calc(50% - 25px);
 	white-space: nowrap;
 	writing-mode: vertical-rl;
 	-webkit-writing-mode: vertical-rl;

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -6457,7 +6457,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					cardEnabled2:function(card){
 						if(get.position(card)=='h') return false;
 					},
-					cardChongzhuable:function(card){
+					cardRecastable:function(card){
 						if(get.position(card)=='h') return false;
 					},
 				},

--- a/theme/simple/style.css
+++ b/theme/simple/style.css
@@ -144,6 +144,7 @@ html{
 }
 
 .player .marks>div:first-child>div{
+	filter: invert(0.8) sepia(1);
 	-webkit-filter: invert(0.8) sepia(1);
 }
 
@@ -201,6 +202,7 @@ html{
 	transition-property: transform;
 	transition-duration: 0s;
 	background-size: cover;
+	filter: blur(3px);
 	-webkit-filter: blur(3px);
 }
 .popup-container>.prompt-container>div>div{


### PR DESCRIPTION
现在`lib.element.player.getHp`可以传入`true`以获取体力了。
现在`lib.element.player.getDamagedHp`可以传入`true`以获取损失的体力了。
现在`lib.element.player.isMaxHp`和`lib.element.player.isMinHp`默认检查体力值了，且可以追加`true`以改为检查体力。
将所有检查最值的函数的`equal`参数改名为`only`。
重构所有涉及到重铸的代码。添加`lib.element.player.recast``lib.element.player.canRecast``lib.filter.cardRecastable`。
修复部分错别字和技能效果。
修复`lib.element.content.addToExpansion`。