### PR TITLE
Add `lib.channel` to give a method of message receiving.

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -357,11 +357,32 @@
 		/**
 		 * **无名杀频道推送机制**
 		 * 
-		 * 模拟`Golang`的`channel`，仅保留部分特征
+		 * 鉴于`Javascript`的特性及自身对所需功能的思考，这是一个参考`Golang`的`channel`设计的、完全和`go channel`不一样的异步消息传递对象
+		 * 
+		 * 当且仅当接收方和发送方均存在时进行消息传递，完全保证信息传递的单一性（发送方/接收方一旦确定则无法更改）和准确性（发送方必然将消息发送给接收方）
+		 * 
+		 * 若存在发送方/接收方时调用`send`/`receive`，将报错
+		 * 
+		 * 若需要异步/不报错发送信息，请等待`lib.actor`
 		 * 
 		 * @template T
+		 * @example
+		 * // 创建一个频道
+		 * const channel = new lib.channel();
+		 * 
+		 * // 从某个角落接收channel发出的消息，若无消息则等待
+		 * const message = await channel.receive();
+		 * 
+		 * // 从某个角落向channel发消息，若无消息接收则等待
+		 * await channel.send(item);
 		 */
 		channel: class {
+			/**
+			 * @template TValue
+			 * @callback PromiseResolve
+			 * @param {TValue} value
+			 * @returns {void}
+			 */
 			constructor() {
 				/**
 				 * @type {"active" | "receiving" | "sending"}
@@ -369,13 +390,15 @@
 				this.status = "active";
 
 				/**
-				 * @type {Promise<T> | [T, Promise<void>] | null}
+				 * @type {PromiseResolve<T> | [T, PromiseResolve<void>] | null}
 				 */
 				this._buffer = null;
 			}
 
 			/**
-			 * @param {T} value
+			 * 向该频道发送消息，在消息未被接受前将等待
+			 * 
+			 * @param {T} value - 要发送的消息
 			 * @returns {Promise<void>}
 			 */
 			send(value) {
@@ -387,7 +410,7 @@
 							break;
 						case "receiving":
 							/**
-							 * @type {Promise<T>}
+							 * @type {PromiseResolve<T>}
 							 */
 							const buffer = this._buffer;
 							this._buffer = null;
@@ -404,7 +427,9 @@
 			}
 
 			/**
-			 * @returns {Promise<T>}
+			 * 接收频道所发送的消息，若无消息发送则等待
+			 * 
+			 * @returns {Promise<T>} 接收到的消息
 			 */
 			receive() {
 				return new Promise((resolve, reject) => {
@@ -415,7 +440,7 @@
 							break;
 						case "sending":
 							/**
-							 * @type {[T, Promise<void>]}
+							 * @type {[T, PromiseResolve<void>]}
 							 */
 							const buffer = this._buffer;
 							this._buffer = null;


### PR DESCRIPTION
我们为无名杀添加了一个`lib.channel`。这是一个参考Go语言的`channel`设计的异步消息传递模块。话虽如此，`lib.channel`的使用方式几乎与Go的`channel`无关。

`lib.channel`能确保发送方和接收方在等待对方时阻塞各自的协程，及发送方与接收方在任何一方缺席时等待对面，而在双方均存在时同时继续进行。这以无法并发的代价保证了两个协程之间必然能正确的传递所需的消息。

具体方式请参考`lib.channel`的文档；不过由于Javascript的机制，我们仍需要`await`来确保消息阻塞。