### PR TITLE
Support character die-audio tag && Provide failure callback for game.getFileList.

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -18237,26 +18237,26 @@
 						game.dead.push(player);
 						_status.dying.remove(player);
 
-						if(!lib.config.background_speak) return;
-						do {
-							if(!lib.character[player.name]) break;
-							if(lib.character[player.name][4].some(tag=>/^die:.+$/.test(tag))) {
-								const tag=lib.character[player.name][4].find(tag=>/^die:.+$/.test(tag))
+						if(lib.config.background_speak){
+							if(lib.character[player.name]&&lib.character[player.name][4].some(tag=>/^die:.+$/.test(tag))){
+								const tag=lib.character[player.name][4].find(tag=>/^die:.+$/.test(tag));
+								const reg=new RegExp("^ext:(.+)?/");
 								const match=tag.match(/^die:(.+)$/);
-								if (!match) break;
-								let path=match[1];
-								if(/^ext:(.+)/.test(path)) path=path.replace(/^ext:(.+?)\//, (_o,p)=>`../extension/${p}/`);
-								game.playAudio(path);
-								return;
+								if(match){
+									let path=match[1];
+									if(reg.test(path)) path=path.replace(reg,(_o,p)=>`../extension/${p}/`);
+									game.playAudio(path);
+								}
 							}
-							else if(lib.character[player.name][4].contains('die_audio')){
+							else if(lib.character[player.name]&&lib.character[player.name][4].contains('die_audio')){
 								game.playAudio('die',player.name);
-								return;
 							}
-						} while (false);
-						game.playAudio('die',player.name,function(){
-							game.playAudio('die',player.name.slice(player.name.indexOf('_')+1));
-						});
+							else{
+								game.playAudio('die',player.name,function(){
+									game.playAudio('die',player.name.slice(player.name.indexOf('_')+1));
+								});
+							}
+						}
 					},player);
 
 					game.addVideo('diex',player);

--- a/game/game.js
+++ b/game/game.js
@@ -8580,10 +8580,13 @@
 					game.getFileList=(dir,success,failure)=>{
 						var files=[],folders=[];
 						dir=__dirname+'/'+dir;
-						if(!failure){
-							failure=function(err){
+						if(typeof failure=="undefined"){
+							failure=err=>{
 								throw err;
 							};
+						}
+						else if(failure == null){
+							failure=()=>{};
 						}
 						lib.node.fs.access(dir,lib.node.fs.constants.F_OK|lib.node.fs.constants.R_OK,err=>{
 							if(err) {

--- a/game/game.js
+++ b/game/game.js
@@ -18238,14 +18238,21 @@
 						_status.dying.remove(player);
 
 						if(lib.config.background_speak){
-							if(lib.character[player.name]&&lib.character[player.name][4].contains('die_audio')){
-								game.playAudio('die',player.name);
-							}
-							// else if(true){
-							else{
+							if (!lib.character[player.name]){
 								game.playAudio('die',player.name,function(){
 									game.playAudio('die',player.name.slice(player.name.indexOf('_')+1));
 								});
+							}
+							else if(lib.character[player.name][4].some(tag=>/^die:.+$/.test(tag))) {
+								const tag=lib.character[player.name][4].find(tag=>/^die:.+$/.test(tag))
+								const match=tag.match(/^die:(.+)$/);
+								if (!match) return;
+								let path=match[1];
+								if(/^ext:(.+)/.test(path)) path=path.replace(/^ext:(.+?)\//, (_o,p)=>`../extension/${p}/`);
+								game.playAudio(path);
+							}
+							else if(lib.character[player.name][4].contains('die_audio')){
+								game.playAudio('die',player.name);
 							}
 						}
 					},player);

--- a/game/game.js
+++ b/game/game.js
@@ -18237,24 +18237,26 @@
 						game.dead.push(player);
 						_status.dying.remove(player);
 
-						if(lib.config.background_speak){
-							if (!lib.character[player.name]){
-								game.playAudio('die',player.name,function(){
-									game.playAudio('die',player.name.slice(player.name.indexOf('_')+1));
-								});
-							}
-							else if(lib.character[player.name][4].some(tag=>/^die:.+$/.test(tag))) {
+						if(!lib.config.background_speak) return;
+						do {
+							if(!lib.character[player.name]) break;
+							if(lib.character[player.name][4].some(tag=>/^die:.+$/.test(tag))) {
 								const tag=lib.character[player.name][4].find(tag=>/^die:.+$/.test(tag))
 								const match=tag.match(/^die:(.+)$/);
-								if (!match) return;
+								if (!match) break;
 								let path=match[1];
 								if(/^ext:(.+)/.test(path)) path=path.replace(/^ext:(.+?)\//, (_o,p)=>`../extension/${p}/`);
 								game.playAudio(path);
+								return;
 							}
 							else if(lib.character[player.name][4].contains('die_audio')){
 								game.playAudio('die',player.name);
+								return;
 							}
-						}
+						} while (false);
+						game.playAudio('die',player.name,function(){
+							game.playAudio('die',player.name.slice(player.name.indexOf('_')+1));
+						});
 					},player);
 
 					game.addVideo('diex',player);


### PR DESCRIPTION
提供一个扩展可用的武将死亡配音标签。
在角色死亡时判断武将标签中存不存在以`die:`开头的标签，如果有则根据此标签的信息播放指定的配音。
格式如下: 
- `die:audio/die/sunce`
- `die:ext:test/foo/bar`

---

提供`game.getFileList`的第三个参数，使`game.getFileList`读取文件夹失败时调用。
同时兼容以前的特性。