### PR TITLE
[Enhancement] 更新钩子相关代码

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -33426,13 +33426,15 @@
 		addNature:(nature,translation,config)=>{
 			if(!nature) throw new TypeError();
 			if(translation&&translation.length) lib.translate['nature_'+nature]=translation;
-			lib.onload.add(()=>{
+			var hookCall=()=>{
 				for(const hook of lib.hooks.addNature){
 					if(hook!=null&&typeof hook=="function"){
 						hook(nature,translation,config);
 					}
 				}
-			})
+			};
+			if ("onload" in lib) lib.onload.add(hookCall);
+			else hookCall();
 			return nature;
 		},
 		//设置卡牌信息/事件的属性
@@ -33500,13 +33502,15 @@
 			lib.group.add(id);
 			if(short)lib.translate[id] = short;
 			if(name)lib.translate[`${id}2`] = name;
-			lib.onload.add(()=>{
+			var hookCall=()=>{
 				for(const hook of lib.hooks.addGroup){
 					if(hook!=null&&typeof hook=="function"){
 						hook(id,short,name,config);
 					}
 				}
-			})
+			};
+			if ("onload" in lib) lib.onload.add(hookCall);
+			else hookCall();
 			return id;
 		},
 		//Yingbian

--- a/game/game.js
+++ b/game/game.js
@@ -33494,13 +33494,6 @@
 			lib.group.add(id);
 			if(short)lib.translate[id] = short;
 			if(name)lib.translate[`${id}2`] = name;
-			var hookCall=()=>{
-				for(const hook of lib.hooks.addGroup){
-					if(hook!=null&&typeof hook=="function"){
-						hook(id,short,name,config);
-					}
-				}
-			};
 			game.callHook("addGroup",[id,short,name,config]);
 			return id;
 		},

--- a/game/game.js
+++ b/game/game.js
@@ -266,7 +266,7 @@
 				});
 			}],
 			//增加新属性杀
-			addNature:[(nature,config)=>{
+			addNature:[(nature,_translation,config)=>{
 				if(typeof config!='object') config={};
 				let linked=config.linked,order=config.order,background=config.background,lineColor=config.lineColor;
 				if(typeof linked!='boolean') linked=true;
@@ -33429,7 +33429,7 @@
 			lib.onload.add(()=>{
 				for(const hook of lib.hooks.addNature){
 					if(hook!=null&&typeof hook=="function"){
-						hook(nature,config);
+						hook(nature,translation,config);
 					}
 				}
 			})

--- a/game/game.js
+++ b/game/game.js
@@ -305,7 +305,7 @@
 						cs.of(
 							cs.class("card","fullskin",`${nature}`),
 							'>',
-							cs.class("name"),
+							cs.class("name")
 						)
 					);
 					let result={};

--- a/game/game.js
+++ b/game/game.js
@@ -33426,15 +33426,7 @@
 		addNature:(nature,translation,config)=>{
 			if(!nature) throw new TypeError();
 			if(translation&&translation.length) lib.translate['nature_'+nature]=translation;
-			var hookCall=()=>{
-				for(const hook of lib.hooks.addNature){
-					if(hook!=null&&typeof hook=="function"){
-						hook(nature,translation,config);
-					}
-				}
-			};
-			if ("onload" in lib) lib.onload.add(hookCall);
-			else hookCall();
+			game.callHook("addNature",[nature,translation,config]);
 			return nature;
 		},
 		//设置卡牌信息/事件的属性
@@ -33509,9 +33501,20 @@
 					}
 				}
 			};
-			if ("onload" in lib) lib.onload.add(hookCall);
-			else hookCall();
+			game.callHook("addGroup",[id,short,name,config]);
 			return id;
+		},
+		//通用的调用钩子函数
+		callHook:(name,args)=>{
+			const callHook=()=>{
+				for(const hook of lib.hooks[name]){
+					if(hook!=null&&typeof hook=="function"){
+						hook(...args);
+					}
+				}
+			}
+			if ("onload" in lib) lib.onload.add(callHook);
+			else callHook();
 		},
 		//Yingbian
 		//应变


### PR DESCRIPTION
- 修复兼容版不支持函数尾随逗号
- 补充`addNature`钩子的参数，使`game.addNature`和`hooks.addNature`的参数列表一致
- 将调用钩子的函数抽离成`game.callHook<T>(name: string, args: Parameters<T>): void`，现在可以直接用诸如`game.callHook("addNature",[...])`来调用`lib.hooks.addNature`里的所有函数，并自动判断执行时机。`args`的参数将被传入`lib.hooks`的函数当中。

---

# 兼容测试

> 懒得做语法分析了直接上结果

本次测试使用一扩展方便测试，代码如下：

```Javascript
game.import("extension",function(lib,game,ui,get,ai,_status){return {name:"钩子测试",content:function(config,pack){
    game.addGroup("test2_group","试","测试2",{
        color: [127,0,255, 1]
    });
    game.addNature("test_nature", "测试", {
        color: [255,0,255, 1]
    })
},precontent:function(){
    game.addGroup("test1_group","测","测试1",{
        color: [255,0,127, 1]
    });
},config:{},help:{},package:{
    character:{
        character:{
            "hook_test_a": ["none", "test1_group", 4, ["hook_test_gainCards"], []],
            "hook_test_b": ["none", "test2_group", 4, [], []]
        },
        translate:{
        },
    },
    card:{
        card:{
        },
        translate:{
        },
        list:[],
    },
    skill:{
        skill:{
            "hook_test_gainCards": {
                trigger: {
                    player: "phaseBegin"
                },
                charlotte: true,
                silent: true,
                content: () => {
                    player.gain(game.createCard("sha", "heart", 7, "test_nature"));
                }
            }
        },
        translate:{
        },
    },
    intro:"",
    author:"Rintim",
    diskURL:"",
    forumURL:"",
    version:"1.0",
},files:{"character":[],"card":[],"skill":[]}}})
```

## 由理电脑版

![图片](https://github.com/libccy/noname/assets/29033099/d6046ad1-f884-4939-b62b-0d429be594b5)
![图片](https://github.com/libccy/noname/assets/29033099/995b9115-6a4b-4e8a-9deb-ca11ce407b15)

## 由理兼容版

![图片](https://github.com/libccy/noname/assets/29033099/6caf3536-94c9-4a52-92ce-afebebfb4983)
![图片](https://github.com/libccy/noname/assets/29033099/1c358e22-8ad8-48db-ac05-c33937d1dd48)


