### PR TITLE
增加可为一张杀赋予多种属性的功能；可自定义加入新属性杀

### DIFF
--- a/card/extra.js
+++ b/card/extra.js
@@ -781,7 +781,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 							if(card.name=='sha'){
 								var equip1=player.getEquip('zhuque');
 								if(equip1&&equip1.name=='zhuque') return 1.9;
-								if(!card.nature) return 'zerotarget';
+								if(!card.hasNature()) return 'zerotarget';
 							}
 						}
 					}
@@ -791,7 +791,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				equipSkill:true,
 				trigger:{player:'damageBegin3'},
 				filter:function(event,player){
-					if(event.nature!='fire') return false;
+					if(!event.hasNature('fire')) return false;
 					if(player.hasSkillTag('unequip2')) return false;
 					if(event.source&&event.source.hasSkillTag('unequip',false,{
 						name:event.card?event.card.name:null,
@@ -810,7 +810,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 					effect:{
 						target:function(card,player,target,current){
 							if(card.name=='sha'){
-								if(card.nature=='fire') return 2;
+								if(card.hasNature('fire')) return 2;
 								if(player.hasSkill('zhuque_skill')) return 1.9;
 							}
 							if(get.tag(card,'fireDamage')&&current<0) return 2;
@@ -830,7 +830,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						target:player,
 						card:event.card
 					})) return false;
-					if(event.card.name=='sha'&&!event.card.nature) return true;
+					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
 					return false;
 				},
 				content:function(){
@@ -906,7 +906,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				trigger:{player:'useCard1'},
 				//priority:7,
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.nature) return true;
+					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
 				},
 				audio:true,
 				check:function(event,player){
@@ -924,14 +924,14 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 					return '将'+get.translation(event.card)+'改为火属性';
 				},
 				content:function(){
-					trigger.card.nature='fire';
+					game.setNature(trigger.card,'fire');
 					if(get.itemtype(trigger.card)=='card'){
 						var next=game.createEvent('zhuque_clear');
 						next.card=trigger.card;
 						event.next.remove(next);
 						trigger.after.push(next);
 						next.setContent(function(){
-							delete card.nature;
+							game.setNature(trigger.card,[]);
 						});
 					}
 				}

--- a/card/guozhan.js
+++ b/card/guozhan.js
@@ -469,7 +469,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						return lib.filter.cardDiscardable(card,target,'shuiyanqijunx');
 					})){
 						var next=target.damage();
-						if(!get.is.single()) next.nature='thunder';
+						if(!get.is.single()) game.setNature(next,'thunder',true);
 						event.finish();
 						return;
 					}
@@ -490,7 +490,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 					}
 					else{
 						var next=target.damage();
-						if(!get.is.single()) next.nature='thunder'
+						if(!get.is.single()) game.setNature(next,'thunder',true);
 					}
 					event.finish();
 				},
@@ -1211,7 +1211,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				},
 				filter:function(event,player){
 					if(['huoshaolianying','huogong'].contains(event.card.name)) return true;
-					if(event.card.name=='sha') return event.card.nature=='fire';
+					if(event.card.name=='sha') return event.card.hasNature('fire');
 					return false;
 				},
 				content:function(){
@@ -1220,7 +1220,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				ai:{
 					effect:{
 						target:function(card,player,target,current){
-							if(['huoshaolianying','huogong'].contains(card.name)||(card.name=='sha'&&card.nature=='fire')){
+							if(['huoshaolianying','huogong'].contains(card.name)||(card.name=='sha'&&card.hasNature('fire'))){
 								return 'zeroplayertarget';
 							}
 						},

--- a/card/standard.js
+++ b/card/standard.js
@@ -96,9 +96,17 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				},
 				selectTarget:1,
 				cardPrompt:function(card){
-					if(card.nature=='stab') return '出牌阶段，对你攻击范围内的一名角色使用。其须使用一张【闪】，且在此之后需弃置一张手牌（没有则不弃）。否则你对其造成1点伤害。';
-					if(lib.linked.contains(card.nature)) return '出牌阶段，对你攻击范围内的一名角色使用。其须使用一张【闪】，否则你对其造成1点'+get.translation(card.nature)+'属性伤害。';
-					return '出牌阶段，对你攻击范围内的一名角色使用。其须使用一张【闪】，否则你对其造成1点伤害。';
+					var natures=get.natureList(Array.isArray(card)?card[3]:card);
+					if(lib.translate['sha_nature_'+natures[0]+'_info']) return lib.translate['sha_nature_'+natures[0]+'_info'];
+					var str='出牌阶段，对你攻击范围内的一名角色使用。其须使用一张【闪】，';
+					if(natures.includes('stab')){
+						str+='且在此之后需弃置一张手牌（没有则不弃）。';
+					}
+					str+='否则你对其造成1点';
+					var linked=lib.linked.filter(n=>natures.includes(n));
+					if(linked.length) str+=get.translation(get.nature(linked))+'属性';
+					str+='伤害。';
+					return str;
 				},
 				defaultYingbianEffect:'add',
 				filterTarget:function(card,player,target){return player!=target},
@@ -126,7 +134,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						if(event.shanRequired>1){
 							next.set('prompt2','（共需使用'+event.shanRequired+'张闪）');
 						}
-						else if(event.card.nature=='stab'){
+						else if(event.card.hasNature('stab')){
 							next.set('prompt2','（在此之后仍需弃置一张手牌）');
 						}
 						next.set('ai1',function(card){
@@ -160,7 +168,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						if(event.shanRequired>0){
 							event.goto(1);
 						}
-						else if(event.card.nature=='stab'&&target.countCards('h')>0){
+						else if(event.card.hasNature('stab')&&target.countCards('h')>0){
 							event.responded=result;
 							event.goto(4);
 						}
@@ -257,7 +265,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 					},
 					order:function(item,player){
 						if(player.hasSkillTag('presha',true,null,true)) return 10;
-						if(lib.linked.contains(get.nature(item))){
+						if(item.hasNature('linked')){
 							if(game.hasPlayer(function(current){
 								return current!=player&&current.isLinked()&&player.canUse(item,current,null,true)&&get.effect(current,item,player,player)>0&&lib.card.sha.ai.canLink(player,current,item);
 							})&&game.countPlayer(function(current){
@@ -298,20 +306,20 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						respond:1,
 						respondShan:1,
 						damage:function(card){
-							if(card.nature=='poison') return;
+							if(card.hasNature('poison')) return;
 							return 1;
 						},
 						natureDamage:function(card){
-							if(card.nature) return 1;
+							if(card.hasNature()) return 1;
 						},
 						fireDamage:function(card,nature){
-							if(card.nature=='fire') return 1;
+							if(card.hasNature('fire')) return 1;
 						},
 						thunderDamage:function(card,nature){
-							if(card.nature=='thunder') return 1;
+							if(card.hasNature('thunder')) return 1;
 						},
 						poisonDamage:function(card,nature){
-							if(card.nature=='poison') return 1;
+							if(card.hasNature('poison')) return 1;
 						}
 					}
 				}
@@ -330,20 +338,20 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						respond:1,
 						respondShan:1,
 						damage:function(card){
-							if(card.nature=='poison') return;
+							if(card.hasNature('poison')) return;
 							return 1;
 						},
 						natureDamage:function(card){
-							if(card.nature) return 1;
+							if(card.hasNature()) return 1;
 						},
 						fireDamage:function(card,nature){
-							if(card.nature=='fire') return 1;
+							if(card.hasNature('fire')) return 1;
 						},
 						thunderDamage:function(card,nature){
-							if(card.nature=='thunder') return 1;
+							if(card.hasNature('thunder')) return 1;
 						},
 						poisonDamage:function(card,nature){
-							if(card.nature=='poison') return 1;
+							if(card.hasNature('poison')) return 1;
 						}
 					}
 				}
@@ -1907,7 +1915,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				equipSkill:false,
 				ruleSkill:true,
 				filter:function(event){
-					return event.nature=='ice'&&event.notLink()&&event.player.getCards('he').length>0;
+					return event.hasNature('ice')&&event.notLink()&&event.player.getCards('he').length>0;
 				},
 			},
 			renwang_skill:{

--- a/card/swd.js
+++ b/card/swd.js
@@ -4441,7 +4441,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				direct:true,
 				filter:function(event,player){
 					if(event._notrigger.contains(event.player)) return false;
-					return event.nature&&event.player&&event.player.isAlive();
+					return event.hasNature()&&event.player&&event.player.isAlive();
 				},
 				content:function(){
 					player.gainPlayerCard(get.prompt('qinglonglingzhu',trigger.player),trigger.player,function(button){
@@ -4507,7 +4507,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				trigger:{source:'damageBegin'},
 				forced:true,
 				filter:function(event){
-					return event.nature=='fire'&&event.notLink();
+					return event.hasNature('fire')&&event.notLink();
 				},
 				content:function(){
 					trigger.num++;
@@ -4870,7 +4870,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				trigger:{player:'damageBefore'},
 				forced:true,
 				filter:function(event){
-					return event.nature=='thunder';
+					return event.hasNature('thunder');
 				},
 				content:function(){
 					trigger.cancel();

--- a/card/yingbian.js
+++ b/card/yingbian.js
@@ -307,7 +307,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				equipSkill:true,
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					return (event.card.name=='sha'&&event.card.nature&&event.card.nature!='kami');
+					return (event.card.name=='sha'&&lib.linked.some(n=>n!='kami'&&event.card.hasNature(n)));
 				},
 				audio:true,
 				direct:true,
@@ -315,13 +315,13 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 					'step 0'
 					var list=lib.linked.slice(0);
 					list.remove('kami');
-					list.remove(trigger.card.nature);
+					list.removeArray(get.natureList(trigger.card));
 					list.push('cancel2');
 					player.chooseControl(list).set('prompt',get.prompt('wuxinghelingshan_skill')).set('prompt2','将'+get.translation(trigger.card)+'转换为以下属性之一');
 					'step 1'
 					if(result.control!='cancel2'){
 						player.logSkill('wuxinghelingshan_skill');
-						trigger.card.nature=result.control;
+						game.setNature(trigger.card,result.control);
 						player.popup(get.translation(result.control)+'杀',result.control);
 						game.log(trigger.card,'被转为了','#y'+get.translation(result.control),'属性')
 					}

--- a/character/collab.js
+++ b/character/collab.js
@@ -490,7 +490,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				audio:2,
 				trigger:{player:'damageBegin4'},
 				filter:function(event){
-					return event.nature=='fire';
+					return event.hasNature('fire');
 				},
 				forced:true,
 				content:function(){

--- a/character/ddd.js
+++ b/character/ddd.js
@@ -875,7 +875,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						var player=_status.event.player,target=_status.event.getParent().target;
 						if(get.attitude(player,target)<0) return false;
 						if(!_status.event.colors.contains(get.color(card,player))) return 0;
-						if(card.nature) return 1.2;
+						if(card.hasNature()) return 1.2;
 						return 1;
 					})
 					'step 3'
@@ -897,8 +897,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						var name=get.name(card,target),type=get.type(card);
 						if(type!='basic'&&type!='trick') continue;
 						if(name=='sha'){
-							var nature=get.nature(card,target);
-							if(nature&&lib.nature.contains(nature)) name+=('|'+nature);
+							var natures=get.natureList(card,target);
+							for(var nature of natures){
+								if(nature&&lib.nature.has(nature)) name+=('|'+nature);
+							}
 						}
 						names.push(name);
 					}
@@ -910,7 +912,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						'是否视为使用一张牌？',
 						[event.names.map(name=>{
 							if(name.indexOf('sha|')==0){
-								return ['基本','','sha',name.slice(4)];
+								return ['基本','','sha',name.slice(4).split('|')];
 							}
 							return [get.type(name),'',name];
 						}),'vcard']
@@ -939,7 +941,12 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						target.chooseUseTarget(card,true,false);
 						if(event.num>0){
 							var name=card.name;
-							if(name=='sha'&&lib.nature.contains(card.nature)) name=(card.name+'|'+card.nature);
+							if(name=='sha'){
+								var natures=get.natureList(card,target);
+								for(var nature of natures){
+									if(nature&&lib.nature.has(nature)) name+=('|'+nature);
+								}
+							}
 							event.names.remove(name);
 							if(event.names.length>0) event.goto(5);
 						}
@@ -3152,7 +3159,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(!vpos||!vpos.isIn()) return [];
 					var vcard=[];
 					var history=vpos.getPrevious().actionHistory.filter(evt=>!evt.custom.some(i=>i['dddyouxue']));
-					debugger
 					history=history[history.length-2];
 					var evts=history.useCard;
 					for(var evt of evts){

--- a/character/extra.js
+++ b/character/extra.js
@@ -1532,7 +1532,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						mark:true,
 						content:function(){
 							trigger.num++;
-							trigger.nature='thunder';
+							game.setNature(trigger,'thunder');
 						},
 						marktext:'⚡',
 						intro:{
@@ -5346,7 +5346,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			dawu2:{
 				trigger:{player:'damageBegin4'},
 				filter:function(event){
-					if(event.nature!='thunder') return true;
+					if(!event.hasNature('thunder')) return true;
 					return false;
 				},
 				mark:true,
@@ -5419,7 +5419,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			kuangfeng2:{
 				trigger:{player:'damageBegin3'},
 				filter:function(event){
-					if(event.nature=='fire') return true;
+					if(event.hasNature('fire')) return true;
 					return false;
 				},
 				mark:true,
@@ -6112,7 +6112,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								if(['trick','delay'].contains(lib.card[card.name].type)) return 'thunder';
 							},
 							cardUsable:function(card,player){
-								if(card.name=='sha'&&card.nature=='thunder') return Infinity;
+								if(card.name=='sha'&&card.hasNature('thunder')) return Infinity;
 							},
 						},
 						ai:{

--- a/character/huicui.js
+++ b/character/huicui.js
@@ -6307,7 +6307,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				prompt2:function(event,player){
 					var str=('令'+get.translation(event.player)+'即将受到的');
 					str+=(''+event.num+'点');
-					if(lib.linked.contains(event.nature)){
+					if(lib.linked.some(n=>event.hasNature(n))){
 						str+=(get.translation(event.nature)+'属性');
 					}
 					str+='伤害+1';
@@ -6931,7 +6931,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}).length;
 					//var str='视为额外使用'+get.cnNumber(num)+'张'
 					var str='额外结算'+get.cnNumber(num)+'次'
-					if(event.card.name=='sha'&&event.card.nature) str+=get.translation(event.card.nature);
+					if(event.card.name=='sha'&&event.card.hasNature()) str+=get.translation(event.card.nature);
 					return (str+'【'+get.translation(event.card.name)+'】');
 				},
 				check:function(event,player){
@@ -9475,7 +9475,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				filter:function(event,player){
 					if(!player.countMark('recangchu')) return false;
-					return (event.name=='damage')?(event.nature=='fire'):(event.card&&event.card.name=='jiu');
+					return (event.name=='damage')?event.hasNature('fire'):(event.card&&event.card.name=='jiu');
 				},
 				content:function(){
 					player.removeMark('recangchu',Math.min(player.countMark('recangchu'),trigger.num||1));

--- a/character/jsrg.js
+++ b/character/jsrg.js
@@ -980,7 +980,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							precontent:function(){
 								delete event.result.skill;
 								var card=event.result.card;
-								if(get.color(card,player)!='red'||get.name(card)!='sha'||get.nature(card)){
+								if(get.color(card,player)!='red'||get.name(card)!='sha'||get.natureList(card).length){
 									player.addTempSkill('jsrgnianen_blocker');
 									player.addAdditionalSkill('jsrgnianen_blocker','mashu');
 								}
@@ -1827,7 +1827,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						},
 						forced:true,
 						filter:function(event,player){
-							return event.nature=='fire';
+							return event.hasNature('fire');
 						},
 						content:function(){
 							player.addTempSkill('jsrgshishou_blocker',{player:'phaseEnd'});

--- a/character/mobile.js
+++ b/character/mobile.js
@@ -3169,7 +3169,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						forced:true,
 						trigger:{player:'damageBegin4'},
 						filter:function(event){
-							return event.nature!='thunder';
+							return !event.hasNature('thunder');
 						},
 						content:function(){
 							trigger.cancel();
@@ -6420,10 +6420,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				charlotte:true,
 				filter:function(event,player){
-					return event.nature!='fire';
+					return !event.hasNature('fire');
 				},
 				content:function(){
-					trigger.nature='fire';
+					game.setNature(trigger,'fire');
 				},
 			},
 			tiansuan2_3:{
@@ -9070,13 +9070,13 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				group:['relihuo_baigei','relihuo_damage'],
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.nature) return true;
+					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
 				},
 				check:function(event,player){
 					return false;
 				},
 				content:function(){
-					trigger.card.nature='fire';
+					game.setNature(trigger.card,'fire');
 					trigger.relihuo=true;
 				},
 			},
@@ -9096,7 +9096,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				audio:'relihuo',
 				filter:function(event,player){
-					if(event.card.name!='sha'||event.card.nature!='fire') return false;
+					if(event.card.name!='sha'||!event.card.hasNature('fire')) return false;
 					var num=0;
 					player.getHistory('sourceDamage',function(evt){
 						if(evt.card==event.card) num+=evt.num;
@@ -10715,7 +10715,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(get.color(card)=='red'&&game.hasPlayer(function(current){
 						return current!=player&&current.isDamaged()&&get.attitude(player,current)>2;
 					})) return 2;
-					if(get.nature(card)) return 1.5;
+					if(get.natureList(card).length) return 1.5;
 					return 1;
 				},
 				discard:false,
@@ -10727,7 +10727,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.recover();
 					'step 1'
 					var num=1;
-					if(get.nature(cards[0])) num++;
+					if(get.natureList(cards[0]).length) num++;
 					target.draw(num);
 					if(get.color(cards[0])=='red') target.recover();
 				},
@@ -10741,7 +10741,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						target:function(player,target){
 							if(ui.selected.cards.length){
 								var num=1;
-								if(get.nature(ui.selected.cards[0])) num++;
+								if(get.natureList(ui.selected.cards[0]).length) num++;
 								if(target.hasSkillTag('nogain')) num=0;
 								if(get.color(ui.selected.cards[0])=='red') return num+2
 								else return num+1;
@@ -12686,7 +12686,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				audio:2,
 				trigger:{player:'damageBegin4'},
 				filter:function(event){
-					return event.nature=='fire';
+					return event.hasNature('fire');
 				},
 				forced:true,
 				content:function(){

--- a/character/offline.js
+++ b/character/offline.js
@@ -731,7 +731,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						mark:true,
 						content:function(){
 							trigger.num++;
-							trigger.nature='thunder';
+							game.setNature(trigger,'thunder');
 						},
 						marktext:'⚡',
 						intro:{
@@ -920,7 +920,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				filter:function(event,player){
 					if(!player.hasEmptySlot(2)) return false;
 					if(event.card.name!='sha') return false;
-					return event.nature;
+					return event.card.hasNature();
 				},
 				content:function(){
 					trigger.cancel();
@@ -6214,7 +6214,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			fulu:{
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.nature) return true;
+					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
 				},
 				audio:true,
 				check:function(event,player){
@@ -6229,14 +6229,14 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					return eff>=0;
 				},
 				content:function(){
-					trigger.card.nature='thunder';
+					game.setNature(trigger.card,'thunder');
 					if(get.itemtype(trigger.card)=='card'){
 						var next=game.createEvent('fulu_clear');
 						next.card=trigger.card;
 						event.next.remove(next);
 						trigger.after.push(next);
 						next.setContent(function(){
-							delete card.nature;
+							game.setNature(card,[]);
 						});
 					}
 				}
@@ -6244,7 +6244,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			fuji:{
 				trigger:{global:'damageBegin1'},
 				filter:function(event){
-					return event.source&&event.nature=='thunder';
+					return event.source&&event.source.isIn()&&event.hasNature('thunder');
 				},
 				check:function(event,player){
 					return get.attitude(player,event.source)>0&&get.attitude(player,event.player)<0;

--- a/character/old.js
+++ b/character/old.js
@@ -523,7 +523,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						if(player.getStorage('old_guhuo_cheated').contains(card.name+card.nature)&&!player.hasCard(function(cardx){
 							if(card.name==cardx.name){
 								if(card.name!='sha') return true;
-								return get.nature(card)==get.nature(cardx);
+								return get.is.sameNature(card,cardx);
 							}
 							return false;
 						},'hs')&&Math.random()<0.7) return 0;
@@ -532,7 +532,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							if(!player.hasCard(function(cardx){
 								if(card.name==cardx.name){
 									if(card.name!='sha') return true;
-									return get.nature(card)==get.nature(cardx);
+									return get.is.sameNature(card,cardx);
 								}
 								return false;
 							},'hs')){
@@ -572,7 +572,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								});
 								var cardx=lib.skill.old_guhuo_backup.viewAs;
 								if(enemyNum){
-									if(card.name==cardx.name&&(card.name!='sha'||card.nature==cardx.nature)||player.getStorage('old_guhuo_cheated').contains(card.name+card.nature)) return (get.suit(card)=='heart'?8:4)+Math.random()*3;
+									if(card.name==cardx.name&&(card.name!='sha'||get.is.sameNature(card,cardx))||player.getStorage('old_guhuo_cheated').contains(card.name+card.nature)) return (get.suit(card)=='heart'?8:4)+Math.random()*3;
 									else if(lib.skill.old_guhuo_backup.aiUse<0.5&&!player.isDying()) return 0;
 								}
 								return get.value(cardx)-get.value(card);
@@ -649,7 +649,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					event.goon=true;
 					event.betrayers=[];
 					var card=trigger.cards[0];
-					if(card.name!=trigger.card.name||(card.name=='sha'&&(trigger.card.nature||card.nature)&&trigger.card.nature!=card.nature)) event.fake=true;
+					if(card.name!=trigger.card.name||(card.name=='sha'&&!get.is.sameNature(trigger.card,card))) event.fake=true;
 					if(event.fake){
 						player.addSkill('old_guhuo_cheated');
 						player.markAuto('old_guhuo_cheated',[trigger.card.name+trigger.card.nature]);

--- a/character/ow.js
+++ b/character/ow.js
@@ -1166,7 +1166,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				trigger:{global:'damageEnd'},
 				forced:true,
 				filter:function(event){
-					return event.nature=='fire';
+					return event.hasNature('fire');
 				},
 				content:function(){
 					player.draw();

--- a/character/refresh.js
+++ b/character/refresh.js
@@ -5966,7 +5966,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.nature) return true;
+					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
 					return false;
 				},
 				audio:'lihuo',
@@ -5983,7 +5983,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					});
 				},
 				content:function(){
-					trigger.card.nature='fire';
+					game.setNature(trigger.card,'fire');
 					trigger.lihuo_changed=true;
 				},
 				group:['ollihuo2','ollihuo3','ollihuo4'],
@@ -5994,7 +5994,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			ollihuo2:{
 				trigger:{player:'useCard2'},
 				filter:function(event,player){
-					if(event.card.name!='sha'||event.card.nature!='fire') return false;
+					if(event.card.name!='sha'||!event.card.hasNature('fire')) return false;
 					return game.hasPlayer(function(current){
 						return !event.targets.contains(current)&&lib.filter.targetEnabled(event.card,player,current)&&lib.filter.targetInRange(event.card,player,current);
 					});
@@ -7459,7 +7459,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			decadelihuo:{
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.nature) return true;
+					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
 					return false;
 				},
 				audio:'lihuo',
@@ -7475,7 +7475,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					});
 				},
 				content:function(){
-					trigger.card.nature='fire';
+					game.setNature(trigger.card,'fire');
 				},
 				group:['decadelihuo2','decadelihuo3'],
 				ai:{
@@ -7485,7 +7485,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			decadelihuo2:{
 				trigger:{player:'useCard2'},
 				filter:function(event,player){
-					if(event.card.name!='sha'||event.card.nature!='fire') return false;
+					if(event.card.name!='sha'||!event.card.hasNature('fire')) return false;
 					return game.hasPlayer(function(current){
 						return !event.targets.contains(current)&&player.canUse(event.card,current);
 					});
@@ -7515,7 +7515,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			decadelihuo3:{
 				trigger:{player:'useCardAfter'},
 				filter:function(event,player){
-					return event.card.name=='sha'&&event.card.nature=='fire'&&event.targets.length>1&&player.getHistory('sourceDamage',function(evt){
+					return event.card.name=='sha'&&event.card.hasNature('fire')&&event.targets.length>1&&player.getHistory('sourceDamage',function(evt){
 						return evt.card==event.card;
 					}).length>0;
 				},
@@ -8784,9 +8784,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						event.type='dying';
 						player.loseToDiscardpile(result.links);
 						target.useCard({name:'jiu',isCard:true},target);
-						var nature=get.nature(result.links[0]);
-						if(nature=='fire') player.recover();
-						if(nature=='thunder') player.draw(2);
+						var natures=get.natureList(result.links[0]);
+						if(natures.includes('fire')) player.recover();
+						if(natures.includes('thunder')) player.draw(2);
 					}
 				},
 				ai:{
@@ -10356,7 +10356,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							if(!player.countCards('h',function(cardx){
 								if(card.name==cardx.name){
 									if(card.name!='sha') return true;
-									return get.nature(card)==get.nature(cardx);
+									return get.is.sameNature(card,cardx);
 								}
 								return false;
 							})) return 0;
@@ -10391,7 +10391,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								var rand=_status.event.getRand('reguhuo');
 								var cardx=lib.skill.reguhuo_backup.viewAs;
 								if(hasEnemy&&rand>0.3){
-									if(card.name==cardx.name&&(card.name!='sha'||card.nature==cardx.nature)) return 10;
+									if(card.name==cardx.name&&(card.name!='sha'||get.is.sameNature(card,cardx))) return 10;
 									return 0;
 								}
 								return 6-get.value(card);
@@ -10527,7 +10527,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.addTempSkill('reguhuo_phase');
 					event.fake=false;
 					var card=trigger.cards[0];
-					if(card.name!=trigger.card.name||(card.name=='sha'&&(trigger.card.nature||card.nature)&&trigger.card.nature!=card.nature)) event.fake=true;
+					if(card.name!=trigger.card.name||(card.name=='sha'&&!get.is.sameNature(trigger.card,card))) event.fake=true;
 					//player.logSkill('reguhuo');
 					player.line(trigger.targets,get.nature(trigger.card));
 					event.cardTranslate=get.translation(trigger.card.name);
@@ -10535,7 +10535,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					trigger.card.suit=get.suit(card);
 					//trigger.line=false;
 					trigger.skill='reguhuo_backup';
-					if(trigger.card.name=='sha'&&trigger.card.nature) event.cardTranslate=get.translation(trigger.card.nature)+event.cardTranslate;
+					if(trigger.card.name=='sha'&&get.natureList(trigger.card).length) event.cardTranslate=get.translation(trigger.card.nature)+event.cardTranslate;
 					player.popup(event.cardTranslate,trigger.name=='useCard'?'metal':'wood');
 					event.prompt='是否质疑'+get.translation(player)+'声明的'+event.cardTranslate+'？';
 					game.log(player,'声明了','#y'+event.cardTranslate);

--- a/character/sb.js
+++ b/character/sb.js
@@ -2980,7 +2980,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				group:'sbguidao_defend',
 				filter:function(event,player){
 					if(player.countMark('sbguidao')>=8) return false;
-					if(event.name=='damage') return event.nature&&!player.hasSkill('sbguidao_forbid');
+					if(event.name=='damage') return event.hasNature()&&!player.hasSkill('sbguidao_forbid');
 					return (event.name!='phase'||game.phaseNumber==0);
 				},
 				content:function(){
@@ -4644,7 +4644,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			sbleiji:'雷击',
 			sbleiji_info:'出牌阶段，你可以选择一名其他角色并弃4枚“道兵”，对其造成1点雷电伤害。',
 			sbguidao:'鬼道',
-			sbguidao_info:'①游戏开始时，你获得4枚“道兵”标记。②“道兵”上限为8。③一名角色受到属性伤害后，你获得2枚“道兵”。④当你受到伤害时，你可以弃2枚“道兵”并防止此伤害。然后若当前回合角色不为你，〖鬼道③〗于你下回合开始前无效。',
+			sbguidao_info:'①游戏开始时，你获得4枚“道兵”标记（“道兵”上限为8）。②一名角色受到属性伤害后，你获得2枚“道兵”。③当你受到伤害时，你可以弃2枚“道兵”并防止此伤害。然后若当前回合角色不为你，〖鬼道②〗于你下回合开始前无效。',
 			sbhuangtian:'黄天',
 			sbhuangtian_info:'主公技，锁定技。①回合开始时，若本回合为你的第一个回合且游戏轮数为1，且游戏内没有【太平要术】，你装备【太平要术】。②其他群势力角色造成伤害后，若你拥有〖鬼道〗，你获得1枚“道兵”（每轮你至多以此法获得4枚“道兵”）。',
 			sb_caocao:'谋曹操',

--- a/character/shenhua.js
+++ b/character/shenhua.js
@@ -7412,7 +7412,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							if(!player.hasCard(function(cardx){
 								if(card.name==cardx.name){
 									if(card.name!='sha') return true;
-									return get.nature(card)==get.nature(cardx);
+									return get.is.sameNature(card,cardx);
 								}
 								return false;
 							},'hs')){
@@ -7452,7 +7452,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								});
 								var cardx=lib.skill.xinfu_guhuo_backup.viewAs;
 								if(enemyNum){
-									if(card.name==cardx.name&&(card.name!='sha'||card.nature==cardx.nature)) return 2+Math.random()*3;
+									if(card.name==cardx.name&&(card.name!='sha'||get.is.sameNature(card,cardx))) return 2+Math.random()*3;
 									else if(lib.skill.xinfu_guhuo_backup.aiUse<0.5&&!player.isDying()) return 0;
 								}
 								return 6-get.value(card);
@@ -7501,7 +7501,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					event.fake=false;
 					event.betrayer=null;
 					var card=trigger.cards[0];
-					if(card.name!=trigger.card.name||(card.name=='sha'&&(trigger.card.nature||card.nature)&&trigger.card.nature!=card.nature)) event.fake=true;
+					if(card.name!=trigger.card.name||(card.name=='sha'&&!get.is.sameNature(trigger.card,card))) event.fake=true;
 					player.popup(trigger.card.name,'metal');
 					player.lose(card,ui.ordering).relatedEvent=trigger;
 					// player.line(trigger.targets,trigger.card.nature);

--- a/character/shiji.js
+++ b/character/shiji.js
@@ -403,7 +403,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				trigger:{source:'damageBegin2'},
 				logTarget:'player',
 				filter:function(event,player){
-					return player!=event.player&&lib.linked.contains(event.nature)&&event.player.countCards('h')>0&&!player.isMaxHandcard(true);
+					return player!=event.player&&event.hasNature('linked')&&event.player.countCards('h')>0&&!player.isMaxHandcard(true);
 				},
 				check:function(event,player){
 					return get.attitude(player,event.player)<=0;

--- a/character/sp.js
+++ b/character/sp.js
@@ -2219,7 +2219,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						trigger:{global:'damageEnd'},
 						forced:true,
 						filter:function(event){
-							return event.nature=='thunder'&&lib.skill.oltianhou_spade.logTarget(event).length>0;
+							return event.hasNature('thunder')&&lib.skill.oltianhou_spade.logTarget(event).length>0;
 						},
 						logTarget:function(event){
 							var list=[];
@@ -2258,7 +2258,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						forced:true,
 						logTarget:'source',
 						filter:function(event,player){
-							return event.nature=='fire'&&event.source&&event.source.isIn()&&event.source!=player;
+							return event.hasNature('fire')&&event.source&&event.source.isIn()&&event.source!=player;
 						},
 						content:function(){
 							trigger.cancel();
@@ -7977,7 +7977,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player:"damageBegin4",
 				},
 				filter:function(event,player){
-					if(!lib.linked.contains(event.nature)) return false;
+					if(!event.hasNature('linked')) return false;
 					if(player.hasSkillTag('unequip2')) return false;
 					if(event.source&&event.source.hasSkillTag('unequip',false,{
 						name:event.card?event.card.name:null,
@@ -19301,7 +19301,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				audio:2,
 				trigger:{player:'damageEnd'},
 				filter:function(event,player){
-					return event.nature=='fire';
+					return event.hasNature('fire');
 				},
 				forced:true,
 				check:function(){
@@ -19318,7 +19318,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					effect:{
 						target:function(card,player,target,current){
 							if(card.name=='sha'){
-								if(card.nature=='fire'||player.hasSkill('zhuque_skill')) return 2;
+								if(card.hasNature('fire')||player.hasSkill('zhuque_skill')) return 2;
 							}
 							if(get.tag(card,'fireDamage')&&current<0) return 2;
 						}
@@ -19344,7 +19344,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			hanyong:{
 				trigger:{player:'useCard'},
 				filter:function(event,player){
-					return event.card&&(event.card.name=='nanman'||event.card.name=='wanjian'||(event.card.name=='sha'&&!event.card.nature&&get.suit(event.card)=='spade'))&&player.isDamaged();
+					return event.card&&(event.card.name=='nanman'||event.card.name=='wanjian'||(event.card.name=='sha'&&!event.card.hasNature()&&get.suit(event.card)=='spade'))&&player.isDamaged();
 				},
 				content:function(){
 					trigger.baseDamage++;
@@ -21967,7 +21967,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				filter:function(event,player){
 					if(event._notrigger.contains(event.player)||!event.player.isIn()) return false;
-					return event.nature=='fire';
+					return event.hasNature('fire');
 				},
 				logTarget:'player',
 				content:function(){
@@ -23692,7 +23692,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				filter:function (event,player){
 					if(player.hasSkill('smh_huoji')||player.hasSkill('smh_lianhuan')) return false;
 					if(!player.hasEmptySlot(2)) return false;
-					if(event.nature) return true;
+					if(event.hasNature()) return true;
 					return get.type(event.card,'trick')=='trick';
 				},
 				content:function (){
@@ -24040,7 +24040,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				audio:2,
 				filter:function (event,player){
-					//if(!event.nature) return false;
+					//if(!event.hasNature()) return false;
 					return player.hasMark('xinfu_falu_diamond');
 				},
 				prompt2:'弃置「勾陈♦」标记，从牌堆中获得每种类型的牌各一张。',

--- a/character/sp2.js
+++ b/character/sp2.js
@@ -1279,7 +1279,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(get.color(card)=='red'&&game.hasPlayer(function(current){
 						return current!=player&&current.isDamaged()&&get.attitude(player,current)>2;
 					})) return 2;
-					if(get.nature(card)) return 1.5;
+					if(get.natureList(card).length) return 1.5;
 					return 1;
 				},
 				discard:false,
@@ -1291,7 +1291,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.recover();
 					'step 1'
 					var num=1;
-					if(get.nature(cards[0])) num++;
+					if(get.natureList(cards[0]).length) num++;
 					player.draw('nodelay');
 					target.draw(num);
 					if(get.color(cards[0])=='red') target.recover();
@@ -1306,7 +1306,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						target:function(player,target){
 							if(ui.selected.cards.length){
 								var num=1;
-								if(get.nature(ui.selected.cards[0])) num++;
+								if(get.natureList(ui.selected.cards[0]).length) num++;
 								if(target.hasSkillTag('nogain')) num=0;
 								if(get.color(ui.selected.cards[0])=='red') return num+2
 								else return num+1;
@@ -3036,7 +3036,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				usable:1,
 				filter:function(event,player){
-					return event.source&&event.source.hp!=player.hp&&!lib.linked.contains(event.nature)&&event.source.countCards('h')!=player.countCards('h');
+					return event.source&&event.source.hp!=player.hp&&!event.hasNature('linked')&&event.source.countCards('h')!=player.countCards('h');
 				},
 				content:function(){
 					trigger.cancel();
@@ -6465,7 +6465,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					else{
 						var vcard=[get.type(trigger.card),'',trigger.card.name];
-						if(trigger.card.nature) vcard.push(trigger.card.nature);
+						if(trigger.card.hasNature()) vcard.push(get.nature(trigger.card));
 						player.storage.juanhui3.push(vcard);
 						player.markSkill('juanhui2');
 					}
@@ -7244,7 +7244,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				filter:function(event,player){
 					if(event.name!='damage') return (event.name!='phase'||game.phaseNumber==0);
-					return event.nature=='fire'&&player.countMark('cangchu')>0;
+					return event.hasNature('fire')&&player.countMark('cangchu')>0;
 				},
 				content:function(){
 					if(trigger.name!='damage') player.addMark('cangchu',3);
@@ -7266,7 +7266,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						target:function(card,player,target,current){
 							if(target.hasMark('cangchu')){
 								if(card.name=='sha'){
-									if(lib.skill.global.contains('huoshaowuchao')||card.nature=='fire'||player.hasSkill('zhuque_skill')) return 2;
+									if(lib.skill.global.contains('huoshaowuchao')||card.hasNature('fire')||player.hasSkill('zhuque_skill')) return 2;
 								}
 								if(get.tag(card,'fireDamage')&&current<0) return 2;
 							}

--- a/character/swd.js
+++ b/character/swd.js
@@ -1239,7 +1239,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				skillAnimation:true,
 				animationColor:'fire',
 				filter:function(event,player){
-					return !player.storage.shenyan&&event.nature=='fire';
+					return !player.storage.shenyan&&event.hasNature('fire');
 				},
 				intro:{
 					content:'limited'
@@ -5202,7 +5202,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			benlei2:{
 				trigger:{source:'damageAfter'},
 				filter:function(event,player){
-					return event.nature=='thunder'&&player.hp<player.maxHp;
+					return event.hasNature('thunder')&&player.hp<player.maxHp;
 				},
 				forced:true,
 				content:function(){
@@ -7803,7 +7803,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					next.logSkill=['zhuyu',trigger.player,'fire'];
 					var num=game.countPlayer(function(current){
 						if(current.isLinked()){
-							if(trigger.nature){
+							if(trigger.hasNature()){
 								return get.sgn(get.damageEffect(current,player,player,'fire'));
 							}
 							else{
@@ -7826,7 +7826,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					"step 1"
 					if(result.bool){
 						trigger.num++;
-						trigger.nature='fire';
+						game.setNature(trigger,'fire');
 					}
 				}
 			},

--- a/character/tw.js
+++ b/character/tw.js
@@ -6031,10 +6031,11 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					var list=[];
 					player.getHistory('useCard',function(evt){
 						if(get.type(evt.card)!='basic') return;
-						var name=evt.card.name,nature=evt.card.nature||'';
+						var name=evt.card.name,nature=evt.card.hasNature()?get.nature(evt.card):'';
 						if(!list.contains(name+nature)) list.push(name+nature);
 					});
-					player.chooseTarget(get.prompt('twfenwu'),'失去1点体力并视为使用一张无距离限制的【杀】'+(list.length>1?'（伤害基数+1）':''),function(card,player,target){
+					event.addDamage=list.length>1;
+					player.chooseTarget(get.prompt('twfenwu'),'失去1点体力并视为使用一张无距离限制的【杀】'+(event.addDamage?'（伤害基数+1）':''),function(card,player,target){
 						return target!=player&&player.canUse('sha',target,false,false);
 					}).set('ai',function(target){
 						var player=_status.event.player;
@@ -6053,16 +6054,11 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					});
 					'step 1'
 					if(result.bool){
-						var num=1,list=[];
-						player.getHistory('useCard',function(evt){
-							if(get.type(evt.card)!='basic') return;
-							var name=evt.card.name,nature=evt.card.nature||'';
-							if(!list.contains(name+nature)) list.push(name+nature);
-						});
+						var num=1;
 						var target=result.targets[0];
 						player.logSkill('twfenwu',target);
 						player.loseHp();
-						if(list.length>=2){
+						if(event.addDamage){
 							num=2;
 							game.log('#y杀','的伤害基数+1');
 						}
@@ -9790,7 +9786,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						}
 					},
 					prompt:function(links,player){
-						return '请选择【'+get.translation(links[0][3]||'')+get.translation(links[0][2])+'】的目标';
+						return '选择'+get.translation(links[0][3]||'')+'【'+get.translation(links[0][2])+'】的目标';
 					}
 				},
 				subSkill:{
@@ -10446,7 +10442,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			twlihuo:{
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.nature) return true;
+					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
 					return false;
 				},
 				audio:'lihuo',
@@ -10460,7 +10456,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					});
 				},
 				content:function(){
-					trigger.card.nature='fire';
+					game.setNature(trigger.card,'fire');
 					trigger.card.twlihuo_buffed=true;
 				},
 				group:['twlihuo2','twlihuo3'],
@@ -10471,7 +10467,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			twlihuo2:{
 				trigger:{player:'useCard2'},
 				filter:function(event,player){
-					if(event.card.name!='sha'||event.card.nature!='fire') return false;
+					if(event.card.name!='sha'||!event.card.hasNature('fire')) return false;
 					return game.hasPlayer(function(current){
 						return !event.targets.contains(current)&&player.canUse(event.card,current);
 					});
@@ -13503,7 +13499,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				filter:function(event,player){
 					if(player.countCards('h')) return false;
-					if(event.nature) return true;
+					if(event.hasNature()) return true;
 					return get.type(event.card,'trick')=='trick';
 				},
 				content:function(){

--- a/character/xianding.js
+++ b/character/xianding.js
@@ -107,18 +107,18 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							game.countPlayer(current=>cards.addArray(current.getCards('hejxs')));
 							for(var name of lib.inpile){
 								if(!get.tag({name:name},'damage')) continue;
-								if(cards.some(card=>get.name(card,false)==name&&!get.nature(card,false))){
+								if(cards.some(card=>get.name(card,false)==name&&!get.natureList(card,false).length)){
 									for(var suit of suits){
-										if(cards.some(card=>get.name(card,false)==name&&!get.nature(card,false)&&get.suit(card,false)==suit)){
+										if(cards.some(card=>get.name(card,false)==name&&!get.natureList(card,false).length&&get.suit(card,false)==suit)){
 											list.push([get.type(name),get.translation(suit),name,undefined,suit]);
 										}
 									}
 								}
 								if(name=='sha'){
 									for(var nature of lib.inpile_nature){
-										if(cards.some(card=>get.name(card,false)==name&&get.nature(card,false)==nature)){
+										if(cards.some(card=>get.name(card,false)==name&&get.is.sameNature(get.natureList(card,false),nature))){
 											for(var suit of suits){
-												if(cards.some(card=>get.name(card,false)==name&&get.nature(card,false)==nature&&get.suit(card,false)==suit)){
+												if(cards.some(card=>get.name(card,false)==name&&get.is.sameNature(get.natureList(card,false),nature)&&get.suit(card,false)==suit)){
 													list.push([get.type(name),get.translation(suit),name,nature,suit]);
 												}
 											}
@@ -852,7 +852,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							player:'damageBegin3',
 						},
 						filter:function(event,player){
-							return event.nature&&player.hasMark('dcchangqu_add');
+							return event.hasNature()&&player.hasMark('dcchangqu_add');
 						},
 						forced:true,
 						onremove:true,
@@ -4554,7 +4554,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					var num=player.getStat('gain');
 					if(num&&num>0) return false;
 					if(event.name=='link') return !player.isLinked();
-					return !event.nature;
+					return event.hasNature();
 				},
 				content:function(){
 					if(trigger.name=='link') trigger.cancel();
@@ -4611,15 +4611,15 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				filter:function(event,player){
 					if(player==_status.currentPhase) return false;
-					return !event.nature&&!player.hasHistory('damage',evt=>{
-						return !evt.nature&&evt!=event;
-					},event)||event.nature&&!player.hasHistory('damage',evt=>{
-						return evt.nature&&evt!=event;
+					return !event.hasNature()&&!player.hasHistory('damage',evt=>{
+						return !evt.hasNature()&&evt!=event;
+					},event)||event.hasNature()&&!player.hasHistory('damage',evt=>{
+						return evt.hasNature()&&evt!=event;
 					},event)&&event.source&&event.source.isIn()&&event.source.countGainableCards(player,'h');
 				},
 				content:function(){
 					'step 0'
-					if(!trigger.nature){
+					if(!trigger.hasNature()){
 						player.recover();
 					}
 					else{
@@ -4636,7 +4636,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							if(!get.tag(card,'damage')||player.hasSkillTag('jueqing',false,target)) return;
 							if(_status.event.getParent('useCard',true)||_status.event.getParent('_wuxie',true)) return;
 							if(!get.tag(card,'natureDamage')){
-								if(target.hasHistory('damage',evt=>!evt.nature)) return 1.5;
+								if(target.hasHistory('damage',evt=>!evt.hasNature())) return 1.5;
 								else if(target.hp<=1||player.hasSkillTag('damageBonus',false,{
 									target:target,
 									card:card
@@ -4660,7 +4660,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 									if(num<2) return [0,0];
 								}
 							}
-							if(get.tag(card,'natureDamage')&&!target.hasHistory('damage',evt=>evt.nature)&&player.countCards('he')>1) return [1,1,1,-1];
+							if(get.tag(card,'natureDamage')&&!target.hasHistory('damage',evt=>evt.hasNature())&&player.countCards('he')>1) return [1,1,1,-1];
 						}
 					}
 				}

--- a/character/xianjian.js
+++ b/character/xianjian.js
@@ -2793,7 +2793,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				trigger:{source:'damageBegin'},
 				forced:true,
 				filter:function(event){
-					return event.nature=='fire'&&event.notLink();
+					return event.hasNature('fire')&&event.notLink();
 				},
 				content:function(){
 					trigger.num++;
@@ -2804,7 +2804,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				popup:false,
 				filter:function(event){
-					return event.nature=='fire';
+					return event.hasNature('fire');
 				},
 				content:function(){
 					player.loseHp();
@@ -2814,7 +2814,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				trigger:{player:'damageEnd'},
 				forced:true,
 				filter:function(event){
-					return event.nature=='thunder';
+					return event.hasNature('thunder');
 				},
 				content:function(){
 					player.recover();
@@ -4083,7 +4083,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				group:['tianshe2'],
 				trigger:{player:'damageBefore'},
 				filter:function(event){
-					if(event.nature) return true;
+					if(event.hasNature()) return true;
 					return false;
 				},
 				forced:true,
@@ -4105,7 +4105,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			tianshe2:{
 				trigger:{source:'damageAfter'},
 				filter:function(event,player){
-					if(event.nature&&player.hp<player.maxHp) return true;
+					if(event.hasNature()&&player.hp<player.maxHp) return true;
 				},
 				forced:true,
 				content:function(){

--- a/character/yijiang.js
+++ b/character/yijiang.js
@@ -5234,7 +5234,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				trigger:{player:'damageBegin3'},
 				forced:true,
 				filter:function(event,player){
-					return player.isLinked()&&event.notLink()&&event.nature=='fire';
+					return player.isLinked()&&event.notLink()&&event.hasNature('fire');
 				},
 				content:function(){
 					trigger.num++;
@@ -6645,7 +6645,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			lihuo:{
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.nature) return true;
+					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
 					return false;
 				},
 				audio:2,
@@ -6654,7 +6654,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					return false;
 				},
 				content:function(){
-					trigger.card.nature='fire';
+					game.setNature(trigger.card,'fire');
 					var next=game.createEvent('lihuo_clear');
 					next.player=player;
 					next.card=trigger.card;
@@ -6665,7 +6665,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						if(player.isIn()&&player.getHistory('sourceDamage',function(evt){
 							return evt.getParent(2)==event.parent;
 						}).length>0) player.loseHp();
-						delete card.nature;
+						game.setNature(card,[],true);
 					});
 				},
 				group:'lihuo2'
@@ -6673,7 +6673,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			lihuo2:{
 				trigger:{player:'useCard2'},
 				filter:function(event,player){
-					if(event.card.name!='sha'||get.nature(event.card)!='fire') return false;
+					if(event.card.name!='sha'||!event.card.hasNature('fire')) return false;
 					return game.hasPlayer(function(current){
 						return !event.targets.contains(current)&&player.canUse(event.card,current);
 					});

--- a/character/zhuogui.js
+++ b/character/zhuogui.js
@@ -134,7 +134,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				trigger:{player:'damageBegin'},
 				filter:function(event,player){
 					if(player.getEquip(2)) return false;
-					if(event.nature=='fire') return true;
+					if(event.hasNature('fire')) return true;
 				},
 				forced:true,
 				check:function(){

--- a/game/game.js
+++ b/game/game.js
@@ -265,6 +265,61 @@
 					}
 				});
 			}],
+			//增加新属性杀
+			addNature:[(nature,config)=>{
+				if(typeof config!='object') config={};
+				let linked=config.linked,order=config.order,background=config.background,lineColor=config.lineColor;
+				if(typeof linked!='boolean') linked=true;
+				if(typeof order!='number') order=0;
+				if(typeof background!='string') background='';
+				if(!Array.isArray(lineColor)||lineColor.length!=3) lineColor=[];
+				else if(background.indexOf('ext:')==0){
+					background=background.replace(/ext:/,'extension/');
+				}
+				if(linked) lib.linked.add(nature);
+				if(lineColor.length) lib.lineColor.set(nature,lineColor);
+				lib.nature.set(nature,order);
+				if(background.length>0) lib.natureBg.set(nature,background);
+
+				let color1,color2;
+				if (typeof config.color=="string"&&/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(config.color)){
+					let c1=parseInt(`0x${item[1].slice(1, 3)}`);
+					let c2=parseInt(`0x${item[1].slice(3, 5)}`);
+					let c3=parseInt(`0x${item[1].slice(5, 7)}`);
+					color1=color2=[c1,c2,c3,1];
+				}
+				else if(Array.isArray(config.color)&&config.color.length>=2&&config.color.length<=4){
+					if(config.color.every(item=>Array.isArray(item))){
+						color1=config.color[0];
+						color2=config.color[1];
+					}
+					else{
+						let color=config.color.slice();
+						if(color.length==3) color.push(1);
+						color1=color2=color;
+					}
+				}
+				if(color1&&color2){
+					const cs=lib.linq.cselector;
+					const g1=cs.group(
+						cs.of(
+							cs.class("card","fullskin",`${nature}`),
+							'>',
+							cs.class("name"),
+						)
+					);
+					let result={};
+					result[g1]={
+						color:`rgba(${color1.join()})`,
+						border:cs.merge(
+							'1px',
+							'solid',
+							`rgba(${color2.join()})`
+						),
+					};
+					game.dynamicStyle.addObject(result);
+				}
+			}],
 		},
 		hookmap:{},
 		imported:{},
@@ -7975,6 +8030,17 @@
 						this.sort(lib.sort.seat);
 						delete lib.tempSortSeat;
 						return this;
+					}
+				});
+				Object.defineProperty(Object.prototype,'hasNature',{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(nature,player){
+						var natures=get.natureList(this,player);
+						if(!nature) return natures.length>0;
+						if(nature=='linked') return natures.some(n=>lib.linked.includes(n));
+						return get.is.sameNature(natures,nature,true);
 					}
 				});
 				if (!('includes' in Array.prototype)) {
@@ -17417,8 +17483,9 @@
 					if(cardaudio) game.broadcastAll((player,card)=>{
 						if(!lib.config.background_audio||get.type(card)=='equip'&&!lib.config.equip_audio) return;
 						const sex=player.sex=='female'?'female':'male';
-						if(card.name=='sha'&&['fire','thunder','ice','stab'].includes(card.nature)){
-							game.playAudio('card',sex,`${card.name}_${card.nature}`);
+						var nature=get.natureList(card)[0];
+						if(card.name=='sha'&&['fire','thunder','ice','stab'].includes(nature)){
+							game.playAudio('card',sex,`${card.name}_${nature}`);
 							return;
 						}
 						const audio=lib.card[card.name].audio;
@@ -17457,7 +17524,8 @@
 						}
 						else{
 							var config={};
-							if(card.nature||card.classList&&card.classList.contains(card.nature)) config.color=card.nature;
+							var nature=get.natureList(card)[0];
+							if(nature||card.classList&&card.classList.contains(nature)) config.color=nature;
 							if(event.addedTarget){
 								player.line2(targets.concat(event.addedTargets),config);
 							}
@@ -19040,18 +19108,19 @@
 					}
 					if(event.animate!==false){
 						player.$damage(source);
-						game.broadcastAll(function(nature,player){
+						var natures=(event.nature||'').split(lib.natureSeparator);
+						game.broadcastAll(function(natures,player){
 							if(lib.config.animation&&!lib.config.low_performance){
-								if(nature=='fire'){
+								if(natures.includes('fire')){
 									player.$fire();
 								}
-								else if(nature=='thunder'){
+								if(natures.includes('thunder')){
 									player.$thunder();
 								}
 							}
-						},event.nature,player);
+						},natures,player);
 						var numx=Math.max(0,num-player.hujia);
-						player.$damagepop(-numx,event.nature);
+						player.$damagepop(-numx,natures[0]);
 					}
 					if(event.unreal) event.goto(6)
 					if(!event.notrigger){
@@ -24269,6 +24338,11 @@
 						else if(get.itemtype(arguments[i])=='nature'&&arguments[i]!='stab'){
 							next.nature=arguments[i];
 						}
+						else if(get.itemtype(arguments[i])=='natures'){
+							var natures=arguments[i].split(lib.natureSeparator);
+							natures.remove('stab');
+							if(natures.length) next.nature=natures.join(lib.natureSeparator);
+						}
 					}
 					if(next.card==undefined&&!nocard) next.card=event.card;
 					if(next.cards==undefined&&!nocard) next.cards=event.cards;
@@ -24278,7 +24352,13 @@
 					if(next.num==undefined) next.num=(event.baseDamage||1)+(event.extraDamage||0);
 					next.original_num=next.num;
 					next.change_history=[];
-					if(next.nature=='poison') delete next._triggered;
+					next.hasNature=function(nature){
+						if(!nature) return Boolean(this.nature&&this.nature.length>0);
+						let natures=get.natureList(nature),naturesx=get.natureList(this.nature);
+						if(nature=='linked') return naturesx.some(n=>lib.linked.includes(n));
+						return get.is.sameNature(natures,naturesx,true);
+					};
+					if(next.hasNature('poison')) delete next._triggered;
 					next.setContent('damage');
 					next.filterStop=function(){
 						if(this.source&&this.source.isDead()) delete this.source;
@@ -28625,6 +28705,63 @@
 				}
 			},
 			card:{
+				hasNature:function(nature,player){
+					var natures=get.natureList(this,player);
+					if(!nature) return natures.length>0;
+					if(nature=='linked') return natures.some(n=>lib.linked.includes(n));
+					return get.is.sameNature(natures,nature,true);
+				},
+				//只针对【杀】起效果
+				addNature:function(nature){
+					let natures=[];
+					if(!this.nature) this.nature='';
+					else{
+						natures.addArray(get.natureList(this.nature));
+					}
+					natures.addArray(get.natureList(nature));
+					this.nature=get.nature(natures);
+					this.classList.add(nature);
+					let str=get.translation(this.nature)+'杀';
+					this.node.name.innerText=str;
+					let name=get.name(this,false);
+					do{
+						if(name=='sha'){
+							let _bg;
+							for(const n of natures) if(lib.natureBg.has(n)) _bg=n;
+							if(_bg){
+								this.node.image.setBackgroundImage(lib.natureBg.get(_bg));
+								break;
+							}
+						}
+						this.node.image.setBackgroundImage('image/card/'+name+'.png');
+					}
+					while(0);
+					return this.nature;
+				},
+				removeNature:function(nature){
+					if(!this.nature) return;
+					let natures=get.natureList(this.nature);
+					natures.remove(nature);
+					if(!natures.length) delete this.nature;
+					else this.nature=get.nature(natures);
+					this.classList.remove(nature);
+					let str=get.translation(this.nature)+'杀';
+					this.node.name.innerText=str;
+					let name=get.name(this,false);
+					do{
+						if(name=='sha'){
+							let _bg;
+							for(const n of natures) if(lib.natureBg.has(n)) _bg=n;
+							if(_bg){
+								this.node.image.setBackgroundImage(lib.natureBg.get(_bg));
+								break;
+							}
+						}
+						this.node.image.setBackgroundImage('image/card/'+name+'.png');
+					}
+					while(0);
+					return this.nature;
+				},
 				addGaintag:function(gaintag){
 					if(Array.isArray(gaintag)) this.gaintag=gaintag.slice(0);
 					else this.gaintag.add(gaintag);
@@ -28654,23 +28791,30 @@
 					if(Array.isArray(card)){
 						if(card[2]=='huosha'){
 							card[2]='sha';
-							card[3]='fire';
+							card[3]=['fire'];
 						}
-						if(card[2]=='leisha'){
+						else if(card[2]=='leisha'){
 							card[2]='sha';
-							card[3]='thunder';
+							card[3]=['thunder'];
 						}
-						if(card[2]=='kamisha'){
+						// else if(card[2]=='kamisha'){
+						// 	card[2]='sha';
+						// 	card[3]=['kami'];
+						// }
+						// else if(card[2]=='icesha'){
+						// 	card[2]='sha';
+						// 	card[3]=['ice'];
+						// }
+						else if(card[2]=='cisha'){
 							card[2]='sha';
-							card[3]='kami';
+							card[3]=['stab'];
 						}
-						if(card[2]=='icesha'){
-							card[2]='sha';
-							card[3]='ice';
-						}
-						if(card[2]=='cisha'){
-							card[2]='sha';
-							card[3]='stab';
+						else if(card[2].length>3){
+							let prefix=card[2].slice(0,card[2].lastIndexOf('sha'));
+							if(prefix.length+3==card[2].length){
+								card[2]='sha';
+								card[3]=[prefix];
+							}
 						}
 					}
 					else if(typeof card=='object'){
@@ -28756,13 +28900,24 @@
 								this.node.image.setBackgroundImage('image/mode/'+lib.card[bg].modeimage+'/card/'+bg+'.png');
 							}
 							else{
-								if(bg=='sha'&&card[3]=='stab') this.node.image.setBackgroundImage('image/card/cisha.png');
-								else this.node.image.setBackgroundImage('image/card/'+bg+'.png');
+								do{
+									let nature=card[3];
+									if(bg=='sha'&&typeof nature=='string'){
+										let natures=get.natureList(nature),_bg;
+										for(const n of natures) if(lib.natureBg.has(n)) _bg=n;
+										if(_bg){
+											this.node.image.setBackgroundImage(lib.natureBg.get(_bg));
+											break;
+										}
+									}
+									this.node.image.setBackgroundImage('image/card/'+bg+'.png');
+								}
+								while(0);
 							}
 						}
 					}
 					else if(lib.card[bg].image=='background'){
-						if(card[3]) this.node.background.setBackground(bg+'_'+card[3],'card');
+						if(card[3]) this.node.background.setBackground(bg+'_'+get.natureList(card[3])[0],'card');
 						else this.node.background.setBackground(bg,'card');
 					}
 					else if(lib.card[bg].fullimage){
@@ -28839,7 +28994,7 @@
 						}
 					}
 					else if(lib.card[bg].image=='card'){
-						if(card[3]) this.setBackground(bg+'_'+card[3],'card');
+						if(card[3]) this.setBackground(bg+'_'+get.natureList(card[3])[0],'card');
 						else this.setBackground(bg,'card');
 					}
 					else if(typeof lib.card[bg].image=='string'&&!lib.card[bg].fullskin){
@@ -28903,25 +29058,17 @@
 					this.node.image.className='image';
 					var name=get.translation(card[2]);
 					if(card[2]=='sha'){
-						if(card[3]=='fire'){
-							name='火'+name;
-							this.node.image.classList.add('fire');
+						name='';
+						let nature=card[3];
+						if(nature){
+							let natures=get.natureList(nature);
+							natures.sort(lib.sort.nature);
+							for(let nature of natures){
+								name+=lib.translate['nature_'+nature]||lib.translate[nature]||'';
+								if(nature!='stab') this.node.image.classList.add(nature);
+							}
 						}
-						else if(card[3]=='thunder'){
-							name='雷'+name;
-							this.node.image.classList.add('thunder');
-						}
-						else if(card[3]=='kami'){
-							name='神'+name;
-							this.node.image.classList.add('kami');
-						}
-						else if(card[3]=='ice'){
-							name='冰'+name;
-							this.node.image.classList.add('ice');
-						}
-						else if(card[3]=='stab'){
-							name='刺'+name;
-						}
+						name+='杀';
 					}
 					this.node.name.innerHTML=name;
 					if(name.length>=5){
@@ -28936,8 +29083,9 @@
 					this.name=card[2];
 					this.classList.add('card');
 					if(card[3]){
-						if(lib.nature.contains(card[3])) this.nature=card[3];
-						this.classList.add(card[3]);
+						let natures=get.natureList(card[3]);
+						natures.forEach(n=>{if(n) this.classList.add(n)});
+						this.nature=natures.filter(n=>lib.nature.has(n)).sort(lib.sort.nature).join(lib.natureSeparator);
 					}
 					else if(this.nature){
 						this.classList.remove(this.nature);
@@ -30674,6 +30822,9 @@
 			}
 		},
 		sort:{
+			nature:function(a,b){
+				return (lib.nature.get(b)||0)-(lib.nature.get(a)||0);
+			},
 			group:function(a,b){
 				const groupSort=function(group){
 					let base=0;
@@ -31349,7 +31500,7 @@
 					return '是否防止即将对'+get.translation(event.player)+'造成的伤害，改为令其减少'+get.cnNumber(event.num)+'点体力上限？';
 				},
 				filter:function(event,player){
-					return event.nature=='kami'&&event.num>0;
+					return event.hasNature('kami')&&event.num>0;
 				},
 				ruleSkill:true,
 				check:function(event,player){
@@ -32003,7 +32154,7 @@
 				forceDie:true,
 				filter:function(event,player){
 					var evt=event.getParent();
-					return evt&&evt.name=='damage'&&evt.nature&&lib.linked.contains(evt.nature)&&player.isLinked();
+					return evt&&evt.name=='damage'&&evt.hasNature('linked')&&player.isLinked();
 				},
 				content:function(){
 					player.link();
@@ -33125,8 +33276,20 @@
 			none:['none'],
 		},
 		group:['wei','shu','wu','qun','jin','shen'],
-		nature:['fire','thunder','kami','ice','stab','poison'],
+		//数值代表各元素在名称中排列的先后顺序
+		nature:new Map([
+			['fire',20],
+			['thunder',30],
+			['kami',60],
+			['ice',40],
+			['stab',10],
+			['poison',50]
+		]),
 		linked:['fire','thunder','kami','ice'],
+		natureBg:new Map([
+			['stab','image/card/cisha.png']
+		]),
+		natureSeparator:'|',
 		groupnature:{
 			shen:'thunder',
 			wei:'water',
@@ -33182,6 +33345,34 @@
 		}
 	};
 	const game={
+		//添加新的属性杀
+		addNature:(nature,translation,config)=>{
+			if(!nature) throw new TypeError();
+			if(translation&&translation.length) lib.translate['nature_'+nature]=translation;
+			lib.onload.add(()=>{
+				for(const hook of lib.hooks.addNature){
+					if(hook!=null&&typeof hook=="function"){
+						hook(nature,config);
+					}
+				}
+			})
+			return nature;
+		},
+		//设置卡牌信息/事件的属性
+		setNature:(item,nature,addNature)=>{
+			if(!nature) nature=[];
+			if(!addNature){
+				item.nature=get.nature(nature);
+				if(!item.nature.length) delete item.nature;
+			}
+			else{
+				let natures=Array.isArray(nature)?nature:nature.split(lib.natureSeparator);
+				let _nature=get.natureList(item,false);
+				_nature.addArray(natures);
+				item.nature=_nature.join(lib.natureSeparator);
+			}
+			return item.nature;
+		},
 		//洗牌
 		washCard:()=>{
 			if(!ui.cardPile.hasChildNodes()&&!ui.discardPile.hasChildNodes()) return false;
@@ -38172,8 +38363,7 @@
 					for(i=0;i<cards.length;i++){
 						if(lib.config.cardtempname!='off'){
 							var cardname=get.name(cards[i]);
-							var cardnature=get.nature(cards[i]);
-							if(cards[i].name!=cardname||((cardnature||cards[i].nature)&&cards[i].nature!=cardnature)){
+							if(cards[i].name!=cardname||!get.is.sameNature(get.nature(cards[i]),cards[i].nature)){
 								var node=ui.create.cardTempName(cards[i]);
 								var cardtempnameConfig=lib.config.cardtempname;
 								if(cardtempnameConfig!=='default') node.classList.remove('vertical');
@@ -49936,7 +50126,8 @@
 						node.style.color=item.style.color;
 					}
 					if(item.nature){
-						node.classList.add(item.nature);
+						let natures=get.natureList(item.nature);
+						natures.forEach(n=>node.classList.add(n));
 					}
 					if(!noclick){
 						lib.setIntro(node);
@@ -50466,8 +50657,9 @@
 					}
 				}
 				lib.inpile.sort(lib.sort.card);
+				const natures=Array.from(lib.nature.keys());
 				lib.inpile_nature.sort(function(a,b){
-					return lib.nature.indexOf(a)-lib.nature.indexOf(b);
+					return natures.indexOf(a)-natures.indexOf(b);
 				})
 				for(var i in _status.cardtag){
 					if(!_status.cardtag[i].length) delete _status.cardtag[i];
@@ -55014,6 +55206,45 @@
 			return 0;
 		},
 		is:{
+			/**
+			 * 判断传入的参数的属性是否相同（参数可以为卡牌、卡牌信息、属性等）
+			 * @param ...infos 要判断的属性列表 
+			 * @param partly {boolean} 是否判断每一个传入的属性是否存在部分相同而不是完全相同
+			 */
+			sameNature:function(){
+				var _args=Array.from(arguments);
+				var args=[],partly=false;
+				for(const arg of _args){
+					if(typeof arg=='boolean') partly=arg;
+					else{
+						if(arg) args.push(arg);
+					}
+				}
+				if(!args.length) return true;
+				if(args.length==1){
+					if(Array.isArray(args[0])) args=args[0];
+					else return false;
+				}
+				var naturesList=[];
+				const getN=(cardx)=>{
+					if(typeof cardx=='string') return cardx.split(lib.natureSeparator);
+					else if(Array.isArray(cardx)) return cardx;
+					return get.natureList(cardx||{});
+				}
+				naturesList=args.map(getN);
+				if(naturesList.length==1) return false;
+				if(naturesList.some(natures=>Array.isArray(natures)&&natures.length)){
+					var uniqueNatures=new Set(naturesList.flat());
+					for(var nature of uniqueNatures){
+						if(!nature) continue;
+						var lens=naturesList.map(natures=>natures.filter(n=>n===nature).length);
+						var lensx=Array.from(new Set(lens));
+						if(partly&&lensx.length==1) return true;
+						if(!partly&&lensx.length!=1) return false;
+					}
+				}
+				return !Boolean(partly);
+			},
 			//判断一张牌是否为明置手牌
 			shownCard:function(card){
 				if(card&&Array.isArray(card.gaintag)){
@@ -56567,7 +56798,8 @@
 					}
 					if(bool) return 'position';
 				}
-				if(lib.nature.contains(obj)) return 'nature';
+				if(obj.indexOf(lib.natureSeparator)!=-1&&obj.split(lib.natureSeparator).every(n=>lib.nature.has(n))) return 'natures';
+				if(lib.nature.has(obj)) return 'nature';
 			}
 			if(Array.isArray(obj)&&obj.length){
 				var isPlayers=true;
@@ -56715,14 +56947,27 @@
 			}
 			return number;
 		},
+		//返回一张杀的属性。如有多种属性则用 lib.natureSeparator 分割开来。例：火雷【杀】的返回值为 fire|thunder
 		nature:function(card,player){
+			if(typeof card=='string') return card.split(lib.natureSeparator).sort(lib.sort.nature).join(lib.natureSeparator);
+			if(Array.isArray(card)) return card.sort(lib.sort.nature).join(lib.natureSeparator);
+			var nature=card.nature;
 			if(get.itemtype(player)=='player'||player!==false){
 				var owner=get.owner(card);
 				if(owner){
-					return game.checkMod(card,owner,card.nature,'cardnature',owner);
+					return game.checkMod(card,owner,nature,'cardnature',owner);
 				}
 			}
-			return card.nature;
+			return nature;
+		},
+		//返回包含所有属性的数组
+		natureList:function(card,player){
+			if(!card) return [];
+			if(get.itemtype(card)=='natures') return card.split(lib.natureSeparator);
+			if(get.itemtype(card)=='nature') return [card];
+			var natures=get.nature.apply(this,arguments);
+			if(typeof natures!='string') return [];
+			return natures.split(lib.natureSeparator);
 		},
 		cards:function(num,putBack){
 			if(_status.waitingForCards){
@@ -56982,21 +57227,14 @@
 					str2=get.translation(str.name);
 				}
 				if(str2=='杀'){
-					if(str.nature=='fire'){
-						str2='火'+str2;
+					str2='';
+					if(typeof str.nature=='string'){
+						let natures=str.nature.split(lib.natureSeparator).sort(lib.sort.nature);
+						for(let nature of natures){
+							str2+=lib.translate['nature_'+nature]||lib.translate[nature]||'';
+						}
 					}
-					else if(str.nature=='thunder'){
-						str2='雷'+str2;
-					}
-					else if(str.nature=='kami'){
-						str2='神'+str2;
-					}
-					else if(str.nature=='ice'){
-						str2='冰'+str2;
-					}
-					else if(str.nature=='stab'){
-						str2='刺'+str2;
-					}
+					str2+='杀';
 				}
 				if(get.itemtype(str)=='card'||str.isCard){
 					if(_status.cardtag&&str.cardid){
@@ -57034,6 +57272,14 @@
 				}
 				return str2;
 			}
+			if(get.itemtype(str)=='natures'){
+				let natures=str.split(lib.natureSeparator).sort(lib.sort.nature);
+				var str2='';
+				for(var nature of natures){
+					str2+=lib.translate['nature_'+nature]||lib.translate[nature]||'';
+				}
+				return str2;
+			}
 			if(arg=='skill'){
 				if(lib.translate[str+'_ab']) return lib.translate[str+'_ab'];
 				if(lib.translate[str]) return lib.translate[str].slice(0,2);
@@ -57055,6 +57301,7 @@
 				return lib.translate[str];
 			}
 			if(typeof str=='string'){
+				if(lib.translate['nature_'+str]) return lib.translate['nature_'+str];
 				return str;
 			}
 			if(typeof str=='number'||typeof str=='boolean'){
@@ -59357,6 +59604,10 @@
 			return final;
 		},
 		damageEffect:function(target,player,viewer,nature){
+			if(get.itemtype(nature)=='natures'){
+				var natures=get.natureList(nature);
+				return natures.map(n=>get.damageEffect(target,player,viewer,n)).reduce((p,c)=>p+c,0)/(natures.length||1);
+			}
 			if(!player){
 				player=target;
 			}

--- a/mode/boss.js
+++ b/mode/boss.js
@@ -2030,7 +2030,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					game.log(trigger.card,'被改为神属性');
-					trigger.card.nature='kami';
+					game.setNature(trigger.card,'kami');
 				}
 			},
 			shanrangzhaoshu:{
@@ -2659,7 +2659,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					if(!player.hasEmptySlot('equip2')) return false;
 					if(event.card.name=='nanman') return true;
 					if(event.card.name=='wanjian') return true;
-					return event.card.name=='sha'&&!get.nature(event.card);
+					return event.card.name=='sha'&&event.card.hasNature();
 				},
 				content:function(){
 					trigger.cancel();
@@ -2672,7 +2672,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 							if(card.name=='sha'){
 								var equip1=player.getEquip(1);
 								if(equip1&&equip1.name=='zhuque') return 1.9;
-								if(!card.nature) return 'zerotarget';
+								if(!card.hasNature()) return 'zerotarget';
 							}
 						}
 					}
@@ -3697,12 +3697,12 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				},
 				forced:true,
 				filter:function(event,player){
-					if(player==event.player) return event.nature=='fire'||player==event.source;
+					if(player==event.player) return event.hasNature('fire')||player==event.source;
 					return true;
 				},
 				content:function(){
 					if(player==trigger.player) trigger.cancel();
-					else trigger.nature='fire';
+					else game.setNature(trigger,'fire');
 				},
 				ai:{
 					unequip:true,
@@ -4069,7 +4069,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					thunder:{
 						trigger:{player:'damageBegin4'},
 						filter:function(event){
-							return event.nature=='thunder'&&game.roundNumber<7;
+							return event.hasNature('thunder')&&game.roundNumber<7;
 						},
 						forced:true,
 						content:function(){
@@ -4499,7 +4499,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 						trigger:{player:'damageBegin1'},
 						forced:true,
 						filter:function(event,player){
-							return _status.currentPhase!=player&&event.nature=='fire';
+							return _status.currentPhase!=player&&event.hasNature('fire');
 						},
 						content:function(){
 							trigger.num++;
@@ -4676,21 +4676,21 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				trigger:{source:'damageBegin1'},
 				forced:true,
 				content:function(){
-					trigger.nature='fire';
+					game.setNature(trigger,'fire');
 				}
 			},
 			longfenghemingjian:{
 				equipSkill:true,
 				inherit:'cixiong_skill',
 				filter:function(event,player){
-					return lib.linked.contains(event.card.nature);
+					return event.card.hasNature('linked');
 				},
 			},
 			qicaishenlu:{
 				trigger:{source:'damageBegin1'},
 				forced:true,
 				filter:function(event,player){
-					return lib.linked.contains(event.nature);
+					return event.card.hasNature('linked');
 				},
 				content:function(){
 					trigger.num++;
@@ -5489,10 +5489,10 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				trigger:{source:'damageBegin1'},
 				forced:true,
 				filter:function(event){
-					return event.nature!='fire';
+					return !event.hasNature('fire');
 				},
 				content:function(){
-					trigger.nature='fire';
+					trigger.hasNature('fire');
 				},
 				mod:{
 					cardUsable:function(card){
@@ -6273,10 +6273,10 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 						return player.countCards('h')==0;
 					},
 					x6:function(player,event){
-						return event.nature=='fire';
+						return event.hasNature('fire');
 					},
 					x5:function(player,event){
-						return event.nature=='thunder';
+						return event.hasNature('thunder');
 					},
 					x4:function(player,event){
 						return event.name=='loseHp';
@@ -7353,7 +7353,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				trigger:{player:'damageBegin3'},
 				filter:function(event,player){
 					if(player.getEquip(2)) return false;
-					if(event.nature=='fire') return true;
+					if(event.hasNature('fire')) return true;
 				},
 				forced:true,
 				check:function(){
@@ -8007,7 +8007,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				unique:true,
 				filter:function(event){
-					return event.nature=='fire';
+					return event.hasNature('fire');
 				},
 				content:function(){
 					trigger.cancel();

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -3913,7 +3913,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				trigger:{source:'damageBegin1'},
 				forced:true,
 				filter:function(event){
-					return event.nature=='fire';
+					return event.hasNature('fire');
 				},
 				content:function(){
 					trigger.num++;

--- a/mode/versus.js
+++ b/mode/versus.js
@@ -4584,10 +4584,10 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				silent:true,
 				firstDo:true,
 				filter:function(event,player){
-					return !lib.linked.contains(event.nature);
+					return !event.hasNature('linked');
 				},
 				content:function(){
-					trigger.nature='fire';
+					game.setNature(trigger,'fire');
 				},
 			},
 			liangcaokuifa:{
@@ -5868,7 +5868,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				audio:false,
 				trigger:{player:'damageBefore'},
 				filter:function(event){
-					if(event.nature!='thunder') return true;
+					if(!event.hasNature('thunder')) return true;
 					return false;
 				},
 				forced:true,
@@ -5893,7 +5893,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 			boss_biantian3:{
 				trigger:{player:'damageBegin3'},
 				filter:function(event){
-					if(event.nature=='fire') return true;
+					if(event.hasNature('fire')) return true;
 					return false;
 				},
 				mark:true,
@@ -5969,7 +5969,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				audio:true,
 				trigger:{player:'damageBegin2'},
 				filter:function(event){
-					return event.nature=='fire';
+					return event.hasNature('fire');
 				},
 				forced:true,
 				content:function(){


### PR DESCRIPTION
1. 分别在 `Object.prototype`、`lib.element.card`、`lib.element.player.damage` 上定义`hasNature`方法，用于判断 某卡牌信息 / 某实体牌 / 某次伤害 是否有某种属性，参数为属性或属性数组；
2. 定义某张卡牌/某次伤害可以有多种属性。当有多种属性时，属性间用 `lib.natureSeparator` 分隔开（默认为 `|`），例如 `fire|stab`；
3. 在 `get.itemtype` 中加入多种属性（如 `fire|stab`）的类别为 `natures`；
4. 定义 `get.natureList` 函数，参数为卡牌或未分隔的属性字符串。返回值为所有属性组成的数组；
5. 修改 `get.nature` 函数，使得其可以将一个数组参数合并为属性字符串并按照 `lib.sort.nature` 的规则排列，即 `get.nature(['ice','fire','thunder'])` => `'ice|thunder|fire'`；
6. 定义 `lib.element.card.addNature` 和 `lib.element.card.removeNature`，用于对实体牌进行增加或者减少属性的操作（虽然可能没什么用）；
7. 将 `lib.nature` 改为 `Map` 类型，其中键为属性 `id`，对应的值为该属性名在卡牌名称显示中的优先值。如若“⑨”属性的 `order` 大于30，则一张雷属性+⑨属性的【杀】的名称会显示为**⑨雷杀**（P.S.：雷属性的 `order` 为30）；
8. 新增 `lib.natureBg`，存储拥有单独原画的属性杀的原画对应的文件位置（如**刺【杀】**）；
9. 新增 `get.is.sameNature` 函数，用于判断给定的卡牌或者属性是否相同。参数可以是任意属性、属性数组、卡牌，或者是元素为任意属性或属性数组或卡牌的单一数组。若某个参数为布尔值 `true`，则仅判断给定参数的元素是否存在一个共有的元素，否则则判定所有参数的元素均相同；
10. 新增 `game.setNature` 函数，用于设定一个卡牌信息或伤害事件的属性。参数为 `(item,nature,addNature)`。其中 `item` 为要设置属性的卡牌信息或者事件，`nature` 为要设置的属性或属性数组，`addNature` 标识了是否为增加而不是覆盖，即若为真则向已有的属性中添加给定属性；
11. 新增 `game.addNature` 函数，用于在 `lib.init.onload` 执行前为游戏新增新的属性杀。参数为 `(nature,translation,config)`，其中 `nature` 为新增属性的属性 `id`，`translation` 为该属性的翻译名称，`config` 为一个对象，用于设定一些额外信息，其中目前有下列键：<ul><li>`linked` 该属性是否可通过铁索连环传导，默认为true；<li>`order` 该属性名在卡牌名称显示中的优先值；<li>`background` 该属性杀的单独的卡牌背景对应的文件路径；<li>`lineColor` 该属性杀使用时的指示线颜色；<li>`color` 该属性杀实体牌的边框颜色。<br>若该属性为元素均为数组的数组，则其第一个元素为文字颜色，第二个元素为文字外围圆角矩形方框的颜色；<br>若该属性为RGB字符串或十六进制颜色码，或为单一数组，则文字颜色和边框颜色均为该属性对应的颜色。</ul>
12. 更新所有涉及判断属性的技能的相关判断方式。