### PR TITLE
[Bug Fix] Fix abort when extension content is not function.

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -9454,7 +9454,7 @@
 							try{
 								_status.extension=lib.extensions[i][0];
 								_status.evaluatingExtension=lib.extensions[i][3];
-								lib.extensions[i][1](lib.extensions[i][2],lib.extensions[i][4]);
+								if (typeof lib.extensions[i][1]=="function") lib.extensions[i][1](lib.extensions[i][2],lib.extensions[i][4]);
 								if(lib.extensions[i][4]){
 									if(lib.extensions[i][4].character){
 										for(var j in lib.extensions[i][4].character.character){

--- a/game/game.js
+++ b/game/game.js
@@ -30,33 +30,33 @@
 		}
 	}
 	function asyncGeneratorStep(gen,resolve,reject,_next,_throw,key,arg){
-        try{
-            var info=gen[key](arg);
-            var value=info.value;
-        }catch(error){
-            reject(error);
-            return;
-        }
-        if(info.done){
-            resolve(value);
-        }else{
-            Promise.resolve(value).then(_next,_throw);
-        }
+		try{
+			var info=gen[key](arg);
+			var value=info.value;
+		}catch(error){
+			reject(error);
+			return;
+		}
+		if(info.done){
+			resolve(value);
+		}else{
+			Promise.resolve(value).then(_next,_throw);
+		}
 	}
 	function _asyncToGenerator(fn){
-        return function(){
-            var self=this,args=arguments;
-            return new Promise(function(resolve, reject){
-                var gen=fn.apply(self,args);
-                function _next(value){
-                    asyncGeneratorStep(gen,resolve,reject,_next,_throw,"next",value);
-                }
-                function _throw(err){
-                    asyncGeneratorStep(gen,resolve,reject,_next,_throw,"throw",err);
-                }
-                _next(undefined);
-            });
-        };
+		return function(){
+			var self=this,args=arguments;
+			return new Promise(function(resolve, reject){
+				var gen=fn.apply(self,args);
+				function _next(value){
+					asyncGeneratorStep(gen,resolve,reject,_next,_throw,"next",value);
+				}
+				function _throw(err){
+					asyncGeneratorStep(gen,resolve,reject,_next,_throw,"throw",err);
+				}
+				_next(undefined);
+			});
+		};
 	}
 	const GeneratorFunction=(function*(){}).constructor;
 	const _status={


### PR DESCRIPTION
修复了原来扩展的`content`不为函数时会引发错误，从而被捕获并打印到控制台。