### PR TITLE
Add the ability for lib.init.parsex to remove all comments before parsing, and fix recasting related errors.

### DIFF
--- a/card/mtg.js
+++ b/card/mtg.js
@@ -501,6 +501,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						}
 						if(cardsToGain.length) player.gain(cardsToGain,'draw');
 						if(cards.length-cardsToGain.length) player.draw(cards.length-cardsToGain.length).log=false;
+						return cardsToGain;
 					});
 				},
 				ai:{

--- a/card/mtg.js
+++ b/card/mtg.js
@@ -494,9 +494,9 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				usable:1,
 				content:function(){
 					player.recast(cards,null,(player,cards)=>{
-						const cardsToGain=[];
+						var cardsToGain=[];
 						for(let repetition=0;repetition<cards.length;repetition++){
-							const card=get.cardPile(card=>get.type(card,'trick')=='trick');
+							var card=get.cardPile(card=>get.type(card,'trick')=='trick');
 							if(card) cardsToGain.push(card);
 						}
 						if(cardsToGain.length) player.gain(cardsToGain,'draw');

--- a/character/ddd.js
+++ b/character/ddd.js
@@ -117,7 +117,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						target.useCard(result.targets,card,event.links);
 					}
 					else{
-						target.recast(event.links,(player,cards)=>game.cardsDiscard(cards));
+						target.recast(event.links,(player,cards)=>game.cardsDiscard(cards).cards);
 					}
 					'step 4'
 					for(var card of cards){

--- a/character/huicui.js
+++ b/character/huicui.js
@@ -580,25 +580,20 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.logSkill('dcjini');
 						player.addTempSkill('dcjini_counted');
 						player.addMark('dcjini_counted',cards.length,false);
-						player.recast(cards);
+						event.recast=player.recast(cards);
 					}
 					else event.finish();
 					'step 2'
-					if(trigger.source&&trigger.source.isIn()&&Array.isArray(result)){
-						for(var i of result){
-							if(get.name(i,player)=='sha'&&get.owner(i)==player&&get.position(i)=='h'){
-								player.chooseToUse(function(card,player,event){
-									if(get.name(card)!='sha') return false;
-									return lib.filter.filterCard.apply(this,arguments);
-								},'击逆：是否对'+get.translation(trigger.source)+'使用一张不可被响应的杀？').set('complexSelect',true).set('filterTarget',function(card,player,target){
-									if(target!=_status.event.sourcex&&!ui.selected.targets.contains(_status.event.sourcex)) return false;
-									return lib.filter.targetEnabled.apply(this,arguments);
-								}).set('sourcex',trigger.source).set('oncard',()=>{
-									_status.event.directHit.addArray(game.players);
-								});
-								break;
-							}
-						}
+					if(trigger.source&&trigger.source.isIn()&&player.hasHistory('gain',evt=>evt.getParent(2)==event.recast&&evt.cards.some(value=>get.name(value)=='sha'))){
+						player.chooseToUse(function(card){
+							if(get.name(card)!='sha') return false;
+							return lib.filter.filterCard.apply(this,arguments);
+						},'击逆：是否对'+get.translation(trigger.source)+'使用一张不可被响应的杀？').set('complexSelect',true).set('filterTarget',function(card,player,target){
+							if(target!=_status.event.sourcex&&!ui.selected.targets.contains(_status.event.sourcex)) return false;
+							return lib.filter.targetEnabled.apply(this,arguments);
+						}).set('sourcex',trigger.source).set('oncard',()=>{
+							_status.event.directHit.addArray(game.players);
+						});
 					}
 				},
 				subSkill:{

--- a/character/refresh.js
+++ b/character/refresh.js
@@ -4059,18 +4059,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			reyanyu2:{
 				trigger:{player:'phaseUseEnd'},
 				direct:true,
-				filter:function(event,player){
-					return player.getHistory('lose',function(evt){
-						var evt2=evt.getParent();
-						return evt2.name=='useSkill'&&evt2.skill=='reyanyu'&&evt.getParent(3)==event;
-					}).length>0;
-				},
+				filter:(event,player)=>player.hasHistory('useSkill',evt=>evt.skill=='reyanyu'&&evt.event.getParent(2)==event),
 				content:function(){
 					'step 0'
-					event.num=Math.min(3,player.getHistory('lose',function(evt){
-						var evt2=evt.getParent();
-						return evt2.name=='useSkill'&&evt2.skill=='reyanyu'&&evt.getParent(3)==trigger;
-					}).length);
+					event.num=Math.min(3,player.getHistory('useSkill',evt=>evt.skill=='reyanyu'&&evt.event.getParent(2)==trigger).length);
 					player.chooseTarget(get.prompt('reyanyu'),'令一名男性角色摸'+get.cnNumber(event.num)+'张牌',function(card,player,target){
 						return target.hasSex('male')&&target!=player;
 					}).set('ai',function(target){

--- a/character/tw.js
+++ b/character/tw.js
@@ -11190,7 +11190,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						direct:true,
 						filter:function(event,player){
 							return player.getHistory('lose',function(evt){
-								return evt.getParent(2).name=='twgezhi'&&evt.getParent('phaseUse')==event;
+								return evt.getParent(3).name=='twgezhi'&&evt.getParent('phaseUse')==event;
 							}).length>1;
 						},
 						content:function(){

--- a/game/game.js
+++ b/game/game.js
@@ -9714,9 +9714,11 @@
 					localStorage.removeItem(lib.configprefix+'background');
 				}
 			},
-			//by 诗笺
+			//by 诗笺、Tipx-L
 			parsex:function(func){
-				var str=func.toString();
+				//Remove all comments
+				//移除所有注释
+				var str=func.toString().replace(/((?:(?:^[ \t]*)?(?:\/\*[^*]*\*+(?:[^\/*][^*]*\*+)*\/(?:[ \t]*\r?\n(?=[ \t]*(?:\r?\n|\/\*|\/\/)))?|\/\/(?:[^\\]|\\(?:\r?\n)?)*?(?:\r?\n(?=[ \t]*(?:\r?\n|\/\*|\/\/))|(?=\r?\n))))+)|("(?:\\[\S\s]|[^"\\])*"|'(?:\\[\S\s]|[^'\\])*'|(?:\r?\n|[\S\s])[^\/"'\\\s]*)/mg,'$2').trim();
 				//获取第一个 { 后的所有字符
 				str=str.slice(str.indexOf('{')+1);
 				//func中要写步骤的话，必须要写step 0
@@ -9750,7 +9752,6 @@
 					}
 					str=`if(event.step==${k}){event.finish();return;}`+str;
 				}
-				str=`"use strict";\n${str}`;
 				return (new Function('event','step','source','player','target','targets',
 					'card','cards','skill','forced','num','trigger','result',
 					'_status','lib','game','ui','get','ai',str));
@@ -29946,7 +29947,7 @@
 						let numberOfCardsToDraw=cards.length;
 						cards.forEach(value=>{
 							if(lib.config.mode=='stone'&&_status.mode=='deck'&&!player.isMin()&&get.type(value).indexOf('stone')==0){
-								const stonecard=get.stonecard(1,player.career);
+								var stonecard=get.stonecard(1,player.career);
 								numberOfCardsToDraw--;
 								if(stonecard.length) player.gain(game.createCard(stonecard.randomGet()),'draw');
 								else player.draw({
@@ -29954,13 +29955,13 @@
 								}).log=false;
 							}
 							else if(get.subtype(value)=='spell_gold'){
-								const libCard=get.libCard(info=>info.subtype=='spell_silver');
+								var libCard=get.libCard(info=>info.subtype=='spell_silver');
 								if(!libCard.length) return;
 								numberOfCardsToDraw--;
 								player.gain(game.createCard(libCard.randomGet()),'draw');
 							}
 							else if(get.subtype(value)=='spell_silver'){
-								const libCard=get.libCard(info=>info.subtype=='spell_bronze');
+								var libCard=get.libCard(info=>info.subtype=='spell_bronze');
 								if(!libCard.length) return;
 								numberOfCardsToDraw--;
 								player.gain(game.createCard(libCard.randomGet()),'draw');

--- a/game/game.js
+++ b/game/game.js
@@ -10705,16 +10705,16 @@
 				recast:()=>{
 					'step 0'
 					game.log(player,'重铸了',cards);
-					if(typeof event.recastingLose=='function') event.recastingLoseCards=event.recastingLose(player,cards);
+					if(typeof event.recastingLose=='function') event.recastingLostCards=event.recastingLose(player,cards);
 					'step 1'
 					event.trigger('recast');
 					'step 2'
 					if(typeof event.recastingGain!='function') return;
-					event.recastingGainCards=event.recastingGain(player,cards);
-					if(get.itemtype(event.recastingGainCards)=='card') event.recastingGainCards=[event.recastingGainCards];
+					event.recastingGainedCards=event.recastingGain(player,cards);
+					if(get.itemtype(event.recastingGainedCards)=='card') event.recastingGainedCards=[event.recastingGainedCards];
 					'step 3'
 					event.result=[];
-					if(get.itemtype(event.recastingGainCards)=='cards') event.result.addArray(event.recastingGainCards);
+					if(get.itemtype(event.recastingGainedCards)=='cards') event.result.addArray(event.recastingGainedCards);
 					if(get.itemtype(result.cards)=='card') event.result.push(result.cards);
 					else if(get.itemtype(result.cards)=='cards') event.result.addArray(result.cards);
 					if(get.itemtype(result)=='card') event.result.push(result);

--- a/layout/default/layout.css
+++ b/layout/default/layout.css
@@ -1741,8 +1741,8 @@ div:not(.handcards)>.card>.info>span,
 	position: relative;
 	margin-top: 8px;
 	margin-bottom: 8px;
-	margin-left: 4px;
-	margin-right: 4px;
+	margin-left: auto;
+	margin-right: auto;
 }
 .content>.caption + .buttons:not(*:last-child){
 	margin-top: 0;


### PR DESCRIPTION
现在`lib.init.parsex`可以无视函数中的注释了，可以避免一些因注释导致解析出错的问题。
修复了一些和重铸有关的问题。
经测试支持兼容版。