### PR TITLE
新增lib.init.addJsForExtension方法

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -7901,6 +7901,9 @@
 					}
 					var loadPack=function(){
 						var toLoad=lib.config.all.cards.length+lib.config.all.characters.length+1;
+						if(_status.jsExt){
+							toLoad += _status.jsExt.length;
+						}
 						var packLoaded=function(){
 							toLoad--;
 							if(toLoad==0){
@@ -7925,6 +7928,9 @@
 						lib.init.js(lib.assetURL+'card',lib.config.all.cards,packLoaded,packLoaded);
 						lib.init.js(lib.assetURL+'character',lib.config.all.characters,packLoaded,packLoaded);
 						lib.init.js(lib.assetURL+'character','rank',packLoaded,packLoaded);
+						for(var i=0;i<_status.jsExt.length;i++){
+							lib.init.js(lib.assetURL+_status.jsExt[i].path,_status.jsExt[i].name,packLoaded,packLoaded);
+						}
 						// if(lib.device!='ios'&&lib.config.enable_pressure) lib.init.js(lib.assetURL+'game','pressure');
 					};
 
@@ -9468,6 +9474,13 @@
 					document.head.appendChild(style);
 				}
 				return style;
+			},
+			//在扩展的precontent中调用，用于加载扩展必需的JS文件。
+			addJsForExtension:function(path,name){
+				if(!_status.jsExt){
+					_status.jsExt = [];
+				}
+				_status.jsExt.add({path:path,name:name});
 			},
 			js:function(path,file,onload,onerror){
 				if(path[path.length-1]=='/'){

--- a/game/game.js
+++ b/game/game.js
@@ -7928,8 +7928,10 @@
 						lib.init.js(lib.assetURL+'card',lib.config.all.cards,packLoaded,packLoaded);
 						lib.init.js(lib.assetURL+'character',lib.config.all.characters,packLoaded,packLoaded);
 						lib.init.js(lib.assetURL+'character','rank',packLoaded,packLoaded);
-						for(var i=0;i<_status.jsExt.length;i++){
-							lib.init.js(lib.assetURL+_status.jsExt[i].path,_status.jsExt[i].name,packLoaded,packLoaded);
+						if(_status.jsExt){
+							for(var i=0;i<_status.jsExt.length;i++){
+								lib.init.js(lib.assetURL+_status.jsExt[i].path,_status.jsExt[i].name,packLoaded,packLoaded);
+							}
 						}
 						// if(lib.device!='ios'&&lib.config.enable_pressure) lib.init.js(lib.assetURL+'game','pressure');
 					};


### PR DESCRIPTION
用于在扩展的precontent中调用，方便扩展在无名杀启动前加载需要的JS文件