### PR TITLE
十常侍结党机制大改+bug修复

### DIFF
--- a/character/mobile.js
+++ b/character/mobile.js
@@ -775,12 +775,27 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				filter:function(event,player){
 					return event.name!='phase'||game.phaseNumber==0;
 				},
-				derivation:'mbdanggu_faq',
+				derivation:['mbdanggu_faq','mbdanggu_faq2'],
 				forced:true,
 				unique:true,
 				onremove:function(player){
 					delete player.storage.mbdanggu;
 					delete player.storage.mbdanggu_current;
+					if(lib.skill.mbdanggu.isSingleShichangshi(player)){
+						game.broadcastAll(function(player){
+							player.name1=player.name;
+							player.smoothAvatar(false);
+							player.node.avatar.setBackground(player.name,'character');
+							player.node.name.innerHTML=get.slimName(player.name);
+							delete player.name2;
+							player.classList.remove('fullskin2');
+							player.node.avatar2.classList.add('hidden');
+							player.node.name2.innerHTML='';
+							if(player==game.me&&ui.fakeme){
+								ui.fakeme.style.backgroundImage=player.node.avatar.style.backgroundImage;
+							}
+						},player);
+					}
 				},
 				changshi:[
 					['scs_zhangrang','scstaoluan'],
@@ -794,17 +809,27 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					['scs_guosheng','scsniqu'],
 					['scs_gaowang','scsmiaoyu']
 				],
-				conflictMap:{
-					scs_zhangrang:['scs_hankui'],
-					scs_zhaozhong:['scs_guosheng','scs_lisong'],
-					scs_sunzhang:['scs_duangui','scs_hankui'],
-					scs_bilan:['scs_hankui','scs_xiayun','scs_zhaozhong','scs_sunzhang'],
-					scs_xiayun:['scs_zhaozhong','scs_lisong'],
-					scs_hankui:['scs_bilan','scs_zhangrang'],
-					scs_lisong:['scs_guosheng','scs_duangui'],
-					scs_duangui:['scs_guosheng'],
-					scs_guosheng:['scs_duangui'],
-					scs_gaowang:['scs_xuayun','scs_sunzhang'],
+				conflictMap:function(){
+					if(!_status.changshiMap){
+						_status.changshiMap={
+							scs_zhangrang:[],
+							scs_zhaozhong:[],
+							scs_sunzhang:[],
+							scs_bilan:['scs_hankui'],
+							scs_xiayun:[],
+							scs_hankui:['scs_bilan'],
+							scs_lisong:[],
+							scs_duangui:['scs_guosheng'],
+							scs_guosheng:['scs_duangui'],
+							scs_gaowang:[],
+						};
+						var list=lib.skill.mbdanggu.changshi.map(i=>i[0]);
+						for(var i of list){
+							var select=list.filter(scs=>scs!=i&&!_status.changshiMap[i].contains(i));
+							_status.changshiMap[i].addArray(select.randomGets(get.rand(0,select.length)));
+						}
+					}
+					return _status.changshiMap;
 				},
 				group:'mbdanggu_back',
 				content:function(){
@@ -831,59 +856,43 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				contentx:function(){
 					'step 0'
-					var list=player.getStorage('mbdanggu');
-					var first=list.randomRemove(1)[0];
+					var list=player.getStorage('mbdanggu').slice();
+					var first=list.randomRemove();
 					event.first=first;
-					game.broadcastAll(function(changshi){
-						if(lib.config.background_speak) game.playAudio('skill',changshi+'_enter');
-					},first);
-					if(lib.skill.mbdanggu.isSingleShichangshi(player)){
-						game.broadcastAll(function(player,first){
-							if(!player.name2) player.smoothAvatar(false);
-							player.name1=first;
-							player.node.avatar.setBackground(first,'character');
-							player.node.name.innerHTML=get.slimName(first);
-							delete player.name2;
-							player.smoothAvatar(true);
-							player.node.avatar2.classList.add('hidden');
-							player.classList.remove('fullskin2');
-							player.node.name2.innerHTML='';
-							if(player==game.me&&ui.fakeme){
-								ui.fakeme.style.backgroundImage=player.node.avatar.style.backgroundImage;
-							}
-						},player,first);
-					}
 					var others=list.randomGets(4);
-					var next=player.chooseButton([
-						'党锢：请选择结党对象',
-						[[first],'character'],
-						'<div class="text center">可选常侍</div>',
-						[others,'character']
-					],true);
-					next.set('filterButton',button=>{
-						return !_status.event.canChoose.contains(button.link);
-					})
-					next.set('canChoose',function(){
+					if(others.length==1) event._result={bool:true,links:others};
+					else{
 						var conflictList=others.filter(changshi=>{
-							var map=lib.skill.mbdanggu.conflictMap;
+							var map=lib.skill.mbdanggu.conflictMap();
 							var names=map[first];
 							return names.contains(changshi);
-						});
-						var list=[];
-						if(conflictList.length&&others.length>1) list.push(conflictList.randomGet());
-						return list;
-					}());
-					next.set('ai',button=>{
-						return Math.random()*10;
-					})
+						}),list=others.slice();
+						if(conflictList.length){
+							var conflict=conflictList.randomGet();
+							list.remove(conflict);
+							game.broadcastAll(function(changshi,player){
+								if(lib.config.background_speak){
+									if(player.isUnderControl(true)) game.playAudio('skill',changshi+'_enter');
+								}
+							},conflict,player);
+						}
+						player.chooseButton([
+							'党锢：请选择结党对象',
+							[[first],'character'],
+							'<div class="text center">可选常侍</div>',
+							[others,'character']
+						],true).set('filterButton',button=>{
+							return _status.event.canChoose.contains(button.link);
+						}).set('canChoose',list).set('ai',button=>Math.random()*10);
+					}
 					'step 1'
 					if(result.bool){
 						var first=event.first;
 						var chosen=result.links[0];
 						var skills=[];
 						var list=lib.skill.mbdanggu.changshi;
-						var changshis=[event.first,chosen];
-						player.unmarkAuto('mbdanggu',[chosen]);
+						var changshis=[first,chosen];
+						player.unmarkAuto('mbdanggu',changshis);
 						player.storage.mbdanggu_current=changshis;
 						for(var changshi of changshis){
 							for(var cs of list){
@@ -891,7 +900,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							}
 						}
 						if(lib.skill.mbdanggu.isSingleShichangshi(player)){
-							game.broadcastAll(function(player,chosen){
+							game.broadcastAll(function(player,first,chosen){
+								player.name1=first;
+								player.node.avatar.setBackground(first,'character');
+								player.node.name.innerHTML=get.slimName(first);
 								player.name2=chosen;
 								player.classList.add('fullskin2');
 								player.node.avatar2.classList.remove('hidden');
@@ -900,21 +912,23 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								if(player==game.me&&ui.fakeme){
 									ui.fakeme.style.backgroundImage=player.node.avatar.style.backgroundImage;
 								}
-							},player,chosen);
+							},player,first,chosen);
 						}
 						game.log(player,'选择了常侍','#y'+get.translation(changshis));
-						game.broadcastAll(function(changshi){
-							if(lib.config.background_speak) game.playAudio('skill',changshi+'_enter');
-						},chosen);
 						if(skills.length){
 							player.addAdditionalSkill('mbdanggu',skills);
-							game.log(player,'获得了技能','#g'+get.translation(skills));
-							player.popup(skills);
+							var str='';
+							for(var i of skills){
+								str+='【'+get.translation(i)+'】、';
+								player.popup(i);
+							}
+							str=str.slice(0,-1);
+							game.log(player,'获得了技能','#g'+str);
 						}
 					}
 				},
 				isSingleShichangshi:function(player){
-					var map=lib.skill.mbdanggu.conflictMap;
+					var map=lib.skill.mbdanggu.conflictMap();
 					return player.name=='shichangshi'&&(map[player.name1]&&map[player.name2]||map[player.name1]&&!player.name2||!player.name1&&!player.name2||player.name==player.name1&&!player.name2);
 				},
 				mod:{
@@ -925,11 +939,15 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						return lib.skill.mbdanggu.mod.aiValue.apply(this,arguments);
 					},
 				},
+				ai:{
+					combo:'mbmowang',
+					nokeep:true,
+				},
 				intro:{
 					mark:function(dialog,storage,player){
 						dialog.addText('剩余常侍');
 						dialog.addSmall([storage,'character']);
-						if(player.storage.mbdanggu_current){
+						if(player.storage.mbdanggu_current&&player.isIn()){
 							dialog.addText('当前常侍');
 							dialog.addSmall([player.storage.mbdanggu_current,'character']);
 						}
@@ -944,6 +962,24 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						},
 						forced:true,
 						content:function(){
+							'step 0'
+							delete player.storage.mbdanggu_current;
+							if(lib.skill.mbdanggu.isSingleShichangshi(player)){
+								game.broadcastAll(function(player){
+									player.name1=player.name;
+									player.smoothAvatar(false);
+									player.node.avatar.setBackground(player.name,'character');
+									player.node.name.innerHTML=get.slimName(player.name);
+									delete player.name2;
+									player.classList.remove('fullskin2');
+									player.node.avatar2.classList.add('hidden');
+									player.node.name2.innerHTML='';
+									if(player==game.me&&ui.fakeme){
+										ui.fakeme.style.backgroundImage=player.node.avatar.style.backgroundImage;
+									}
+								},player);
+							}
+							'step 1'
 							var next=game.createEvent('mbdanggu_clique');
 							next.player=player;
 							next.setContent(lib.skill.mbdanggu.contentx);
@@ -976,6 +1012,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						trigger.includeOut=true;
 					}
 				},
+				ai:{combo:'mbdanggu'},
 				dieContent:function(){
 					'step 0'
 					event.forceDie=true;
@@ -1586,7 +1623,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					return event.targets.length==1&&event.card.name=='sha';
 				},
 				prompt2:function(event,player){
-					var str='展示牌堆顶的两张牌并增加伤害；且';
+					var str='亮出牌堆顶的两张牌并增加伤害；且';
 					str+=('令'+get.translation(event.target)+'不能使用');
 					str+='这两张牌所包含的花色';
 					str+=('的牌响应'+get.translation(event.card));
@@ -1613,7 +1650,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							var suitx=get.suit(card,false);
 							suits.add(suitx);
 							if(suit==suitx) evt.baseDamage++;
-							ui.cardPile.insertBefore(card,ui.cardPile.firstChild);
 						}
 						game.updateRoundNumber();
 					}
@@ -1656,6 +1692,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						forced:true,
 						firstDo:true,
 						charlotte:true,
+						popup:false,
 						onremove:function(player){
 							delete player.storage.scschihe_block;
 							delete player.storage.scschihe_blocker;
@@ -14164,7 +14201,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			mbdanggu:'党锢',
 			mbdanggu_info:'锁定技。①游戏开始时，你获得十张“常侍”牌，然后你进行一次结党。②当你修整结束后，你进行一次结党并摸一张牌。③若你有亮出的“常侍”牌，你视为拥有这些牌的技能。',
 			mbdanggu_faq:'关于结党',
-			mbdanggu_faq_info:'<br>系统随机选择一张未亮出过的“常侍”牌，然后选择四张未亮出过的“常侍”牌。你观看前者，然后从后者中选择一名与前者互相认可的“常侍”牌（不认可的“常侍”牌为不可选状态，若有多组不认可的“常侍”牌，则系统随机选择其中一张“常侍”牌为不可选状态，若本次结党“常侍”牌仅有一张，则不存在不认可的“常侍”牌）。然后若此时不为双将模式，你将这两张武将牌作为你的武将牌（不移除原有技能）；否则你获得这两张武将牌上的技能。',
+			mbdanggu_faq_info:'<br>系统随机选择一张未亮出过的“常侍”牌，然后选择四张未亮出过的“常侍”牌。你观看前者，然后从后者中选择一名认可前者的“常侍”牌。然后若此时不为双将模式，你将这两张武将牌作为你的武将牌（不移除原有技能）；否则你获得这两张武将牌上的技能。',
+			mbdanggu_faq2:'关于认可',
+			mbdanggu_faq2_info:'<br>双向不认可常侍为固定组合：<br><li>郭胜、段珪<br><li>韩悝、毕岚<br>单向不认可常侍为系统随机分配。<br>每次结党至多存在一张不认可主将的常侍牌，且若此次结党仅有一张常侍牌，则不会存在不认可情况。',
 			mbmowang:'殁亡',
 			mbmowang_info:'锁定技。①当你死亡前，若你有未亮出的“常侍”牌且体力上限大于0，你将死亡改为修整至你的下个回合开始前，然后你复原武将牌，且不于此次死亡事件中进行展示身份牌、检测游戏胜利条件与执行奖惩的流程。②回合结束后，你死亡。',
 			mbmowang_faq:'关于修整',


### PR DESCRIPTION
机制修改
调整结党除两组互不认可的常侍外，其余单向不认可关系均于第一次获取十常侍时进行随机配对
添加修正结束后若为单将模式则将武将暂时修改回十常侍
调整十常侍嘲讽语音播放逻辑
bug修复
修复结党能选最上面展示的常侍的bug
修复单将模式失去【党锢】后武将牌不变回十常侍的bug
修复段珪【叱吓】亮出的牌仍放回牌堆的bug