### PR TITLE
[Enhancement] 技能的配音文件可以直接给语音地址

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -35040,6 +35040,7 @@
 				if(Array.isArray(audioInfo)){
 					audioName=audioInfo[0];
 					if(!fixedNum) fixedNum=audioInfo[1];//数组会取第一个指定语音数
+					// TODO: 判断不完整，但现在无合适的方法，先放着 @kuangshen04
 					if(audioName in lib.skill) audioInfo=lib.skill[audioName].audio;
 					else audioInfo=parseInt(fixedNum);
 					continue;

--- a/game/game.js
+++ b/game/game.js
@@ -35040,7 +35040,8 @@
 				if(Array.isArray(audioInfo)){
 					audioName=audioInfo[0];
 					if(!fixedNum) fixedNum=audioInfo[1];//数组会取第一个指定语音数
-					audioInfo=lib.skill[audioName].audio;
+					if(audioName in lib.skill) audioInfo=lib.skill[audioName].audio;
+					else audioInfo=parseInt(fixedNum);
 					continue;
 				}
 				break;
@@ -35077,7 +35078,8 @@
 				game.playAudio('skill',`${audioName}${Math.floor(audioInfo*Math.random())+1}`);
 			}
 			//直接指定配音文件名的新格式
-			else if(typeof audioInfo=="object"&&"type" in audioInfo&&audioInfo.type=="direct"&&"files" in audioInfo){
+			else if(typeof audioInfo=="object"){
+				if(!("type" in audioInfo&&audioInfo.type=="direct"&&"files" in audioInfo)) return;
 				let audioFiles=audioInfo.files;
 				if(typeof audioFiles!="object") return;
 				if(!Array.isArray(audioFiles)){

--- a/game/game.js
+++ b/game/game.js
@@ -54793,17 +54793,13 @@
 							}
 							else if(typeof audioinfo=="object"&&"type" in audioinfo&&audioinfo.type=="direct"&&"files" in audioinfo){
 								let audioFiles=audioinfo.files;
-								if(typeof audioFiles!="object") return;
-								if(!Array.isArray(audioFiles)){
-									if(!player)return;
-									if(player.name&&player.name in audioFiles&&(!info.audioname2||!info.audioname2[player.name]))audioFiles=audioFiles[player.name];
-									else if(player.name1&&player.name1 in audioFiles&&(!info.audioname2||!info.audioname2[player.name1]))audioFiles=audioFiles[player.name1];
-									else if(player.name2&&player.name2 in audioFiles&&(!info.audioname2||!info.audioname2[player.name2]))audioFiles=audioFiles[player.name2];
+								if(typeof audioFiles=="object"){
+									if(!Array.isArray(audioFiles)&&playername&&playername in audioFiles)audioFiles=audioFiles[playername];
+									if(Array.isArray(audioFiles)){
+										const length=audioFiles.length;
+										game.playAudio(audioFiles[getIndex(length)-1]);
+									}
 								}
-								if(!Array.isArray(audioFiles))return;
-								const length=audioFiles.length;
-								//game.playAudio(`${audioInfo[0]}:${audioInfo[1]}`,`${audioName}${+1}.${audioInfo[3]||'mp3'}`);
-								game.playAudio(audioFiles[getIndex(length)-1]);
 							}
 							else if(audioinfo){
 								if(Array.isArray(info.audioname)&&info.audioname.contains(playername)) audioname=audioname+'_'+playername;
@@ -55068,17 +55064,13 @@
 							}
 							else if(typeof audioinfo=="object"&&"type" in audioinfo&&audioinfo.type=="direct"&&"files" in audioinfo){
 								let audioFiles=audioinfo.files;
-								if(typeof audioFiles!="object") return;
-								if(!Array.isArray(audioFiles)){
-									if(!player)return;
-									if(player.name&&player.name in audioFiles&&(!info.audioname2||!info.audioname2[player.name]))audioFiles=audioFiles[player.name];
-									else if(player.name1&&player.name1 in audioFiles&&(!info.audioname2||!info.audioname2[player.name1]))audioFiles=audioFiles[player.name1];
-									else if(player.name2&&player.name2 in audioFiles&&(!info.audioname2||!info.audioname2[player.name2]))audioFiles=audioFiles[player.name2];
+								if(typeof audioFiles=="object"){
+									if(!Array.isArray(audioFiles)&&playername&&playername in audioFiles)audioFiles=audioFiles[playername];
+									if(Array.isArray(audioFiles)){
+										const length=audioFiles.length;
+										game.playAudio(audioFiles[getIndex(length)-1]);
+									}
 								}
-								if(!Array.isArray(audioFiles))return;
-								const length=audioFiles.length;
-								//game.playAudio(`${audioInfo[0]}:${audioInfo[1]}`,`${audioName}${+1}.${audioInfo[3]||'mp3'}`);
-								game.playAudio(audioFiles[getIndex(length)-1]);
 							}
 							else if(audioinfo){
 								if(Array.isArray(info.audioname)&&info.audioname.contains(playername)) audioname=audioname+'_'+playername;

--- a/game/game.js
+++ b/game/game.js
@@ -35081,12 +35081,12 @@
 				let audioFiles=audioInfo.files;
 				if(typeof audioFiles!="object") return;
 				if(!Array.isArray(audioFiles)){
-					if(!player)return;
+					if(!player) return;
 					if(player.name&&player.name in audioFiles&&(!info.audioname2||!info.audioname2[player.name]))audioFiles=audioFiles[player.name];
 					else if(player.name1&&player.name1 in audioFiles&&(!info.audioname2||!info.audioname2[player.name1]))audioFiles=audioFiles[player.name1];
 					else if(player.name2&&player.name2 in audioFiles&&(!info.audioname2||!info.audioname2[player.name2]))audioFiles=audioFiles[player.name2];
 				}
-				if(!Array.isArray(audioFiles))return;
+				if(!Array.isArray(audioFiles)) return;
 				let length=audioFiles.length;
 				if(fixedNum)length=Math.min(length,fixedNum);
 				//game.playAudio(`${audioInfo[0]}:${audioInfo[1]}`,`${audioName}${+1}.${audioInfo[3]||'mp3'}`);

--- a/game/game.js
+++ b/game/game.js
@@ -35076,6 +35076,22 @@
 				if(fixedNum) audioInfo=Math.min(audioInfo, fixedNum);
 				game.playAudio('skill',`${audioName}${Math.floor(audioInfo*Math.random())+1}`);
 			}
+			//直接指定配音文件名的新格式
+			else if(typeof audioInfo=="object"&&"type" in audioInfo&&audioInfo.type=="direct"&&"files" in audioInfo){
+				let audioFiles=audioInfo.files;
+				if(typeof audioFiles!="object") return;
+				if(!Array.isArray(audioFiles)){
+					if(!player)return;
+					if(player.name&&player.name in audioFiles&&(!info.audioname2||!info.audioname2[player.name]))audioFiles=audioFiles[player.name];
+					else if(player.name1&&player.name1 in audioFiles&&(!info.audioname2||!info.audioname2[player.name1]))audioFiles=audioFiles[player.name1];
+					else if(player.name2&&player.name2 in audioFiles&&(!info.audioname2||!info.audioname2[player.name2]))audioFiles=audioFiles[player.name2];
+				}
+				if(!Array.isArray(audioFiles))return;
+				let length=audioFiles.length;
+				if(fixedNum)length=Math.min(length,fixedNum);
+				//game.playAudio(`${audioInfo[0]}:${audioInfo[1]}`,`${audioName}${+1}.${audioInfo[3]||'mp3'}`);
+				game.playAudio(audioFiles[Math.floor(length*Math.random())]);
+			}
 			else if(audioInfo) game.playAudio('skill',audioName);
 			else if(info.audio!==false) game.playSkillAudio(audioName);
 		},
@@ -54775,6 +54791,20 @@
 								if(Array.isArray(info.audioname)&&info.audioname.contains(playername)) audioname=audioname+'_'+playername;
 								game.playAudio('skill',audioname+getIndex(audioinfo));
 							}
+							else if(typeof audioinfo=="object"&&"type" in audioinfo&&audioinfo.type=="direct"&&"files" in audioinfo){
+								let audioFiles=audioinfo.files;
+								if(typeof audioFiles!="object") return;
+								if(!Array.isArray(audioFiles)){
+									if(!player)return;
+									if(player.name&&player.name in audioFiles&&(!info.audioname2||!info.audioname2[player.name]))audioFiles=audioFiles[player.name];
+									else if(player.name1&&player.name1 in audioFiles&&(!info.audioname2||!info.audioname2[player.name1]))audioFiles=audioFiles[player.name1];
+									else if(player.name2&&player.name2 in audioFiles&&(!info.audioname2||!info.audioname2[player.name2]))audioFiles=audioFiles[player.name2];
+								}
+								if(!Array.isArray(audioFiles))return;
+								const length=audioFiles.length;
+								//game.playAudio(`${audioInfo[0]}:${audioInfo[1]}`,`${audioName}${+1}.${audioInfo[3]||'mp3'}`);
+								game.playAudio(audioFiles[getIndex(length)-1]);
+							}
 							else if(audioinfo){
 								if(Array.isArray(info.audioname)&&info.audioname.contains(playername)) audioname=audioname+'_'+playername;
 								game.playAudio('skill',audioname);
@@ -55035,6 +55065,20 @@
 							if(typeof audioinfo=='number'){
 								if(Array.isArray(info.audioname)&&info.audioname.contains(playername)) audioname=audioname+'_'+playername;
 								game.playAudio('skill',audioname+getIndex(audioinfo));
+							}
+							else if(typeof audioinfo=="object"&&"type" in audioinfo&&audioinfo.type=="direct"&&"files" in audioinfo){
+								let audioFiles=audioinfo.files;
+								if(typeof audioFiles!="object") return;
+								if(!Array.isArray(audioFiles)){
+									if(!player)return;
+									if(player.name&&player.name in audioFiles&&(!info.audioname2||!info.audioname2[player.name]))audioFiles=audioFiles[player.name];
+									else if(player.name1&&player.name1 in audioFiles&&(!info.audioname2||!info.audioname2[player.name1]))audioFiles=audioFiles[player.name1];
+									else if(player.name2&&player.name2 in audioFiles&&(!info.audioname2||!info.audioname2[player.name2]))audioFiles=audioFiles[player.name2];
+								}
+								if(!Array.isArray(audioFiles))return;
+								const length=audioFiles.length;
+								//game.playAudio(`${audioInfo[0]}:${audioInfo[1]}`,`${audioName}${+1}.${audioInfo[3]||'mp3'}`);
+								game.playAudio(audioFiles[getIndex(length)-1]);
 							}
 							else if(audioinfo){
 								if(Array.isArray(info.audioname)&&info.audioname.contains(playername)) audioname=audioname+'_'+playername;


### PR DESCRIPTION
- 在`game.trySkillAudio`和`ui.click.charactercard`中给技能的`audio`属性增添了一条新的分支。当满足以下条件时，会执行新分支的内容:
  - `audio`属性不为字符串和数字
  - `audio`属性为对象且拥有`type`和`files`属性
  - `audio.type == "direct"`
- `audio.files`可以为`Object`和`Array`；当`audio.files`为`Object`且传入玩家信息时，会依次查看`player.name`, `player.name1`和`player.name2`是否在`audio.files`里，并读取最先存在的数据；反之当`audio.files`为Array时则直接顺序执行
- 最后随机播放`audio.files`的配音地址指向的文件（如果在`ui.click.charactercard`中则顺序播放）
- `audio.files`中的内容为任意可放到`game.playAudio`里的地址

---

# 特点

- 可在多个技能中使用同一个配音文件，通过原始的方法实现了下面的操作:
> A技能拥有两个功能B和C，其中两条配音对应B，两条配音对应C，希望在点击A技能时能顺序播放B和C共4条配音，而B和C只播放对应的两条配音，且不想多出重复文件
- 能同时在一个技能里使用mp3, ogg, flac等多个格式
- 可将配音文件放在不同的文件夹下
- 能通过部分打包软件来维护扩展配音文件
- etc.

# 关于性能

由于新分支位于判断是否为数字之后，故以往所有的“带配音技能”都不会走到新分支的判断，仅有无`audio`属性或`audio`属性不规范的技能才会绕过新分支，故可以认定性能不会因此受到太大影响

# 其他

为了不创原来的格式，故只能以对象来表示，并用`type`属性的值这种原始方式确定`audio`是期望的`audio`；或许可以考虑加个函数来弥补视觉上的缺点

## 补充

当`audio`为数组时，由于`Math.min`自带`parseInt`的功能，所以按原来的形式传`["foo/bar", "2"]同样可以达到效果，故无法直接用数组来表示；如果要在里面先判断`parseInt`的话，会造成虽然微弱但并无必要的性能损失，故还是创建新的格式

---

# 例子1

```Javascript
{
	...
	audio: {
		type: "direct",
		files: [
			"ext:测试扩展/res/audio/test1.mp3",
			"ext:测试扩展/res/audio/test2.ogg"
		]
	},
	...
}
```

# 例子2

```Javascript
{
	...
	audio: {
		type: "direct",
		files: {
			"caocao": [
				"skill/jianxiong1.mp3",
				"skill/rejianxiong2.mp3"
			],
			"liubei": [
				"skill/rende1.mp3",
				"skill/rerende2.mp3"
			]
		}
	},
	...
}
```