### PR TITLE
Use Object.defineProperty, and Object.getOwnPropertyDescriptor to initialize instead.

### DIFF
--- a/card/yongjian.js
+++ b/card/yongjian.js
@@ -646,6 +646,12 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 			 * @deprecated
 			 */
 			_yongjian_zengyu:{
+				get forceLoad(){
+					return lib.skill._gifting.forceLoad;
+				},
+				set forceLoad(forceLoad){
+					lib.skill._gifting.forceLoad=forceLoad;
+				},
 				get filter(){
 					return lib.skill._gifting.filter;
 				},

--- a/game/game.js
+++ b/game/game.js
@@ -9200,7 +9200,7 @@
 											};
 										}
 										else{
-											lib[j][k]=character[i][j][k];
+											Object.defineProperty(lib[j],k,Object.getOwnPropertyDescriptor(character[i][j],k));
 										}
 										if(j=='card'&&lib[j][k].derivation){
 											if(!lib.cardPack.mode_derivation){


### PR DESCRIPTION
使用`Object.defineProperty`和`Object.getOwnPropertyDescriptor`初始化导入包，避免导入内容失真。
支持兼容版。