### PR TITLE
fix: fix boss_diting conflicting with shouli

### DIFF
--- a/mode/boss.js
+++ b/mode/boss.js
@@ -3117,9 +3117,19 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 						return distance+1;
 					},
 				},
-				init:function(player){
-				player.$disableEquip('equip3');
-				player.$disableEquip('equip4');
+				group: ["boss_diting_init"],
+				subSkill: {
+					"init": {
+						forced: true,
+						trigger: {
+							player: 'enterGame',
+							global: 'phaseBefore',
+						},
+						content: function () {
+							player.disableEquip('equip3');
+							player.disableEquip('equip4');
+						}
+					}
 				},
 				enable:"phaseUse",
 				position:'h',


### PR DESCRIPTION
修复地藏王的坐骑区会随着神马超的技能而恢复的问题。
Before
![image](https://github.com/libccy/noname/assets/60914359/98872519-d992-4d20-910e-7e7a550f8864)
After
![image](https://github.com/libccy/noname/assets/60914359/b16364a5-de31-4ef8-aaa3-b2ddda9bc99b)
