### PR TITLE
Add Promise-Async Methods for parts of `lib.init`

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -8375,19 +8375,56 @@
 			}
 		},
 		init:{
-			// Promise Method
+			/**
+			 * 部分函数的Promise版本
+			 */
 			promises:{
 				/**
 				 * Promise版的`lib.init.js`
+				 * 
+				 * @param {string} path - 文件路径
+				 * @param {string | string[]} [file] - 文件名或文件名组，忽略则直接读取`path`的内容
+				 * @returns {Promise<Event>}
 				 */
 				js:(path,file)=>new Promise((resolve,reject)=>lib.init.js(path,file,resolve,reject)),
+
+				/**
+				 * Promise版的`lib.init.css`
+				 * 
+				 * @param {string} path - 文件路径
+				 * @param {string | string[]} [file] - 文件名或文件名组，忽略则直接读取`path`的内容
+				 * @param {Element} [before] 新样式dom的位置
+				 * @returns {Promise<HTMLLinkElement>}
+				 */
 				css:(path,file,before)=>new Promise((resolve,reject)=>{
 					const style=lib.init.css(path,file,before);
 					style.addEventListener("load",()=>resolve(style));
 					style.addEventListener("error",reject);
 				}),
+
+				/**
+				 * Promise版的`lib.init.req`
+				 * 
+				 * @param {string} str - 要读取的地址
+				 * @param {string} [master]
+				 * @returns {Promise<ProgressEvent>}
+				 */
 				req:(str,master)=>new Promise((resolve,reject)=>lib.init.req(str,resolve,reject,master)),
-				json:(url)=>new Promise((resolve,reject)=>lib.init.js(url,resolve,reject)),
+
+				/**
+				 * Promise版的`lib.init.req`
+				 * 
+				 * @param {string} str - 要读取的地址
+				 * @param {string} [master]
+				 * @returns {Promise<ProgressEvent>}
+				 */
+				json:(url)=>new Promise((resolve,reject)=>lib.init.json(url,resolve,reject)),
+
+				/**
+				 * Promise版的`lib.init.sheet`
+				 * 
+				 * @returns {Promise<HTMLStyleElement>}
+				 */
 				sheet(){
 					return new Promise((resolve,reject)=>{
 						const style=lib.init.sheet.apply(lib.init,arguments);

--- a/game/game.js
+++ b/game/game.js
@@ -8412,11 +8412,10 @@
 				req:(str,master)=>new Promise((resolve,reject)=>lib.init.req(str,resolve,reject,master)),
 
 				/**
-				 * Promise版的`lib.init.req`
+				 * Promise版的`lib.init.json`
 				 * 
-				 * @param {string} str - 要读取的地址
-				 * @param {string} [master]
-				 * @returns {Promise<ProgressEvent>}
+				 * @param {string} url - 要读取的地址
+				 * @returns {Promise<object>}
 				 */
 				json:(url)=>new Promise((resolve,reject)=>lib.init.json(url,resolve,reject)),
 

--- a/game/game.js
+++ b/game/game.js
@@ -8375,6 +8375,27 @@
 			}
 		},
 		init:{
+			// Promise Method
+			promises:{
+				/**
+				 * Promise版的`lib.init.js`
+				 */
+				js:(path,file)=>new Promise((resolve,reject)=>lib.init.js(path,file,resolve,reject)),
+				css:(path,file,before)=>new Promise((resolve,reject)=>{
+					const style=lib.init.css(path,file,before);
+					style.addEventListener("load",()=>resolve(style));
+					style.addEventListener("error",reject);
+				}),
+				req:(str,master)=>new Promise((resolve,reject)=>lib.init.req(str,resolve,reject,master)),
+				json:(url)=>new Promise((resolve,reject)=>lib.init.js(url,resolve,reject)),
+				sheet(){
+					return new Promise((resolve,reject)=>{
+						const style=lib.init.sheet.apply(lib.init,arguments);
+						style.addEventListener("load",()=>resolve(style));
+						style.addEventListener("error",reject);
+					})
+				}
+			},
 			init:function(){
 				if(typeof __dirname==='string'&&__dirname.length){
 					var dirsplit=__dirname.split('/');


### PR DESCRIPTION
为`lib.init.js`、`lib.init.css`、`lib.init.req`、`lib.init.json`和`lib.init.sheet`增加相应的`Promise`版本，用于异步函数直接`await`和部分情况的链式调用和对象传递。

所有添加方式的返回值均取自原有函数，除部分函数的返回值为对应函数所添加的DOM元素。