### PR TITLE
[Experimentalize] Guozhan Extension Interface.

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -137,6 +137,7 @@
 		characterFilter:{},
 		characterSort:{},
 		characterReplace:{},
+		characterGuozhanFilter:["mode_guozhan"],
 		dynamicTranslate:{},
 		cardPack:{},
 		skin:{},

--- a/game/game.js
+++ b/game/game.js
@@ -36108,11 +36108,16 @@
 			lib.characterPack[packname][name]=character;
 			lib.translate[packname+'_character_config']=extname;
 		},
-		addCharacterPack:function(pack,packagename){
+		addCharacterPack:(pack,packagename)=>{
 			var extname=_status.extension||'扩展';
+			let gzFlag=false;
 			packagename=packagename||extname;
 			for(var i in pack){
-				if(i=='mode'||i=='forbid') continue;
+				if(i=='mode'){
+					if(pack[i]=="guozhan") gzFlag=true;
+					continue;
+				}
+				if(i=='forbid') continue;
 				for(var j in pack[i]){
 					if(i=='character'){
 						if(!pack[i][j][4]){
@@ -36126,12 +36131,8 @@
 							imgsrc='ext:'+extname+'/'+j+'.jpg';
 						}
 						const audiosrc='die:ext:'+extname+'/'+j+'.mp3';
-						pack[i][j][4].add(imgsrc);
-						if(!pack[i][j][4].some((str)=>{
-							return typeof str == 'string' && str.indexOf('die:') == 0;
-						})){
-							pack[i][j][4].add(audiosrc);
-						}
+						if(!pack[i][j][4].some(str=>typeof str=="string"&&/^(?:db:extension-|ext:):(?:.+)/.test(str))) pack[i][j][4].add(imgsrc);
+						if(!pack[i][j][4].some(str=>typeof str=="string"&&/^die:(?:.+)/.test(str))) pack[i][j][4].add(audiosrc);
 						if(pack[i][j][4].contains('boss')||
 							pack[i][j][4].contains('hiddenboss')){
 							lib.config.forbidai.add(j);
@@ -36156,6 +36157,7 @@
 			var packname='mode_extension_'+packagename;
 			lib.characterPack[packname]=pack.character;
 			lib.translate[packname+'_character_config']=packagename;
+			if(gzFlag) lib.characterGuozhanFilter.add(packname);
 		},
 		addCard:function(name,info,info2){
 			var extname=(_status.extension||info2.extension);

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -13789,7 +13789,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 						if(chosen.contains(i)) continue;
 						if(lib.filter.characterDisabled(i)) continue;
 						if(get.config('onlyguozhan')){
-							if(!lib.characterPack.mode_guozhan[i]) continue;
+							if(!lib.characterGuozhanFilter.some(pack=>lib.characterPack[pack][i])) continue;
 							if(get.is.jun(i)) continue;
 						}
 						if(lib.character[i][4].contains('hiddenSkill')) continue;
@@ -13872,7 +13872,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 							event.dialogxx=ui.create.characterDialog('heightset',function(i){
 								if(i.indexOf('gz_shibing')==0) return true;
 								if(get.config('onlyguozhan')){
-									if(!lib.characterPack.mode_guozhan[i]) return true;
+									if(!lib.characterGuozhanFilter.some(pack=>lib.characterPack[pack][i])) return true;
 									if(get.is.jun(i)) return true;
 								}
 							},get.config('onlyguozhanexpand')?'expandall':undefined,get.config('onlyguozhan')?'onlypack:mode_guozhan':undefined);


### PR DESCRIPTION
添加`lib.characterGuozhanFilter`接口，使国战模式可读取除`mode_guozhan`以外的支持国战的武将包。

现在只要扩展的`pack.character.mode`属性为`guozhan`，就会被识别为国战武将包。

> 从某种意义上，应该自定义扩展中国战武将区间，但由于`game.addCharacterPack`本来就作用不大，故暂时这么改。
