### PR TITLE
AI修复 | `chooseTarget`可以在“可空选”的情况下确定结果。 

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -59041,6 +59041,9 @@
 				var iwhile=100;
 				while(iwhile--){
 					range=get.select(event.selectTarget);
+					if(ui.selected.targets.length>=range[0]){
+						ok=true;
+					}
 					if(range[1]<=-1){
 						j=0;
 						for(i=0;i<ui.selected.targets.length;i++){


### PR DESCRIPTION
- 参考`ai.basic.chooseCard`，在`ai.basic.chooseTarget`获取到`range`时就判断目标数已经足够，从而使得`selectTarget`为`[0, x]`时AI不再必须选择一名目标才能确定结果。