### PR TITLE
[Bug] 兼容修复 | `Event#setContent`及`lib.init.parsex`接纳更多参数

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -10302,8 +10302,14 @@
 							}
 						}
 						else{
-							// TODO: Parse Common Object
-							throw new Error("NYI: Parse Common Object");
+							if(Symbol.iterator in item) return lib.init.parsex(Array.from(item));
+							if("toString" in item) return lib.init.parsex(item.toString());
+							if("render" in item) {
+								// TODO: Object Render Parse
+								throw new Error("NYI: Object Render Parse");
+							}
+							// TODO: Object Other Parse
+							throw new Error("NYI: Object Other Parse");
 						}
 					case "function":
 						if (gnc.is.generatorFunc(item)) {
@@ -10329,7 +10335,8 @@
 								else lastEvent=res.value;
 							}
 						}
-						else return Legacy(item);
+					default:
+						return Legacy(item);
 				}
 			},
 			eval:function(func){

--- a/game/game.js
+++ b/game/game.js
@@ -28744,9 +28744,14 @@
 							this.content=lib.init.parsex(item);
 							break;
 						default:
-							if(!lib.element.content[item]._parsed){
-								lib.element.content[item]=lib.init.parsex(lib.element.content[item]);
-								lib.element.content[item]._parsed=true;
+							try{
+								if(!lib.element.content[item]._parsed){
+									lib.element.content[item]=lib.init.parsex(lib.element.content[item]);
+									lib.element.content[item]._parsed=true;
+								}
+							}
+							catch{
+								throw new Error(`Content ${item} may not exist.\nlib.element.content[${item}] = ${lib.element.content[item]}`);
 							}
 							this.content=lib.element.content[item];
 							break;


### PR DESCRIPTION
- 现在`Event#setContent`在处理`lib.element.content`出错时会打印`lib.element.content`的内容，用于排查错误
> 目前没处理原有错误
- 现在`lib.init.parsex`可以接纳：
  - 任意可被原来的`parsex`识别的字符串
  - 任意可迭代对象(含有`Symbol.iterator`的对象)
  - 带有`toString`方式的任意对象