### PR TITLE
[BugFix] 兼容版异步等待无限加载问题

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -33692,7 +33692,7 @@
 				})();
 			}
 		},
-		importExtension:function(data,finishLoad,exportext,pkg){
+		importExtension:gnc.async(function*(data,finishLoad,exportext,pkg){
 			//by 来瓶可乐加冰
 			if(!window.JSZip){
 				lib.init.js(lib.assetURL+'game','jszip',function(){
@@ -33941,7 +33941,7 @@
 					return false;
 				}
 			};
-		},
+		}),
 		export:function(textToWrite,name){
 			var textFileAsBlob = new Blob([textToWrite], {type:'text/plain'});
 			var fileNameToSaveAs = name||'noname';

--- a/game/game.js
+++ b/game/game.js
@@ -33694,12 +33694,10 @@
 		},
 		importExtension:gnc.async(function*(data,finishLoad,exportext,pkg){
 			//by 来瓶可乐加冰
-			if(!window.JSZip){
-				lib.init.js(lib.assetURL+'game','jszip',function(){
-					game.importExtension(data,finishLoad,exportext,pkg);
-				});
-			}
-			else if(get.objtype(data)=='object'){
+			if(!window.JSZip)
+				yield new Promise((resolve,reject)=>lib.init.js(`${lib.assetURL}game`,"jszip",resolve,reject));
+
+			if(get.objtype(data)=='object'){
 			//导出
 				var zip=new JSZip();
 				var filelist=[];
@@ -33807,6 +33805,8 @@
 					if(str===""||undefined) throw('你导入的不是扩展！请选择正确的文件');
 					_status.importingExtension=true;
 					eval(str);
+					yield Promise.allSettled(_status.extensionLoading);
+					delete _status.extensionLoading;
 					_status.importingExtension=false;
 					if(!game.importedPack) throw('err');
 					var extname=game.importedPack.name;

--- a/game/game.js
+++ b/game/game.js
@@ -7845,7 +7845,8 @@
 						value:function allSettled(ary){
 							const Promise = this;
 							return new Promise((resolve, reject) => {
-								if (Object.prototype.toString.call(arr) != "[object Array]")
+								// if (Object.prototype.toString.call(arr) != "[object Array]")
+								if (!Array.isArray(ary))
 								return reject(new TypeError(`${typeof arr} ${ary} is not iterable(cannot read property Symbol(Symbol.iterator))`));
 								let args = Array.prototype.slice.call(ary);
 								if (args.length == 0) return resolve([]);


### PR DESCRIPTION
修复了`Promise.allSettled`在兼容版的polyfill中因数组长度过长而无法正常执行`Object.prototype.toString`导致阻塞，从而无法正常进行游戏。

> 顺带修复了异步加载后的一个小并发症。