### PR TITLE
[Enhancement] 在武将的`nodeintro`显示武将的手牌上限

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -59120,7 +59120,7 @@
 					}
 					tr.appendChild(td);
 					td=document.createElement('td');
-					td.innerHTML=node.countCards('h');
+					td.innerHTML=`${node.countCards('h')}/${node.getHandcardLimit()}`;
 					tr.appendChild(td);
 					td=document.createElement('td');
 					td.innerHTML=node.phaseNumber;


### PR DESCRIPTION
- 将`get.nodeintro`中显示武将手牌数量的部分增加了手牌上限的信息

# 关于性能

和距离获取以及标记信息显示一样，只是在点开武将的`nodeintro`时才会读取信息，故不会因为手牌上限的频繁切换而造成性能损失

---

# 更改前

![图片](https://github.com/libccy/noname/assets/29033099/072cd2e5-1b44-4eed-bcdc-12aaa27418ce)

# 更改后

![图片](https://github.com/libccy/noname/assets/29033099/93bb5ad4-31ee-45db-9005-7865570d14c1)