### PR TITLE
将判断属性的方法改为`game.hasNature`

### DIFF
--- a/card/extra.js
+++ b/card/extra.js
@@ -781,7 +781,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 							if(card.name=='sha'){
 								var equip1=player.getEquip('zhuque');
 								if(equip1&&equip1.name=='zhuque') return 1.9;
-								if(!card.hasNature()) return 'zerotarget';
+								if(!game.hasNature(card)) return 'zerotarget';
 							}
 						}
 					}
@@ -810,7 +810,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 					effect:{
 						target:function(card,player,target,current){
 							if(card.name=='sha'){
-								if(card.hasNature('fire')) return 2;
+								if(game.hasNature(card,'fire')) return 2;
 								if(player.hasSkill('zhuque_skill')) return 1.9;
 							}
 							if(get.tag(card,'fireDamage')&&current<0) return 2;
@@ -830,7 +830,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						target:player,
 						card:event.card
 					})) return false;
-					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
+					if(event.card.name=='sha'&&!game.hasNature(event.card)) return true;
 					return false;
 				},
 				content:function(){
@@ -906,7 +906,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				trigger:{player:'useCard1'},
 				//priority:7,
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
+					if(event.card.name=='sha'&&!game.hasNature(event.card)) return true;
 				},
 				audio:true,
 				check:function(event,player){

--- a/card/guozhan.js
+++ b/card/guozhan.js
@@ -1211,7 +1211,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				},
 				filter:function(event,player){
 					if(['huoshaolianying','huogong'].contains(event.card.name)) return true;
-					if(event.card.name=='sha') return event.card.hasNature('fire');
+					if(event.card.name=='sha') return game.hasNature(event.card,'fire');
 					return false;
 				},
 				content:function(){
@@ -1220,7 +1220,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				ai:{
 					effect:{
 						target:function(card,player,target,current){
-							if(['huoshaolianying','huogong'].contains(card.name)||(card.name=='sha'&&card.hasNature('fire'))){
+							if(['huoshaolianying','huogong'].contains(card.name)||(card.name=='sha'&&game.hasNature(card,'fire'))){
 								return 'zeroplayertarget';
 							}
 						},

--- a/card/standard.js
+++ b/card/standard.js
@@ -134,7 +134,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						if(event.shanRequired>1){
 							next.set('prompt2','（共需使用'+event.shanRequired+'张闪）');
 						}
-						else if(event.card.hasNature('stab')){
+						else if(game.hasNature(event.card,'stab')){
 							next.set('prompt2','（在此之后仍需弃置一张手牌）');
 						}
 						next.set('ai1',function(card){
@@ -168,7 +168,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						if(event.shanRequired>0){
 							event.goto(1);
 						}
-						else if(event.card.hasNature('stab')&&target.countCards('h')>0){
+						else if(game.hasNature(event.card,'stab')&&target.countCards('h')>0){
 							event.responded=result;
 							event.goto(4);
 						}
@@ -265,7 +265,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 					},
 					order:function(item,player){
 						if(player.hasSkillTag('presha',true,null,true)) return 10;
-						if(item.hasNature('linked')){
+						if(game.hasNature(item,'linked')){
 							if(game.hasPlayer(function(current){
 								return current!=player&&current.isLinked()&&player.canUse(item,current,null,true)&&get.effect(current,item,player,player)>0&&lib.card.sha.ai.canLink(player,current,item);
 							})&&game.countPlayer(function(current){
@@ -306,20 +306,20 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						respond:1,
 						respondShan:1,
 						damage:function(card){
-							if(card.hasNature('poison')) return;
+							if(game.hasNature(card,'poison')) return;
 							return 1;
 						},
 						natureDamage:function(card){
-							if(card.hasNature()) return 1;
+							if(game.hasNature(card)) return 1;
 						},
 						fireDamage:function(card,nature){
-							if(card.hasNature('fire')) return 1;
+							if(game.hasNature(card,'fire')) return 1;
 						},
 						thunderDamage:function(card,nature){
-							if(card.hasNature('thunder')) return 1;
+							if(game.hasNature(card,'thunder')) return 1;
 						},
 						poisonDamage:function(card,nature){
-							if(card.hasNature('poison')) return 1;
+							if(game.hasNature(card,'poison')) return 1;
 						}
 					}
 				}
@@ -338,20 +338,20 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						respond:1,
 						respondShan:1,
 						damage:function(card){
-							if(card.hasNature('poison')) return;
+							if(game.hasNature(card,'poison')) return;
 							return 1;
 						},
 						natureDamage:function(card){
-							if(card.hasNature()) return 1;
+							if(game.hasNature(card)) return 1;
 						},
 						fireDamage:function(card,nature){
-							if(card.hasNature('fire')) return 1;
+							if(game.hasNature(card,'fire')) return 1;
 						},
 						thunderDamage:function(card,nature){
-							if(card.hasNature('thunder')) return 1;
+							if(game.hasNature(card,'thunder')) return 1;
 						},
 						poisonDamage:function(card,nature){
-							if(card.hasNature('poison')) return 1;
+							if(game.hasNature(card,'poison')) return 1;
 						}
 					}
 				}

--- a/card/yingbian.js
+++ b/card/yingbian.js
@@ -307,7 +307,7 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				equipSkill:true,
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					return (event.card.name=='sha'&&lib.linked.some(n=>n!='kami'&&event.card.hasNature(n)));
+					return (event.card.name=='sha'&&lib.linked.some(n=>n!='kami'&&game.hasNature(event.card,n)));
 				},
 				audio:true,
 				direct:true,

--- a/character/clan.js
+++ b/character/clan.js
@@ -1076,7 +1076,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							try{
 								var cards=player.getCards('hs',cardx=>{
 									if(get.name(cardx)!='sha') return false;
-									return cardx.hasNature('linked');
+									return game.hasNature(cardx,'linked');
 								});
 								cards.map(i=>[i,get.effect(target,i,player,player)]);
 								cards.sort((a,b)=>b[1]-a[1]);
@@ -1096,7 +1096,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						return get.name(card)=='jiu'&&player.hasUseTarget(card);
 					})&&player.countCards('hs',card=>{
 						if(get.name(card)!='sha') return false;
-						return card.hasNature('linked');
+						return game.hasNature(card,'linked');
 					}));
 					'step 1'
 					if(result.bool){

--- a/character/ddd.js
+++ b/character/ddd.js
@@ -875,7 +875,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						var player=_status.event.player,target=_status.event.getParent().target;
 						if(get.attitude(player,target)<0) return false;
 						if(!_status.event.colors.contains(get.color(card,player))) return 0;
-						if(card.hasNature()) return 1.2;
+						if(game.hasNature(card)) return 1.2;
 						return 1;
 					})
 					'step 3'

--- a/character/extra.js
+++ b/character/extra.js
@@ -6177,7 +6177,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								if(['trick','delay'].contains(lib.card[card.name].type)) return 'thunder';
 							},
 							cardUsable:function(card,player){
-								if(card.name=='sha'&&card.hasNature('thunder')) return Infinity;
+								if(card.name=='sha'&&game.hasNature(card,'thunder')) return Infinity;
 							},
 						},
 						ai:{

--- a/character/huicui.js
+++ b/character/huicui.js
@@ -6437,7 +6437,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				prompt2:function(event,player){
 					var str=('令'+get.translation(event.player)+'即将受到的');
 					str+=(''+event.num+'点');
-					if(lib.linked.some(n=>event.hasNature(n))){
+					if(event.hasNature('linked')){
 						str+=(get.translation(event.nature)+'属性');
 					}
 					str+='伤害+1';
@@ -7061,7 +7061,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}).length;
 					//var str='视为额外使用'+get.cnNumber(num)+'张'
 					var str='额外结算'+get.cnNumber(num)+'次'
-					if(event.card.name=='sha'&&event.card.hasNature()) str+=get.translation(event.card.nature);
+					if(event.card.name=='sha'&&game.hasNature(event.card)) str+=get.translation(event.card.nature);
 					return (str+'【'+get.translation(event.card.name)+'】');
 				},
 				check:function(event,player){

--- a/character/mobile.js
+++ b/character/mobile.js
@@ -9624,7 +9624,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				group:['relihuo_baigei','relihuo_damage'],
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
+					if(event.card.name=='sha'&&!game.hasNature(event.card)) return true;
 				},
 				check:function(event,player){
 					return false;
@@ -9650,7 +9650,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				audio:'relihuo',
 				filter:function(event,player){
-					if(event.card.name!='sha'||!event.card.hasNature('fire')) return false;
+					if(event.card.name!='sha'||!game.hasNature(event.card,'fire')) return false;
 					var num=0;
 					player.getHistory('sourceDamage',function(evt){
 						if(evt.card==event.card) num+=evt.num;

--- a/character/offline.js
+++ b/character/offline.js
@@ -940,7 +940,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				filter:function(event,player){
 					if(!player.hasEmptySlot(2)) return false;
 					if(event.card.name!='sha') return false;
-					return event.card.hasNature();
+					return game.hasNature(event.card);
 				},
 				content:function(){
 					trigger.cancel();
@@ -6234,7 +6234,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			fulu:{
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
+					if(event.card.name=='sha'&&!game.hasNature(event.card)) return true;
 				},
 				audio:true,
 				check:function(event,player){

--- a/character/refresh.js
+++ b/character/refresh.js
@@ -6111,7 +6111,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
+					if(event.card.name=='sha'&&!game.hasNature(event.card)) return true;
 					return false;
 				},
 				audio:'lihuo',
@@ -6139,7 +6139,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			ollihuo2:{
 				trigger:{player:'useCard2'},
 				filter:function(event,player){
-					if(event.card.name!='sha'||!event.card.hasNature('fire')) return false;
+					if(event.card.name!='sha'||!game.hasNature(event.card,'fire')) return false;
 					return game.hasPlayer(function(current){
 						return !event.targets.contains(current)&&lib.filter.targetEnabled(event.card,player,current)&&lib.filter.targetInRange(event.card,player,current);
 					});
@@ -7604,7 +7604,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			decadelihuo:{
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
+					if(event.card.name=='sha'&&!game.hasNature(event.card)) return true;
 					return false;
 				},
 				audio:'lihuo',
@@ -7630,7 +7630,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			decadelihuo2:{
 				trigger:{player:'useCard2'},
 				filter:function(event,player){
-					if(event.card.name!='sha'||!event.card.hasNature('fire')) return false;
+					if(event.card.name!='sha'||!game.hasNature(event.card,'fire')) return false;
 					return game.hasPlayer(function(current){
 						return !event.targets.contains(current)&&player.canUse(event.card,current);
 					});
@@ -7660,7 +7660,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			decadelihuo3:{
 				trigger:{player:'useCardAfter'},
 				filter:function(event,player){
-					return event.card.name=='sha'&&event.card.hasNature('fire')&&event.targets.length>1&&player.getHistory('sourceDamage',function(evt){
+					return event.card.name=='sha'&&game.hasNature(event.card,'fire')&&event.targets.length>1&&player.getHistory('sourceDamage',function(evt){
 						return evt.card==event.card;
 					}).length>0;
 				},

--- a/character/sp.js
+++ b/character/sp.js
@@ -19389,7 +19389,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					effect:{
 						target:function(card,player,target,current){
 							if(card.name=='sha'){
-								if(card.hasNature('fire')||player.hasSkill('zhuque_skill')) return 2;
+								if(game.hasNature(card,'fire')||player.hasSkill('zhuque_skill')) return 2;
 							}
 							if(get.tag(card,'fireDamage')&&current<0) return 2;
 						}
@@ -19415,7 +19415,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			hanyong:{
 				trigger:{player:'useCard'},
 				filter:function(event,player){
-					return event.card&&(event.card.name=='nanman'||event.card.name=='wanjian'||(event.card.name=='sha'&&!event.card.hasNature()&&get.suit(event.card)=='spade'))&&player.isDamaged();
+					return event.card&&(event.card.name=='nanman'||event.card.name=='wanjian'||(event.card.name=='sha'&&!game.hasNature(event.card)&&get.suit(event.card)=='spade'))&&player.isDamaged();
 				},
 				content:function(){
 					trigger.baseDamage++;

--- a/character/sp2.js
+++ b/character/sp2.js
@@ -6560,7 +6560,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					else{
 						var vcard=[get.type(trigger.card),'',trigger.card.name];
-						if(trigger.card.hasNature()) vcard.push(get.nature(trigger.card));
+						if(game.hasNature(trigger.card)) vcard.push(get.nature(trigger.card));
 						player.storage.juanhui3.push(vcard);
 						player.markSkill('juanhui2');
 					}
@@ -7361,7 +7361,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						target:function(card,player,target,current){
 							if(target.hasMark('cangchu')){
 								if(card.name=='sha'){
-									if(lib.skill.global.contains('huoshaowuchao')||card.hasNature('fire')||player.hasSkill('zhuque_skill')) return 2;
+									if(lib.skill.global.contains('huoshaowuchao')||game.hasNature(card,'fire')||player.hasSkill('zhuque_skill')) return 2;
 								}
 								if(get.tag(card,'fireDamage')&&current<0) return 2;
 							}

--- a/character/tw.js
+++ b/character/tw.js
@@ -6039,7 +6039,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					var list=[];
 					player.getHistory('useCard',function(evt){
 						if(get.type(evt.card)!='basic') return;
-						var name=evt.card.name,nature=evt.card.hasNature()?get.nature(evt.card):'';
+						var name=evt.card.name,nature=game.hasNature(evt.card)?get.nature(evt.card):'';
 						if(!list.contains(name+nature)) list.push(name+nature);
 					});
 					event.addDamage=list.length>1;
@@ -10450,7 +10450,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			twlihuo:{
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
+					if(event.card.name=='sha'&&!game.hasNature(event.card)) return true;
 					return false;
 				},
 				audio:'lihuo',
@@ -10475,7 +10475,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			twlihuo2:{
 				trigger:{player:'useCard2'},
 				filter:function(event,player){
-					if(event.card.name!='sha'||!event.card.hasNature('fire')) return false;
+					if(event.card.name!='sha'||!game.hasNature(event.card,'fire')) return false;
 					return game.hasPlayer(function(current){
 						return !event.targets.contains(current)&&player.canUse(event.card,current);
 					});

--- a/character/yijiang.js
+++ b/character/yijiang.js
@@ -7010,7 +7010,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			lihuo:{
 				trigger:{player:'useCard1'},
 				filter:function(event,player){
-					if(event.card.name=='sha'&&!event.card.hasNature()) return true;
+					if(event.card.name=='sha'&&!game.hasNature(event.card)) return true;
 					return false;
 				},
 				audio:2,
@@ -7038,7 +7038,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			lihuo2:{
 				trigger:{player:'useCard2'},
 				filter:function(event,player){
-					if(event.card.name!='sha'||!event.card.hasNature('fire')) return false;
+					if(event.card.name!='sha'||!game.hasNature(event.card,'fire')) return false;
 					return game.hasPlayer(function(current){
 						return !event.targets.contains(current)&&player.canUse(event.card,current);
 					});

--- a/game/game.js
+++ b/game/game.js
@@ -8518,6 +8518,8 @@
 						return this;
 					}
 				});
+				//!!!WARNING!!!
+				//Will be deprecated in next verision
 				Object.defineProperty(Object.prototype,'hasNature',{
 					configurable:true,
 					enumerable:false,
@@ -29093,10 +29095,7 @@
 			},
 			card:{
 				hasNature:function(nature,player){
-					var natures=get.natureList(this,player);
-					if(!nature) return natures.length>0;
-					if(nature=='linked') return natures.some(n=>lib.linked.includes(n));
-					return get.is.sameNature(natures,nature);
+					return game.hasNature(this,nature,player);
 				},
 				//只针对【杀】起效果
 				addNature:function(nature){
@@ -33917,6 +33916,13 @@
 			if(translation&&translation.length) lib.translate['nature_'+nature]=translation;
 			game.callHook("addNature",[nature,translation,config]);
 			return nature;
+		},
+		//判断卡牌信息/事件是否有某个属性
+		hasNature:(item,nature,player)=>{
+			var natures=get.natureList(item,player);
+			if(!nature) return natures.length>0;
+			if(nature=='linked') return natures.some(n=>lib.linked.includes(n));
+			return get.is.sameNature(natures,nature);
 		},
 		//设置卡牌信息/事件的属性
 		setNature:(item,nature,addNature)=>{

--- a/mode/boss.js
+++ b/mode/boss.js
@@ -2659,7 +2659,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					if(!player.hasEmptySlot('equip2')) return false;
 					if(event.card.name=='nanman') return true;
 					if(event.card.name=='wanjian') return true;
-					return event.card.name=='sha'&&event.card.hasNature();
+					return event.card.name=='sha'&&game.hasNature(event.card);
 				},
 				content:function(){
 					trigger.cancel();
@@ -2672,7 +2672,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 							if(card.name=='sha'){
 								var equip1=player.getEquip(1);
 								if(equip1&&equip1.name=='zhuque') return 1.9;
-								if(!card.hasNature()) return 'zerotarget';
+								if(!game.hasNature(card)) return 'zerotarget';
 							}
 						}
 					}
@@ -4683,14 +4683,14 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 				equipSkill:true,
 				inherit:'cixiong_skill',
 				filter:function(event,player){
-					return event.card.hasNature('linked');
+					return game.hasNature(event.card,'linked');
 				},
 			},
 			qicaishenlu:{
 				trigger:{source:'damageBegin1'},
 				forced:true,
 				filter:function(event,player){
-					return event.card.hasNature('linked');
+					return game.hasNature(event.card,'linked');
 				},
 				content:function(){
 					trigger.num++;


### PR DESCRIPTION
取消在 `Object.prototype` 上定义 `hasNature` 方法的隐患写法（暂且保留，且于下版本废除），改为用 `game.hasNature` 进行判断。

参数为 `(item, nature, player)`<ul><li>`item` 为要判断的卡牌或事件（不过伤害事件依然保留了 `hasNature` 方法），<li>`nature` 为要判断是否存在的属性，<li> `player` 为通过 `mod` 技影响 `nature` 判断的玩家对象。</ul>