### PR TITLE
[Purify] Modify `lib.gnc`

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -44,6 +44,8 @@
 			let nexts=resolve;
 			let throws=reject;
 			if(gnc.is.coroutine(gen)||(gnc.is.generator(gen)&&!gnc.nocoroutine)) {
+				if(!gen.status)gen.status="next";
+				if(!gen.state)gen.state=undefined;
 				try{
 					result=gen[result.status](result.state);
 				}catch(error){

--- a/game/game.js
+++ b/game/game.js
@@ -43,7 +43,7 @@
 			let result=gen;
 			let nexts=resolve;
 			let throws=reject;
-			if(gnc.is.coroutine(gen)) {
+			if(gnc.is.coroutine(gen)||(gnc.is.generator(gen)&&!gnc.nocoroutine)) {
 				try{
 					result=gen[result.status](result.state);
 				}catch(error){

--- a/game/game.js
+++ b/game/game.js
@@ -43,7 +43,7 @@
 			let result=gen;
 			let nexts=resolve;
 			let throws=reject;
-			if(gnc.is.coroutine(gen)||(gnc.is.generator(gen)&&!gnc.nocoroutine)) {
+			if(gnc.is.coroutine(gen)||(gnc.is.generator(gen)&&!gen.nocoroutine)) {
 				if(!gen.status)gen.status="next";
 				if(!gen.state)gen.state=undefined;
 				try{
@@ -68,6 +68,10 @@
 			}
 			Promise.resolve(result).then(nexts,throws);
 		}),
+		escape:gen=>{
+			gen.nocoroutine=true;
+			return gen;
+		},
 		is:{
 			coroutine:item=>(typeof item=="function"||gnc.is.generator(item))&&item.name=="genCoroutine",
 			generatorFunc:item=>item instanceof GeneratorFunction,
@@ -7269,6 +7273,7 @@
 		gnc:{
 			async:fn=>gnc.async(fn),
 			await:gen=>gnc.await(gen),
+			escape:gen=>gnc.escape(gen),
 			is:{
 				coroutine:item=>gnc.is.coroutine(item),
 				generatorFunc:item=>gnc.is.generatorFunc(item),

--- a/game/game.js
+++ b/game/game.js
@@ -69,7 +69,7 @@
 		is:{
 			coroutine:item=>(typeof item=="function"||gnc.is.generator(item))&&item.name=="genCoroutine",
 			generatorFunc:item=>item instanceof GeneratorFunction,
-			generator:item=>item.constructor.constructor==GeneratorFunction
+			generator:item=>(typeof item=="object")&&("constructor" in item)&&item.constructor&&("constructor" in item.constructor)&&item.constructor.constructor===GeneratorFunction
 		}
 	};
 	const _status={
@@ -8304,8 +8304,8 @@
 					const loadPack=()=>{
 						if (Array.isArray(lib.onprepare)&&lib.onprepare.length){
 							_status.onprepare=Object.freeze(lib.onprepare.map(fn=>{
-								const result=fn();
-								return gnc.is.generatorFunc(fn)?gnc.await(result):result;
+								if(typeof fn!="function") return;
+								return gnc.await(fn());
 							}));
 						}
 						let toLoad=lib.config.all.cards.length+lib.config.all.characters.length+1;
@@ -9096,8 +9096,8 @@
 				delete lib.onload;
 				while(Array.isArray(libOnload)&&libOnload.length){
 					const fun=libOnload.shift();
-					const result=fun();
-					yield gnc.is.generatorFunc(fun)?gnc.await(result):result;
+					if(typeof fun!="function") continue;
+					yield gnc.await(fun());
 				}
 				ui.updated();
 				game.documentZoom=game.deviceZoom;
@@ -9870,8 +9870,8 @@
 				delete lib.onload2;
 				while(Array.isArray(libOnload2)&&libOnload2.length){
 					const fun=libOnload2.shift();
-					const result=fun();
-					yield gnc.is.generatorFunc(fun)?gnc.await(result):result;
+					if(typeof fun!="function") continue;
+					yield gnc.await(fun());
 				}
 			}),
 			startOnline:function(){


### PR DESCRIPTION
修改`lib.gnc`的逻辑，现在`lib.gnc.await`可以给定任意参数，同时不再需要`gnc.next`作为辅助函数。
目前可以直接用`yield gnc.await(fun())`来直接异步未知`fun`情况的函数，而不需要判断是否是`genCoroutine`。同时`lib.gnc.await`可套娃调用，如`lib.gnc.await(lib.gnc.await(gen))`，这也是当`fun`为`genCoroutine`时`yield gnc.await(fun())`会发生的情况。