### PR TITLE
添加知情牌机制，辅助AI判断行动收益。

### DIFF
--- a/card/extra.js
+++ b/card/extra.js
@@ -242,6 +242,17 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						target:function(player,target){
 							if(target.hasSkill('huogong2')||target.countCards('h')==0) return 0;
 							if(player.countCards('h')<=1) return 0;
+							if(_status.event.player == player){
+								if(target.isAllCardsKnown(player)){
+									if(!target.countCards('h',card=>{
+										return player.countCards('h',card2=>{
+											return get.suit(card2) == get.suit(card);
+										});
+									})){
+										return 0;
+									}
+								}
+							}
 							if(target==player){
 								if(typeof _status.event.filterCard=='function'&&
 									_status.event.filterCard({name:'huogong'},player,_status.event)){

--- a/game/game.js
+++ b/game/game.js
@@ -17968,10 +17968,12 @@
 					if(!event.chooseonly){
 						if(event.delay!==false){
 							var next=player.gain(event.cards,target,event.visibleMove?'give':'giveAuto','bySelf');
+							next.set('cardKnower',event.visibleMove?['everyone']:[target]);
 							event.done=next;
 						}
 						else{
 							var next=player.gain(event.cards,target,'bySelf');
+							next.set('cardKnower',event.visibleMove?['everyone']:[target]);
 							event.done=next;
 							target[event.visibleMove?'$give':'$giveAuto'](cards,player);
 							if(event.visibleMove) next.visible=true;
@@ -18048,6 +18050,7 @@
 					else{
 						game.log(player,'展示了',cards);
 					}
+					game.addCardKnowner(cards,'everyone');
 					game.delayx(event.delay_time||2.5);
 					game.addVideo('showCards',player,[event.str,get.cardsInfo(cards)]);
 					"step 1"
@@ -18056,6 +18059,7 @@
 				},
 				viewCards:function(){
 					"step 0"
+					game.addCardKnowner(event.cards,player);
 					if(player==game.me){
 						event.dialog=ui.create.dialog(event.str,event.cards);
 						if(event.isMine()){
@@ -19254,7 +19258,13 @@
 						for(var i in map){
 							var owner=(_status.connectMode?lib.playerOL:game.playerMap)[i];
 							var next=owner.lose(map[i][0],ui.special).set('type','gain').set('forceDie',true).set('getlx',false);
-							if(event.visible==true) next.visible=true;
+							if(event.visible==true){
+								next.visible=true;
+								game.addCardKnowner(map[i][0],'everyone');
+							}else{
+								game.addCardKnowner(map[i][1],owner);
+								game.addCardKnowner(map[i][2],'everyone');
+							}
 							event.relatedLose=next;
 						}
 					}
@@ -19765,6 +19775,7 @@
 					event.js=js;
 					event.ss=ss;
 					event.xs=xs;
+					game.clearCardKnowers(hs);
 					"step 2"
 					if(num<cards.length){
 						if(event.es.contains(cards[num])){
@@ -20606,6 +20617,8 @@
 					for(i=0;i<bottom.length;i++){
 						ui.cardPile.appendChild(bottom[i]);
 					}
+					game.addCardKnowner(top,player);
+					game.addCardKnowner(bottom,player);
 					player.popup(get.cnNumber(top.length)+'上'+get.cnNumber(bottom.length)+'下');
 					game.log(player,'将'+get.cnNumber(top.length)+'张牌置于牌堆顶');
 					game.updateRoundNumber();
@@ -20968,6 +20981,32 @@
 					return this.getCards('h',function(card){
 						return get.is.shownCard(card);
 					});
+				}
+				//获取该角色被other所知的牌。
+				getKnownCards(other,filter){
+					if(!other)other = _status.event.player;
+					if(!other)other = this;
+					if(!filter)filter = (card)=>{return true};
+					return this.getCards('h',function(card){
+						return card.isKnownBy(other) && filter(card);
+					});
+				}
+				//判断此角色的手牌是否已经被看光了。
+				isAllCardsKnown(other){
+					if(!other)other = _status.event.player;
+					if(!other)other = this;
+					return this.countCards('h',function(card){
+						return !card.isKnownBy(other);
+					}) == 0;
+				}
+				//判断此角色是否有被知的牌。
+				hasKnownCards(other,filter){
+					if(!other)other = _status.event.player;
+					if(!other)other = this;
+					if(!filter)filter = (card)=>{return true};
+					return this.countCards('h',function(card){
+						return card.isKnownBy(other) && filter(card);
+					}) > 0;
 				}
 				//Execute the delay card effect
 				//执行延时锦囊牌效果
@@ -28286,8 +28325,13 @@
 					let cards,selected=get.copy(ui.selected.cards);
 					if(get.itemtype(ignore)==='cards') selected.addArray(ignore);
 					else if(get.itemtype(ignore)==='card') selected.add(ignore);
-					if(this===viewer||get.itemtype(viewer)==='player'&&viewer.hasSkillTag('viewHandcard',null,this,true)) cards=this.getCards('h');
-					else cards=this.getShownCards();
+					/*if(this===viewer||get.itemtype(viewer)==='player'&&viewer.hasSkillTag('viewHandcard',null,this,true)) cards=this.getCards('h');
+					else cards=this.getShownCards();*/
+					if(this === viewer || get.itemtype(viewer) == 'player'){
+						cards = this.getKnownCards(viewer);
+					}else{
+						cards = this.getShownCards();
+					}
 					if(cards.some(card=>{
 						if(selected.includes(card)) return false;
 						let name=get.name(card,this);
@@ -28308,8 +28352,13 @@
 					let cards,selected=get.copy(ui.selected.cards);
 					if(get.itemtype(ignore)==='cards') selected.addArray(ignore);
 					else if(get.itemtype(ignore)==='card') selected.add(ignore);
-					if(this===viewer||get.itemtype(viewer)==='player'&&viewer.hasSkillTag('viewHandcard',null,this,true)) cards=this.getCards('h');
-					else cards=this.getShownCards();
+					/*if(this===viewer||get.itemtype(viewer)==='player'&&viewer.hasSkillTag('viewHandcard',null,this,true)) cards=this.getCards('h');
+					else cards=this.getShownCards();*/
+					if(this === viewer || get.itemtype(viewer) == 'player'){
+						cards = this.getKnownCards(viewer);
+					}else{
+						cards = this.getShownCards();
+					}
 					if(cards.some(card=>{
 						if(selected.includes(card)) return false;
 						let name=get.name(card,this);
@@ -30431,6 +30480,41 @@
 				}
 				aiexclude(){
 					_status.event._aiexclude.add(this);
+				}
+				//为此牌添加知情者。参数可为数组，若参数为字符串'everyone'，则所有玩家均为知情者。
+				addKnowner(player){
+					if(!this._knowers){
+						this._knowers = [];
+					}
+					if(typeof player == 'string'){
+						this._knowers.add(player);
+					}else{
+						let type = get.itemtype(player);
+						if(type == 'player'){
+							this._knowers.add(player.playerid);
+						}else if(type == 'players'){
+							player.forEach(p=>this._knowers.add(p.playerid));
+						}
+					}
+				}
+				//清除此牌的知情者。
+				clearKnowers(){
+					if(this._knowers)delete this._knowers;
+				}
+				//判断玩家对此牌是否知情。
+				isKnownBy(player){
+					if(['e','j'].includes(get.position(this)))return true;//装备区或者判定区的牌，必知情。
+					let owner = get.owner(this);
+					if(owner){
+						if(owner == player)return true;//是牌主，必知情。
+						if(player.hasSkillTag('viewHandcard',null,owner,true))return true;//有viewHandcard标签，必知情。
+						if(owner.isUnderControl(true,player))return true;//被操控，必知情。
+					}
+					if(get.is.shownCard(this))return true;//此牌是明置牌，必知情。
+					if(this._knowers){
+						return this._knowers.includes('everyone') || this._knowers.includes(player.playerid);
+					}
+					return false;
 				}
 				getSource(name){
 					if(this.name==name) return true;
@@ -36058,6 +36142,20 @@
 			for(var i of game.players){
 				if(i.storage.renku) i.markSkill('renku');
 			}
+		},
+		//为牌添加知情者。
+		addCardKnowner:function(cards,players){
+			if(get.itemtype(cards) == 'card'){
+				cards = [cards];
+			}
+			cards.forEach(card=>card.addKnowner(players));
+		},
+		//移除牌的所有知情者。
+		clearCardKnowers:function(cards){
+			if(get.itemtype(cards) == 'card'){
+				cards = [cards];
+			}
+			cards.forEach(card=>card.clearKnowers());
 		},
 		loseAsync:function(arg){
 			var next=game.createEvent('loseAsync');

--- a/game/game.js
+++ b/game/game.js
@@ -19779,6 +19779,9 @@
 					event.ss=ss;
 					event.xs=xs;
 					game.clearCardKnowers(hs);
+					if(hs.length && !event.visible){
+						this.getCards('h').forEach(hcard=>{hcard.clearKnowers();});
+					}
 					"step 2"
 					if(num<cards.length){
 						if(event.es.contains(cards[num])){

--- a/game/game.js
+++ b/game/game.js
@@ -19267,6 +19267,9 @@
 							}
 							event.relatedLose=next;
 						}
+						if(event.cardKnower){
+							game.addCardKnowner(cards,event.cardKnower);
+						}
 					}
 					else{
 						event.finish();

--- a/game/game.js
+++ b/game/game.js
@@ -19260,15 +19260,11 @@
 							var next=owner.lose(map[i][0],ui.special).set('type','gain').set('forceDie',true).set('getlx',false);
 							if(event.visible==true){
 								next.visible=true;
-								game.addCardKnower(map[i][0],'everyone');
-							}else{
-								game.addCardKnower(map[i][1],owner);
-								game.addCardKnower(map[i][2],'everyone');
 							}
 							event.relatedLose=next;
-						}
-						if(event.cardKnower){
-							game.addCardKnower(cards,event.cardKnower);
+							if(event.cardKnower){
+								next.set('cardKnower',event.cardKnower);
+							}
 						}
 					}
 					else{
@@ -19286,6 +19282,8 @@
 									var hs=source.getCards('hejsx');
 									if(hs.contains(cards[i])){
 										cards.splice(i--,1);
+									}else{
+										cards[i].addKnower(event.visible?'everyone':source);
 									}
 								}
 							}

--- a/game/game.js
+++ b/game/game.js
@@ -18050,7 +18050,7 @@
 					else{
 						game.log(player,'展示了',cards);
 					}
-					game.addCardKnowner(cards,'everyone');
+					game.addCardKnower(cards,'everyone');
 					game.delayx(event.delay_time||2.5);
 					game.addVideo('showCards',player,[event.str,get.cardsInfo(cards)]);
 					"step 1"
@@ -18059,7 +18059,7 @@
 				},
 				viewCards:function(){
 					"step 0"
-					game.addCardKnowner(event.cards,player);
+					game.addCardKnower(event.cards,player);
 					if(player==game.me){
 						event.dialog=ui.create.dialog(event.str,event.cards);
 						if(event.isMine()){
@@ -19260,15 +19260,15 @@
 							var next=owner.lose(map[i][0],ui.special).set('type','gain').set('forceDie',true).set('getlx',false);
 							if(event.visible==true){
 								next.visible=true;
-								game.addCardKnowner(map[i][0],'everyone');
+								game.addCardKnower(map[i][0],'everyone');
 							}else{
-								game.addCardKnowner(map[i][1],owner);
-								game.addCardKnowner(map[i][2],'everyone');
+								game.addCardKnower(map[i][1],owner);
+								game.addCardKnower(map[i][2],'everyone');
 							}
 							event.relatedLose=next;
 						}
 						if(event.cardKnower){
-							game.addCardKnowner(cards,event.cardKnower);
+							game.addCardKnower(cards,event.cardKnower);
 						}
 					}
 					else{
@@ -20620,8 +20620,8 @@
 					for(i=0;i<bottom.length;i++){
 						ui.cardPile.appendChild(bottom[i]);
 					}
-					game.addCardKnowner(top,player);
-					game.addCardKnowner(bottom,player);
+					game.addCardKnower(top,player);
+					game.addCardKnower(bottom,player);
 					player.popup(get.cnNumber(top.length)+'上'+get.cnNumber(bottom.length)+'下');
 					game.log(player,'将'+get.cnNumber(top.length)+'张牌置于牌堆顶');
 					game.updateRoundNumber();
@@ -30485,7 +30485,7 @@
 					_status.event._aiexclude.add(this);
 				}
 				//为此牌添加知情者。参数可为数组，若参数为字符串'everyone'，则所有玩家均为知情者。
-				addKnowner(player){
+				addKnower(player){
 					if(!this._knowers){
 						this._knowers = [];
 					}
@@ -36147,11 +36147,11 @@
 			}
 		},
 		//为牌添加知情者。
-		addCardKnowner:function(cards,players){
+		addCardKnower:function(cards,players){
 			if(get.itemtype(cards) == 'card'){
 				cards = [cards];
 			}
-			cards.forEach(card=>card.addKnowner(players));
+			cards.forEach(card=>card.addKnower(players));
 		},
 		//移除牌的所有知情者。
 		clearCardKnowers:function(cards){

--- a/game/game.js
+++ b/game/game.js
@@ -17968,12 +17968,10 @@
 					if(!event.chooseonly){
 						if(event.delay!==false){
 							var next=player.gain(event.cards,target,event.visibleMove?'give':'giveAuto','bySelf');
-							next.set('cardKnower',event.visibleMove?['everyone']:[target]);
 							event.done=next;
 						}
 						else{
 							var next=player.gain(event.cards,target,'bySelf');
-							next.set('cardKnower',event.visibleMove?['everyone']:[target]);
 							event.done=next;
 							target[event.visibleMove?'$give':'$giveAuto'](cards,player);
 							if(event.visibleMove) next.visible=true;
@@ -19262,9 +19260,6 @@
 								next.visible=true;
 							}
 							event.relatedLose=next;
-							if(event.cardKnower){
-								next.set('cardKnower',event.cardKnower);
-							}
 						}
 					}
 					else{


### PR DESCRIPTION
添加知情牌机制，用以辅助AI判断逻辑：
知情：若甲知道乙的手牌中包含这张牌，则认定甲是这张牌的知情人。

1、当牌被其他角色获得时，将添加原主为此牌的知情人。
2、当牌被展示或正面向上获取，或从判定区、弃牌堆、五谷丰登获取时，将添加所有角色（everyone）为此牌的知情人。

为card新增以下方法：
1、isKnownBy，判断角色是否对此牌的存在知情。
2、addKnower，为此牌增加知情人。
3、clearKnowers，清除此牌的知情人。

为game新增以下方法：
1、addCardKnower，批量为牌数组添加知情人。
2、clearCardKnowers，批量清除牌组的知情人。

为player新增以下方法：
1、getKnownCards，获取此角色被其他角色知情的牌。
2、hasKnownCards，判断此角色是否有被知情的牌。
3、isAllCardsKnown，判断此角色是否所有牌都被其他角色知情。

相关更新AI：
1、mayHaveSha、mayHaveShan添加知情逻辑。
2、lose事件后清除失去牌的知情信息。
3、gain事件后添加获得牌的知情信息。
4、观星时为牌堆顶、牌堆底的牌添加知情信息。
5、火攻时：若敌方所有牌我已知情，且敌方所有已有花色我都没有，则收益为0。

……其它AI待优化……