### PR TITLE
[Bug] 修复`Player#hasHistory`必须携带`filter`才能使用

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -26747,6 +26747,7 @@
 				},
 				hasHistory:function(key,filter,last){
 					const history=this.getHistory(key);
+					if(!filter||typeof filter!="function") filter=lib.filter.all;
 					if(last){
 						const lastIndex=history.indexOf(last);
 						return history.some((event,index)=>{


### PR DESCRIPTION
- 现在`Player#hasHistory`的第二个参数`filter`拥有默认值`lib.filter.all`，目前可以直接`Player#hasHistory(name)`用来判断玩家是否发生过对应名字的事件