### PR TITLE
[Bug] 修复由理电脑版的第二个兼容问题

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -8915,11 +8915,7 @@
 						else if(failure == null){
 							failure=()=>{};
 						}
-						lib.node.fs.access(dir,lib.node.fs.constants.F_OK|lib.node.fs.constants.R_OK,err=>{
-							if(err) {
-								failure(err);
-								return;
-							}
+						try{
 							lib.node.fs.readdir(dir,(err,filelist)=>{
 								if(err){
 									failure(err);
@@ -8937,7 +8933,10 @@
 								}
 								success(folders,files);
 							});
-						});
+						}
+						catch(e){
+							failure(e);
+						}
 					};
 					game.ensureDirectory=function(list,callback,file){
 						var directorylist;


### PR DESCRIPTION
- 去除调用`fs.access`、`fs.constants.F_OK`和`fs.constants.R_OK`，改为直接用`try catch`获取`fs.readdir`读取不到文件夹的错误。
- > 已被诗笺拷打两次

---

# 兼容测试

> 因本次错误不涉及兼容版，故兼容版只分析语法，而不实测。

## 语法分析

本次改动仅添加了如下代码：

```Javascript
...
try{
    ...
}
catch(e){
   ...
}
...
```

标准的`try catch`，且`catch`带参数，可用于兼容版和由理电脑版。

综上所述，代码在语法层面可兼容兼容版和由理电脑版。

## 由理电脑版实测

![图片](https://github.com/libccy/noname/assets/29033099/c766afd9-ea57-48ea-b791-57907b36b5bd)


