### PR TITLE
[Suggest] advancify get.cardNameLength

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -53194,8 +53194,8 @@
 	const get={
 		//Get the card name length
 		//获取此牌的字数
-		cardNameLength:card=>{
-			const actualCardName=lib.actualCardName,name=get.translation(get.name(card));
+		cardNameLength:(card,player)=>{
+			const actualCardName=lib.actualCardName,name=get.translation(get.name(card,player));
 			return (actualCardName.has(name)?actualCardName.get(name):name).length;
 		},
 		//Yingbian


### PR DESCRIPTION
增加`get.cardNameLength`的第二个参数`player`，用于传入`get.name`中，获取经过`mod`转换后的真实牌。