### PR TITLE
函数增加 | 一些跟`storage`有关的函数

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -24749,8 +24749,12 @@
 					return this.hasStorage(name)?this.getStorage(name):this.setStorage(name,value);
 				},
 				updateStorage:function(name,operation){
-					this.setStorage(name,operation(this.getStorage(name)));
-					return this.getStorage(name);
+					return this.setStorage(name,operation(this.getStorage(name)));
+				},
+				updateStorageAsync:function(name,operation){
+					return Promise.resolve(this.getStorage(name))
+					.then(value=>operation(value))
+					.then(value=>this.setStorage(name,value))
 				},
 				markSkill:function(name,info,card){
 					if(info===true){

--- a/game/game.js
+++ b/game/game.js
@@ -24730,8 +24730,27 @@
 				getExpansions:function(tag){
 					return this.getCards('x',(card)=>card.hasGaintag(tag));
 				},
+				countExpansions:function(tag){
+					return this.getExpansions(tag).length;
+				},
+				hasExpansions:function(tag){
+					return this.countExpansions(tag)>0;
+				},
+				setStorage:function(name,value){
+					return this.storage[name]=value;
+				},
 				getStorage:function(name){
 					return this.storage[name]||[];
+				},
+				hasStorage:function(name){
+					return name in this.storage;
+				},
+				initStorage:function(name,value){
+					return this.hasStorage(name)?this.getStorage(name):this.setStorage(name,value);
+				},
+				updateStorage:function(name,operation){
+					operation(this.getStorage(name));
+					return this.getStorage(name);
 				},
 				markSkill:function(name,info,card){
 					if(info===true){

--- a/game/game.js
+++ b/game/game.js
@@ -24749,7 +24749,7 @@
 					return this.hasStorage(name)?this.getStorage(name):this.setStorage(name,value);
 				},
 				updateStorage:function(name,operation){
-					operation(this.getStorage(name));
+					this.setStorage(name,operation(this.getStorage(name)));
 					return this.getStorage(name);
 				},
 				markSkill:function(name,info,card){


### PR DESCRIPTION
- 增加`Player#setStorage<T>(name: string, value: T): T`，用于设定`player.storage[name]`的值
- 增加`Player#hasStorage(name: string): boolean`，用于判断是否存在`player.storage[name]`
- 增加`Player#initStorage<T, U>(name: string, value:T): U`，用于使用一个给定的初始值初始化`player.storage[name]`，当且仅当`player.storage[name]`不存在时将值给与`player.storage[name]`
- 增加`Player#updateStorage<T>(name: string, operation: (originValue: T) => T): T`，用于获取`player.storage[name]`并立即根据原值更新`player.storage[name]`
- 增加`Player#updateStorageAsnyc<T>(name: string, operation: (originValue: T) => Promise<T> | T): Promise<T>`，作为`Player#updateStorage<T>`的异步版本，可在回调函数中执行异步相关的操作

---

- 增加`Player#countExpansions(tag: string): number`，用于获取X区某一tag的牌的数量
- 增加`Player#hasExpansions(tag: string): boolean`，用于判断X区是否存在某一tag的牌