### PR TITLE
[Purify] `path`不再报错

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -8428,8 +8428,8 @@
 					if (typeof module!="object"||typeof module.exports!="object") lib.init.js(`${lib.assetURL}game`,"path.min",()=>{
 						lib.path=window._noname_path;
 						delete window._noname_path;
-					},(e)=>{
-						throw e;
+					},e=>{
+						console.log(e);
 					});
 					var styleToLoad=6;
 					var styleLoaded=gnc.of(function*(){


### PR DESCRIPTION
- 去除读取`path.min`时因找不到文件而引发的报错，改为打印信息。