### PR TITLE
[Purify] `game.import` fused of `lib.gnc`.

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -33500,9 +33500,11 @@
 					}
 				}
 			});
-			if(typeof _status.extensionLoading=="undefined")_status.extensionLoading=[];
 			const promise=asyncFn();
-			_status.extensionLoading.add(promise);
+			if(type=='extension'){
+				if(typeof _status.extensionLoading=="undefined")_status.extensionLoading=[];	
+				_status.extensionLoading.add(promise);
+			}
 			return promise;
 		},
 		loadExtension:gnc.async(function*(obj){

--- a/game/game.js
+++ b/game/game.js
@@ -9732,7 +9732,7 @@
 							try{
 								_status.extension=lib.extensions[i][0];
 								_status.evaluatingExtension=lib.extensions[i][3];
-								if (typeof lib.extensions[i][1]=="function") yield lib.extensions[i][1](lib.extensions[i][2],lib.extensions[i][4]);
+								if (typeof lib.extensions[i][1]=="function") yield gnc.await(lib.extensions[i][1](lib.extensions[i][2],lib.extensions[i][4]));
 								if(lib.extensions[i][4]){
 									if(lib.extensions[i][4].character){
 										for(var j in lib.extensions[i][4].character.character){
@@ -33493,7 +33493,7 @@
 					if(!lib.imported[type]){
 						lib.imported[type]={};
 					}
-					var content2=yield content(lib,game,ui,get,ai,_status);
+					var content2=yield gnc.await(content(lib,game,ui,get,ai,_status));
 					if(content2.name){
 						lib.imported[type][content2.name]=content2;
 						delete content2.name;
@@ -33508,7 +33508,7 @@
 		loadExtension:gnc.async(function*(obj){
 			var noeval=false;
 			if(typeof obj=='function'){
-				obj=yield obj(lib,game,ui,get,ai,_status);
+				obj=yield gnc.await(obj(lib,game,ui,get,ai,_status));
 				noeval=true;
 			}
 			lib.extensionMenu['extension_'+obj.name]={
@@ -33626,7 +33626,7 @@
 						}
 						if(obj.precontent){
 							_status.extension=obj.name;
-							yield obj.precontent(cfg);
+							yield gnc.await(obj.precontent(cfg));
 							delete _status.extension;
 						}
 						if(obj.content){

--- a/game/game.js
+++ b/game/game.js
@@ -33485,27 +33485,21 @@
 			}
 		},
 		import:function(type,content){
-			const asyncFn=gnc.async(function*(){
-				if(type=='extension'){
-					yield game.loadExtension(content);
-				}
-				else{
-					if(!lib.imported[type]){
-						lib.imported[type]={};
-					}
-					var content2=yield gnc.await(content(lib,game,ui,get,ai,_status));
+			if(type=='extension'){
+				if(typeof _status.extensionLoading=="undefined")_status.extensionLoading=[];
+				const promise=game.loadExtension(content);
+				_status.extensionLoading.add(promise);
+				return promise;
+			}
+			else{
+				if(!lib.imported[type])lib.imported[type]={};
+				return gnc.await(content(lib,game,ui,get,ai,_status)).then(content2=>{
 					if(content2.name){
 						lib.imported[type][content2.name]=content2;
 						delete content2.name;
 					}
-				}
-			});
-			const promise=asyncFn();
-			if(type=='extension'){
-				if(typeof _status.extensionLoading=="undefined")_status.extensionLoading=[];	
-				_status.extensionLoading.add(promise);
+				});
 			}
-			return promise;
 		},
 		loadExtension:gnc.async(function*(obj){
 			var noeval=false;

--- a/mode/identity.js
+++ b/mode/identity.js
@@ -134,7 +134,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 						step4();
 					}
 				};
-				var step4=lib.genAsync(function*(){
+				var step4=lib.gnc.async(function*(){
 					clear();
 					ui.window.classList.add('noclick_important');
 					ui.click.configMenu();


### PR DESCRIPTION
将`game.import`的异步与最新的`lib.gnc`融合，可以直接用生成器函数做配置，而不需要调用`gnc.async`。
从另一个角度来说，在`game.import`时无法调用`lib.gnc`，故必然需要使用`gnc.await`。