### PR TITLE
[Experimental] genCoroutine

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -29,7 +29,7 @@
 			}
 		}
 	}
-	function asyncGeneratorStep(gen,resolve,reject,_next,_throw,key,arg){
+	function _genNext(gen,resolve,reject,_next,_throw,key,arg){
 		try{
 			var info=gen[key](arg);
 			var value=info.value;
@@ -43,18 +43,26 @@
 			Promise.resolve(value).then(_next,_throw);
 		}
 	}
-	function _asyncToGenerator(fn){
-		return function(){
+	function genAwait(gen){
+		return new Promise((resolve,reject)=>{
+			function _next(value){
+				_genNext(gen,resolve,reject,_next,_throw,"next",value);
+			}
+			function _throw(err){
+				_genNext(gen,resolve,reject,_next,_throw,"throw",err);
+			}
+			_next(undefined);
+		})
+	}
+	function genAsync(fn){
+		return function AsyncSimulator(){
 			var self=this,args=arguments;
-			return new Promise(function(resolve, reject){
+			return new Promise((resolve,reject)=>{
 				var gen=fn.apply(self,args);
-				function _next(value){
-					asyncGeneratorStep(gen,resolve,reject,_next,_throw,"next",value);
-				}
-				function _throw(err){
-					asyncGeneratorStep(gen,resolve,reject,_next,_throw,"throw",err);
-				}
-				_next(undefined);
+				genAwait(gen).then((result, err)=>{
+					if(err) reject(err);
+					else resolve(result);
+				});
 			});
 		};
 	}
@@ -8842,16 +8850,13 @@
 				}
 			},
 			//lib.onload支持传入GeneratorFunction以解决异步函数的问题 by诗笺
-			onload:_asyncToGenerator(function*(){
+			onload:genAsync(function*(){
 				const libOnload=lib.onload;
 				delete lib.onload;
 				while(Array.isArray(libOnload)&&libOnload.length){
 					const fun=libOnload.shift();
-					if(fun instanceof GeneratorFunction){
-						yield _asyncToGenerator(fun)();
-					}else{
-						fun();
-					}
+					const result=fun();
+					yield (fun instanceof GeneratorFunction)?genAwait(result):result;
 				}
 				ui.updated();
 				game.documentZoom=game.deviceZoom;

--- a/game/game.js
+++ b/game/game.js
@@ -30,33 +30,33 @@
 		}
 	}
 	function asyncGeneratorStep(gen,resolve,reject,_next,_throw,key,arg){
-        try{
-            var info=gen[key](arg);
-            var value=info.value;
-        }catch(error){
-            reject(error);
-            return;
-        }
-        if(info.done){
-            resolve(value);
-        }else{
-            Promise.resolve(value).then(_next,_throw);
-        }
+		try{
+			var info=gen[key](arg);
+			var value=info.value;
+		}catch(error){
+			reject(error);
+			return;
+		}
+		if(info.done){
+			resolve(value);
+		}else{
+			Promise.resolve(value).then(_next,_throw);
+		}
 	}
 	function _asyncToGenerator(fn){
-        return function(){
-            var self=this,args=arguments;
-            return new Promise(function(resolve, reject){
-                var gen=fn.apply(self,args);
-                function _next(value){
-                    asyncGeneratorStep(gen,resolve,reject,_next,_throw,"next",value);
-                }
-                function _throw(err){
-                    asyncGeneratorStep(gen,resolve,reject,_next,_throw,"throw",err);
-                }
-                _next(undefined);
-            });
-        };
+		return function(){
+			var self=this,args=arguments;
+			return new Promise(function(resolve, reject){
+				var gen=fn.apply(self,args);
+				function _next(value){
+					asyncGeneratorStep(gen,resolve,reject,_next,_throw,"next",value);
+				}
+				function _throw(err){
+					asyncGeneratorStep(gen,resolve,reject,_next,_throw,"throw",err);
+				}
+				_next(undefined);
+			});
+		};
 	}
 	const GeneratorFunction=(function*(){}).constructor;
 	const _status={

--- a/game/game.js
+++ b/game/game.js
@@ -55,7 +55,7 @@
 		})
 	}
 	function genAsync(fn){
-		return function AsyncSimulator(){
+		return function genCoroutine(){
 			var self=this,args=arguments;
 			return new Promise((resolve,reject)=>{
 				var gen=fn.apply(self,args);
@@ -150,6 +150,7 @@
 			card:{},
 		},
 		onload:[],
+		onload2:[],
 		arenaReady:[],
 		onfree:[],
 		inpile:[],
@@ -7152,6 +7153,8 @@
 				'无名杀 - 录像 - '+_status.videoToSave.name[0]+' - '+_status.videoToSave.name[1]);
 			}
 		},
+		genAsync:genAsync,
+		genAwait:genAwait,
 		init:{
 			init:function(){
 				if(typeof __dirname==='string'&&__dirname.length){
@@ -9615,6 +9618,13 @@
 				}
 				localStorage.removeItem(lib.configprefix+'directstart');
 				delete lib.init.init;
+				const libOnload2=lib.onload2;
+				delete lib.onload2;
+				while(Array.isArray(libOnload2)&&libOnload2.length){
+					const fun=libOnload2.shift();
+					const result=fun();
+					yield (fun instanceof GeneratorFunction)?genAwait(result):result;
+				}
 			}),
 			startOnline:function(){
 				'step 0'

--- a/game/game.js
+++ b/game/game.js
@@ -7153,8 +7153,8 @@
 				'无名杀 - 录像 - '+_status.videoToSave.name[0]+' - '+_status.videoToSave.name[1]);
 			}
 		},
-		genAsync:genAsync,
-		genAwait:genAwait,
+		genAsync:fn=>genAsync(fn),
+		genAwait:gen=>genAwait(gen),
 		init:{
 			init:function(){
 				if(typeof __dirname==='string'&&__dirname.length){


### PR DESCRIPTION
声明了一个新名词`genCoroutine`，并添加了两个函数：`genAsync`和`genAwait`，作用如下：

- `genAsync(fn)`用于将一个`Generator Function`包装成`genCoroutine`，`genCoroutine`是个函数，接受参数与被包装的`Generator Function`相同，返回值为一个`Promise`。`genCoroutine`会不断遍历这个`Generator Function`生成的`Generator`，并将结果放入`Promise`中，等待该`Promise`结束后再继续遍历。换言之，`genAsync`相当于`babel`中于低版本模拟`async`的`_asyncToGenerator`
- `genAwait(gen)`是`genCoroutine`需要遍历`Generator`时调用的函数。换言之，`genAwait(gen)`就是将遍历出来的值放入`Promise`中，等待该`Promise`结束后再继续遍历。

---

目前`genCoroutine`的例子为`lib.init.onload`，代码如下：
```
onload:genAsync(function*(){
	const libOnload=lib.onload;
	delete lib.onload;
	while(Array.isArray(libOnload)&&libOnload.length){
		const fun=libOnload.shift();
		const result=fun();
		yield (fun instanceof GeneratorFunction)?genAwait(result):result;
	}
	...
}
```
这串代码展现了`genAsync`和`genAwait`的用法：

- `onload`本身为`genAsync`产生的函数，参数中的生成器函数使函数中可使用`yield`来模拟出`await`的效果，用于等待异步情况结束。
- `yield (fun instanceof GeneratorFunction)?genAwait(result):result;`中，我们尝试判断`fun`本身是不是一个生成器函数，如果是，则调用`genAwait(result)`，使`fun`产生的生成器能转换成异步进行的`Promise`，反之就正常返回`fun`产生的返回值。

我们可以下结论，`genAsync`和`genAwait`是无名杀现在基于老内核下比较好的异步处理方法，通过`genAsync`和`genAwait`，我们可以很直观的等待异步执行完毕，且过程中使用了标准的`Promise`，可以与其他任何代码联通。

---

在无名杀的本体中，任何`game.js`的代码都能访问到`genAsync`和`genAwait`，顺带还能访问到`_genNext`。在无名杀的扩展中，可通过`lib.genAsync`和`lib.genAwait`来访问`genAsync`和`genAwait`。

注意，`lib.genAsync`和`lib.genAwait`并不是`genAsync`和`genAwait`，这两个函数只是`genAsync`和`genAwait`的封装，防止`lib.genAsync`和`lib.genAwait`被修改后影响到本体代码。