### PR TITLE
`Array.prototype`更改

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -8417,206 +8417,207 @@
 					}
 				});
 				/*Map prototype end*/
-				Object.defineProperty(Array.prototype, "filterInD", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function (pos) {
-						if (typeof pos != 'string') pos = 'o';
-						return this.filter(card => pos.includes(get.position(card, true)));
+				Object.defineProperty(Array.prototype,"filterInD",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(pos){
+						if(typeof pos!='string') pos='o';
+						return this.filter(card=>pos.includes(get.position(card,true)));
 					}
 				});
-				Object.defineProperty(Array.prototype, "someInD", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function (pos) {
-						if (typeof pos != 'string') pos = 'o';
-						return this.some(card => pos.includes(get.position(card, true)));
+				Object.defineProperty(Array.prototype,"someInD",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(pos){
+						if(typeof pos!='string') pos='o';
+						return this.some(card=>pos.includes(get.position(card,true)));
 					}
 				});
-				Object.defineProperty(Array.prototype, "everyInD", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function (pos) {
-						if (typeof pos != 'string') pos = 'o';
-						return this.every(card => pos.includes(get.position(card, true)));
+				Object.defineProperty(Array.prototype,"everyInD",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(pos){
+						if(typeof pos!='string') pos='o';
+						return this.every(card=>pos.includes(get.position(card,true)));
 					}
 				});
 				/**
-				 * @legacy Use `Array.prototype.includes(searchElement)` instead.
+				*@legacy Use `Array.prototype.includes(searchElement)` instead.
 				 */
-				Object.defineProperty(Array.prototype, "contains", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: Array.prototype.includes
+				Object.defineProperty(Array.prototype,"contains",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:Array.prototype.includes
 				});
-				Object.defineProperty(Array.prototype, "containsSome", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function () {
+				Object.defineProperty(Array.prototype,"containsSome",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(){
 						return Array.from(arguments).some(i=>this.includes(i));
 					}
 				});
-				Object.defineProperty(Array.prototype, "containsAll", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function () {
+				Object.defineProperty(Array.prototype,"containsAll",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(){
 						return Array.from(arguments).every(i=>this.includes(i));
 					}
 				});
 				
-				Object.defineProperty(Array.prototype, "add", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function () {
-						for (const arg of arguments) {
-							if (this.contains(arg)) continue;
+				Object.defineProperty(Array.prototype,"add",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(){
+						for(const arg of arguments){
+							if(this.contains(arg)) continue;
 							this.push(arg);
 						}
 						return this;
 					}
 				});
-				Object.defineProperty(Array.prototype, "addArray", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function () {
-						return Array.prototype.add.apply(this,Array.from(arguments).flat());
+				Object.defineProperty(Array.prototype,"addArray",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(){
+						for(const i of arguments) this.add(...i);
+						return this;
 					}
 				});
-				Object.defineProperty(Array.prototype, "remove", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function () {
+				Object.defineProperty(Array.prototype,"remove",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(){
 						for(const item of arguments){
-							const pos = this.indexOf(item);
-							if (pos == -1) continue;
-							this.splice(pos, 1);
+							const pos=this.indexOf(item);
+							if(pos==-1) continue;
+							this.splice(pos,1);
 						}
 						return this;
 					}
 				});
-				Object.defineProperty(Array.prototype, "removeArray", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function () {
-						return Array.prototype.remove.apply(this,Array.from(arguments).flat());
+				Object.defineProperty(Array.prototype,"removeArray",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(){
+						for(const i of arguments) this.add(...i);
 					}
 				});
-				Object.defineProperty(Array.prototype, "unique", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function () {
-						let uniqueArray = this.toUniqued();
-						this.length = uniqueArray.length;
-						for (let i = 0; i < uniqueArray.length; i++) this[i] = uniqueArray[i];
+				Object.defineProperty(Array.prototype,"unique",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(){
+						let uniqueArray=[...new Set(this)];
+						this.length=uniqueArray.length;
+						for(let i=0;i<uniqueArray.length;i++) this[i]=uniqueArray[i];
 						return this;
 					}
 				});
-				Object.defineProperty(Array.prototype, "toUniqued", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function () {
+				Object.defineProperty(Array.prototype,"toUniqued",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(){
 						return [...new Set(this)];
 					}
 				});
-				Object.defineProperty(Array.prototype, "randomGet", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function () {
-						let arr = this.slice(0);
+				Object.defineProperty(Array.prototype,"randomGet",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(){
+						let arr=this.slice(0);
 						arr.removeArray(Array.from(arguments));
-						return arr[Math.floor(Math.random() * arr.length)];
+						return arr[Math.floor(Math.random()*arr.length)];
 					}
 				});
-				Object.defineProperty(Array.prototype, "randomGets", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function (num) {
-						if (num > this.length) num = this.length;
-						let arr = this.slice(0);
-						let list = [];
-						for (let i = 0; i < num; i++) {
-							list.push(arr.splice(Math.floor(Math.random() * arr.length), 1)[0]);
+				Object.defineProperty(Array.prototype,"randomGets",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(num){
+						if(num>this.length) num=this.length;
+						let arr=this.slice(0);
+						let list=[];
+						for(let i=0;i<num;i++){
+							list.push(arr.splice(Math.floor(Math.random()*arr.length),1)[0]);
 						}
 						return list;
 					}
 				});
-				Object.defineProperty(Array.prototype, "randomRemove", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function (num) {
-						if (typeof num == 'number') {
-							let list = [];
-							for (let i = 0; i < num; i++) {
-								if (!this.length) break;
+				Object.defineProperty(Array.prototype,"randomRemove",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(num){
+						if(typeof num=='number'){
+							let list=[];
+							for(let i=0;i<num;i++){
+								if(!this.length) break;
 								list.push(this.randomRemove());
 							}
 							return list;
 						}
-						return this.splice(Math.floor(Math.random() * this.length), 1)[0];
+						return this.splice(Math.floor(Math.random()*this.length),1)[0];
 					}
 				});
-				Object.defineProperty(Array.prototype, "randomSort", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function () {
-						var list = [];
-						while (this.length) {
+				Object.defineProperty(Array.prototype,"randomSort",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(){
+						let list=[];
+						while(this.length){
 							list.push(this.randomRemove());
 						}
-						for (var i = 0; i < list.length; i++) {
+						for(let i=0;i<list.length;i++){
 							this.push(list[i]);
 						}
 						return this;
 					}
 				});
-				Object.defineProperty(Array.prototype, "sortBySeat", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function (target) {
-						lib.tempSortSeat = target;
+				Object.defineProperty(Array.prototype,"sortBySeat",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(target){
+						lib.tempSortSeat=target;
 						this.sort(lib.sort.seat);
 						delete lib.tempSortSeat;
 						return this;
 					}
 				});
 				/**
-				 * @description 从数组中寻找某个特征最大的，且通过筛选的第一个元素
+				*@description 从数组中寻找某个特征最大的，且通过筛选的第一个元素
 				 */
-				Object.defineProperty(Array.prototype, "maxBy", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function (sortBy, filter) {
-						let list = this.filter(filter||(() => true));
-						if (sortBy && typeof sortBy == 'function') list.sort((a, b) => sortBy(a) - sortBy(b));
+				Object.defineProperty(Array.prototype,"maxBy",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(sortBy,filter){
+						let list=this.filter(filter||(()=>true));
+						if(sortBy&&typeof sortBy=='function') list.sort((a,b)=>sortBy(a)-sortBy(b));
 						else list.sort();
-						return list[list.length - 1];
+						return list[list.length-1];
 					}
 				});
-				Object.defineProperty(Array.prototype, "minBy", {
-					configurable: true,
-					enumerable: false,
-					writable: true,
-					value: function (sortBy, filter) {
-						let list = this.filter(filter||(() => true));
-						if (sortBy && typeof sortBy == 'function') list.sort((a, b) => sortBy(a) - sortBy(b));
+				Object.defineProperty(Array.prototype,"minBy",{
+					configurable:true,
+					enumerable:false,
+					writable:true,
+					value:function(sortBy,filter){
+						let list=this.filter(filter||(()=>true));
+						if(sortBy&&typeof sortBy=='function') list.sort((a,b)=>sortBy(a)-sortBy(b));
 						else list.sort();
 						return list[0];
 					}

--- a/game/game.js
+++ b/game/game.js
@@ -8510,6 +8510,7 @@
 					writable:true,
 					value:function(){
 						for(const i of Array.from(arguments)) this.remove(...i);
+						return this;
 					}
 				});
 				Object.defineProperty(Array.prototype,"unique",{

--- a/game/game.js
+++ b/game/game.js
@@ -8487,7 +8487,7 @@
 					enumerable:false,
 					writable:true,
 					value:function(){
-						for(const i of arguments) this.add(...i);
+						for(const i of Array.from(arguments)) this.add(...i);
 						return this;
 					}
 				});
@@ -8509,7 +8509,7 @@
 					enumerable:false,
 					writable:true,
 					value:function(){
-						for(const i of arguments) this.add(...i);
+						for(const i of Array.from(arguments)) this.remove(...i);
 					}
 				});
 				Object.defineProperty(Array.prototype,"unique",{

--- a/game/game.js
+++ b/game/game.js
@@ -8418,157 +8418,207 @@
 				});
 				/*Map prototype end*/
 				Object.defineProperty(Array.prototype, "filterInD", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:function(pos){
-						if(typeof pos!='string') pos='o';
-						return this.filter(card=>pos.includes(get.position(card,true)));
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function (pos) {
+						if (typeof pos != 'string') pos = 'o';
+						return this.filter(card => pos.includes(get.position(card, true)));
 					}
 				});
 				Object.defineProperty(Array.prototype, "someInD", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:function(pos){
-						if(typeof pos!='string') pos='o';
-						return this.some(card=>pos.includes(get.position(card,true)));
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function (pos) {
+						if (typeof pos != 'string') pos = 'o';
+						return this.some(card => pos.includes(get.position(card, true)));
+					}
+				});
+				Object.defineProperty(Array.prototype, "everyInD", {
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function (pos) {
+						if (typeof pos != 'string') pos = 'o';
+						return this.every(card => pos.includes(get.position(card, true)));
 					}
 				});
 				/**
 				 * @legacy Use `Array.prototype.includes(searchElement)` instead.
 				 */
 				Object.defineProperty(Array.prototype, "contains", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:Array.prototype.includes
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: Array.prototype.includes
 				});
+				Object.defineProperty(Array.prototype, "containsSome", {
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function () {
+						return Array.from(arguments).some(i=>this.includes(i));
+					}
+				});
+				Object.defineProperty(Array.prototype, "containsAll", {
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function () {
+						return Array.from(arguments).every(i=>this.includes(i));
+					}
+				});
+				
 				Object.defineProperty(Array.prototype, "add", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:function(){
-						for(var i=0;i<arguments.length;i++){
-							if(this.contains(arguments[i])){
-								return false;
-							}
-							this.push(arguments[i]);
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function () {
+						for (const arg of arguments) {
+							if (this.contains(arg)) continue;
+							this.push(arg);
 						}
 						return this;
 					}
 				});
 				Object.defineProperty(Array.prototype, "addArray", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:function(arr){
-						for(var i=0;i<arr.length;i++){
-							this.add(arr[i]);
-						}
-						return this;
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function () {
+						return Array.prototype.add.apply(this,Array.from(arguments).flat());
 					}
 				});
 				Object.defineProperty(Array.prototype, "remove", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:function(item){
-						/*if(Array.isArray(item)){
-							for(var i=0;i<item.length;i++) this.remove(item[i]);
-							return;
-						}*/
-						var pos=this.indexOf(item);
-						if(pos==-1){
-							return false;
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function () {
+						for(const item of arguments){
+							const pos = this.indexOf(item);
+							if (pos == -1) continue;
+							this.splice(pos, 1);
 						}
-						this.splice(pos,1);
 						return this;
 					}
 				});
 				Object.defineProperty(Array.prototype, "removeArray", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:function(arr){
-						for(var i=0;i<arr.length;i++){
-							this.remove(arr[i]);
-						}
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function () {
+						return Array.prototype.remove.apply(this,Array.from(arguments).flat());
+					}
+				});
+				Object.defineProperty(Array.prototype, "unique", {
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function () {
+						let uniqueArray = this.toUniqued();
+						this.length = uniqueArray.length;
+						for (let i = 0; i < uniqueArray.length; i++) this[i] = uniqueArray[i];
 						return this;
 					}
 				});
+				Object.defineProperty(Array.prototype, "toUniqued", {
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function () {
+						return [...new Set(this)];
+					}
+				});
 				Object.defineProperty(Array.prototype, "randomGet", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:function(){
-						var arr=this.slice(0);
-						for(var i=0;i<arguments.length;i++) arr.remove(arguments[i]);
-						return arr[Math.floor(Math.random()*arr.length)];
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function () {
+						let arr = this.slice(0);
+						arr.removeArray(Array.from(arguments));
+						return arr[Math.floor(Math.random() * arr.length)];
+					}
+				});
+				Object.defineProperty(Array.prototype, "randomGets", {
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function (num) {
+						if (num > this.length) num = this.length;
+						let arr = this.slice(0);
+						let list = [];
+						for (let i = 0; i < num; i++) {
+							list.push(arr.splice(Math.floor(Math.random() * arr.length), 1)[0]);
+						}
+						return list;
 					}
 				});
 				Object.defineProperty(Array.prototype, "randomRemove", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:function(num){
-						if(typeof num=='number'){
-							var list=[];
-							for(var i=0;i<num;i++){
-								if(this.length){
-									list.push(this.randomRemove());
-								}
-								else{
-									break;
-								}
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function (num) {
+						if (typeof num == 'number') {
+							let list = [];
+							for (let i = 0; i < num; i++) {
+								if (!this.length) break;
+								list.push(this.randomRemove());
 							}
 							return list;
 						}
-						else{
-							return this.splice(Math.floor(Math.random()*this.length),1)[0];
-						}
+						return this.splice(Math.floor(Math.random() * this.length), 1)[0];
 					}
 				});
 				Object.defineProperty(Array.prototype, "randomSort", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:function(){
-						var list=[];
-						while(this.length){
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function () {
+						var list = [];
+						while (this.length) {
 							list.push(this.randomRemove());
 						}
-						for(var i=0;i<list.length;i++){
+						for (var i = 0; i < list.length; i++) {
 							this.push(list[i]);
 						}
 						return this;
 					}
 				});
-				Object.defineProperty(Array.prototype, "randomGets", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:function(num){
-						if(num>this.length){
-							num=this.length;
-						}
-						var arr=this.slice(0);
-						var list=[];
-						for(var i=0;i<num;i++){
-							list.push(arr.splice(Math.floor(Math.random()*arr.length),1)[0]);
-						}
-						return list;
-					}
-				});
 				Object.defineProperty(Array.prototype, "sortBySeat", {
-					configurable:true,
-					enumerable:false,
-					writable:true,
-					value:function(target){
-						lib.tempSortSeat=target;
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function (target) {
+						lib.tempSortSeat = target;
 						this.sort(lib.sort.seat);
 						delete lib.tempSortSeat;
 						return this;
+					}
+				});
+				/**
+				 * @description 从数组中寻找某个特征最大的，且通过筛选的第一个元素
+				 */
+				Object.defineProperty(Array.prototype, "maxBy", {
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function (sortBy, filter) {
+						let list = this.filter(filter||(() => true));
+						if (sortBy && typeof sortBy == 'function') list.sort((a, b) => sortBy(a) - sortBy(b));
+						else list.sort();
+						return list[list.length - 1];
+					}
+				});
+				Object.defineProperty(Array.prototype, "minBy", {
+					configurable: true,
+					enumerable: false,
+					writable: true,
+					value: function (sortBy, filter) {
+						let list = this.filter(filter||(() => true));
+						if (sortBy && typeof sortBy == 'function') list.sort((a, b) => sortBy(a) - sortBy(b));
+						else list.sort();
+						return list[0];
 					}
 				});
 				//!!!WARNING!!!


### PR DESCRIPTION
1、`add`,`addArray`,`remove`,`removeArray`方法更改，以解决多参数问题（附赠的`everyInD`请当做没看到）
**此次更改涉及到返回值更改**
通过正则搜索以及询问绝大部分扩展作者(包括rintim,show-k等)，我了解到几乎不会有人用返回值，故作此更改，**但是还是请在更新公告中说明返回值改变的问题**
2、感谢Curpond@Curpond提供的`containsSome`,`containsAll`,`maxBy`,`minBy`方法，以简化部分需要包含关系或判断极值的问题
3、感谢钫酸酱@chen079提供的`unique`,`toUniqued`方法，以简化数组去重（因为有人不会用set解决）
4、此次为**联合pr**，不代表@kuangshen04的个人观点
5、此次pr已经发在群中进行测试过，暂未发现问题，**但不保证万无一失**，如果发现bug请在pr-branch尽早提出，尽量不要合并到本体之后进行猎巫行动
