### PR TITLE
[Purify] genCoroutine && lib.onprepare

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -32,17 +32,18 @@
 	const GeneratorFunction=(function*(){}).constructor;
 	// gnc: GeNCoroutine
 	const gnc={
-		async:(fn)=>function genCoroutine(){
+		async:fn=>function genCoroutine(){
 			return gnc.await(fn.apply(this,arguments))
 		},
-		await:(gen)=>new Promise((resolve,reject)=>{
+		await:gen=>new Promise((resolve,reject)=>{
 			const _next=value=>gnc.next(gen,resolve,reject,"next",value,_next,_throw);
 			const _throw=err=>gnc.next(gen,resolve,reject,"throw",err,_next,_throw);
 			_next(undefined);
 		}),
 		is:{
-			coroutine:(item)=>typeof item=="function"&&item.name=="genCoroutine",
-			generator:(item)=>item instanceof GeneratorFunction
+			coroutine:item=>typeof item=="function"&&item.name=="genCoroutine",
+			generator:item=>item instanceof GeneratorFunction,
+			a:item=>item.constructor==GeneratorFunction
 		},
 		next:(gen,resolve,reject,key,arg,_next,_throw)=>{
 			let info,value;
@@ -7157,8 +7158,9 @@
 		},
 		genAsync:fn=>gnc.async(fn),
 		genAwait:gen=>gnc.await(gen),
-		isGenCoroutine:(item)=>typeof item=="function"&&item.name=="genCoroutine",
-		isGenerator:(item)=>item instanceof GeneratorFunction,
+		isGenCoroutine:item=>gnc.is.coroutine(item),
+		isGeneratorFunc:item=>gnc.is.generator(item),
+		isGenerator:item=>gnc.is.a(item),
 		init:{
 			init:function(){
 				if(typeof __dirname==='string'&&__dirname.length){

--- a/game/game.js
+++ b/game/game.js
@@ -7157,6 +7157,8 @@
 		},
 		genAsync:fn=>gnc.async(fn),
 		genAwait:gen=>gnc.await(gen),
+		isGenCoroutine:(item)=>typeof item=="function"&&item.name=="genCoroutine",
+		isGenerator:(item)=>item instanceof GeneratorFunction,
 		init:{
 			init:function(){
 				if(typeof __dirname==='string'&&__dirname.length){
@@ -9096,7 +9098,7 @@
 					});
 				}
 
-				var proceed2=function(){
+				var proceed2=gnc.async(function*(){
 					var mode=lib.imported.mode;
 					var card=lib.imported.card;
 					var character=lib.imported.character;
@@ -9548,8 +9550,12 @@
 						}
 					}
 					delete lib.init.start;
+					if(Array.isArray(_status.onprepare)&&_status.onprepare.length){
+						yield Promise.allSettled(_status.onprepare);
+						delete _status.onprepare;
+					}
 					game.loop();
-				}
+				})
 				var proceed=function(){
 					if(!lib.db){
 						try{
@@ -9666,10 +9672,6 @@
 					const fun=libOnload2.shift();
 					const result=fun();
 					yield gnc.is.generator(fun)?gnc.await(result):result;
-				}
-				if(Array.isArray(_status.onprepare)&&_status.onprepare.length){
-					Promise.allSettled(_status.onprepare);
-					delete _status.onprepare;
 				}
 			}),
 			startOnline:function(){

--- a/game/game.js
+++ b/game/game.js
@@ -144,8 +144,7 @@
 		},
 		onload:[],
 		onload2:[],
-		onload3:[],
-		onload4:[],
+		onprepare:[],
 		arenaReady:[],
 		onfree:[],
 		inpile:[],
@@ -8137,6 +8136,12 @@
 						}
 					}
 					const loadPack=()=>{
+						if (Array.isArray(lib.onprepare)&&lib.onprepare.length){
+							_status.onprepare=Object.freeze(lib.onprepare.map(fn=>{
+								const result=fn();
+								return gnc.is.generator(fn)?gnc.await(result):result;
+							}));
+						}
 						let toLoad=lib.config.all.cards.length+lib.config.all.characters.length+1;
 						if(_status.jsExt) toLoad+=_status.jsExt.reduce((previousValue,currentValue)=>{
 							const arrayLengths=Object.values(currentValue).reduce((previousElement,currentElement)=>{
@@ -8336,7 +8341,7 @@
 						document.addEventListener('touchmove',ui.click.windowtouchmove);
 					}
 				};
-				var proceed2=function(){
+				var proceed2=()=>{
 					if(config3){
 						proceed(config3);
 					}
@@ -8891,21 +8896,13 @@
 			},
 			//lib.onload支持传入GeneratorFunction以解决异步函数的问题 by诗笺
 			onload:gnc.async(function*(){
-				const libOnload=lib.onload,libOnload3=lib.onload3;
+				const libOnload=lib.onload;
 				delete lib.onload;
-				delete lib.onload3;
-				let onload3=[];
-				while(Array.isArray(libOnload3)&&libOnload3.length){
-					const fun=libOnload3.shift();
-					const result=fun();
-					onload3.add(gnc.is.generator(fun)?gnc.await(result):result);
-				}
 				while(Array.isArray(libOnload)&&libOnload.length){
 					const fun=libOnload.shift();
 					const result=fun();
 					yield gnc.is.generator(fun)?gnc.await(result):result;
 				}
-				yield Promise.allSettled(onload3);
 				ui.updated();
 				game.documentZoom=game.deviceZoom;
 				if(game.documentZoom!=1){
@@ -9663,21 +9660,17 @@
 				}
 				localStorage.removeItem(lib.configprefix+'directstart');
 				delete lib.init.init;
-				const libOnload2=lib.onload2,libOnload4=lib.onload4;
+				const libOnload2=lib.onload2;
 				delete lib.onload2;
-				delete lib.onload4;
-				let onload4=[];
-				while(Array.isArray(libOnload4)&&libOnload4.length){
-					const fun=libOnload4.shift();
-					const result=fun();
-					onload4.add(gnc.is.generator(fun)?gnc.await(result):result);
-				}
 				while(Array.isArray(libOnload2)&&libOnload2.length){
 					const fun=libOnload2.shift();
 					const result=fun();
 					yield gnc.is.generator(fun)?gnc.await(result):result;
 				}
-				yield Promise.allSettled(onload4);
+				if(Array.isArray(_status.onprepare)&&_status.onprepare.length){
+					Promise.allSettled(_status.onprepare);
+					delete _status.onprepare;
+				}
 			}),
 			startOnline:function(){
 				'step 0'

--- a/game/game.js
+++ b/game/game.js
@@ -42,8 +42,8 @@
 		}),
 		is:{
 			coroutine:item=>typeof item=="function"&&item.name=="genCoroutine",
-			generator:item=>item instanceof GeneratorFunction,
-			a:item=>item.constructor==GeneratorFunction
+			generatorFunc:item=>item instanceof GeneratorFunction,
+			generator:item=>item.constructor==GeneratorFunction
 		},
 		next:(gen,resolve,reject,key,arg,_next,_throw)=>{
 			let info,value;
@@ -7158,6 +7158,15 @@
 		},
 		genAsync:fn=>gnc.async(fn),
 		genAwait:gen=>gnc.await(gen),
+		gnc:{
+			async:gnc.async(fn),
+			await:gnc.await(gen),
+			is:{
+				coroutine:item=>gnc.is.coroutine(item),
+				generatorFunc:item=>gnc.is.generatorFunc(item),
+				generator:item=>gnc.is.generator(item)
+			}
+		},
 		init:{
 			init:function(){
 				if(typeof __dirname==='string'&&__dirname.length){
@@ -8140,7 +8149,7 @@
 						if (Array.isArray(lib.onprepare)&&lib.onprepare.length){
 							_status.onprepare=Object.freeze(lib.onprepare.map(fn=>{
 								const result=fn();
-								return gnc.is.generator(fn)?gnc.await(result):result;
+								return gnc.is.generatorFunc(fn)?gnc.await(result):result;
 							}));
 						}
 						let toLoad=lib.config.all.cards.length+lib.config.all.characters.length+1;
@@ -8902,7 +8911,7 @@
 				while(Array.isArray(libOnload)&&libOnload.length){
 					const fun=libOnload.shift();
 					const result=fun();
-					yield gnc.is.generator(fun)?gnc.await(result):result;
+					yield gnc.is.generatorFunc(fun)?gnc.await(result):result;
 				}
 				ui.updated();
 				game.documentZoom=game.deviceZoom;
@@ -9670,7 +9679,7 @@
 				while(Array.isArray(libOnload2)&&libOnload2.length){
 					const fun=libOnload2.shift();
 					const result=fun();
-					yield gnc.is.generator(fun)?gnc.await(result):result;
+					yield gnc.is.generatorFunc(fun)?gnc.await(result):result;
 				}
 			}),
 			startOnline:function(){

--- a/game/game.js
+++ b/game/game.js
@@ -7158,9 +7158,6 @@
 		},
 		genAsync:fn=>gnc.async(fn),
 		genAwait:gen=>gnc.await(gen),
-		isGenCoroutine:item=>gnc.is.coroutine(item),
-		isGeneratorFunc:item=>gnc.is.generator(item),
-		isGenerator:item=>gnc.is.a(item),
 		init:{
 			init:function(){
 				if(typeof __dirname==='string'&&__dirname.length){


### PR DESCRIPTION
将`genCoroutine`相关事件移至命名空间`gnc`中。该命名空间不会保存在任何可访问到的全局变量中。`lib.genAsync`和`lib.genAwait`作用不变。同时增加`lib.isGenCoroutine`、`lib.isGeneratorFunc`和`lib.isGenerator`三个函数，分别用于判定一个值是不是`genCoroutine`、`GeneratorFunction`和`Generator`。

---

提供`lib.onprepare`，用于在扩展全部加载后开始执行提供的操作（支持`genCoroutine`）；这些操作会在执行完扩展的`content`后等待执行完毕。

> EAP: 此功能或许有更好的替代方案