### PR TITLE
Rewrite `lib.announce` for new version && Provide announce time for theme change.

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -1563,25 +1563,30 @@ new Promise(resolve=>{
 								node.menu=ui.create.div(node,'','<div></div><div></div><div></div><div></div>');
 							}
 						},
-						onclick:function(theme){
+						onclick:gnc.of(function*(theme){
 							game.saveConfig('theme',theme);
 							ui.arena.hide();
 							lib.init.background();
 							if(lib.config.autostyle){
-								if(theme=='simple'){
-									lib.configMenu.appearence.config.player_border.onclick('slim');
+								if(theme === "simple"){
+									lib.configMenu.appearence.config.player_border.onclick("slim");
 								}
 								else{
-									lib.configMenu.appearence.config.player_border.onclick('normal');
+									lib.configMenu.appearence.config.player_border.onclick("normal");
 								}
 							}
-							setTimeout(function(){
-								var theme=ui.css.theme;
-								ui.css.theme=lib.init.css(lib.assetURL+'theme/'+lib.config.theme,'style');
-								theme.remove();
-								setTimeout(function(){ui.arena.show();},100);
-							},500);
-						}
+							lib.announce.publish("Noname.Apperaence.Theme.onChanging", theme);
+							yield new Promise(resolve => setTimeout(resolve, 500));
+
+							const deletingTheme = ui.css.theme;
+							ui.css.theme=lib.init.css(lib.assetURL+'theme/'+lib.config.theme,'style');
+							deletingTheme.remove();
+							lib.announce.publish("Noname.Apperaence.Theme.onChanged", theme);
+							yield new Promise(resolve => setTimeout(resolve, 100));
+
+							ui.arena.show();
+							lib.announce.publish("Noname.Apperaence.Theme.onChangeFinished", theme);
+						})
 					},
 					layout:{
 						name:'布局',

--- a/game/src/lib/announce.js
+++ b/game/src/lib/announce.js
@@ -1,0 +1,133 @@
+// TODO: 补充一点描述
+
+/**
+ * @type {WeakMap<AnnounceSubscriber, EventTarget>}
+ */
+const vm = new WeakMap();
+
+/**
+ *
+ */
+export class Announce {
+	/**
+	 * @type {EventTarget}
+	 */
+	#handler;
+
+	/**
+	 * @type {WeakMap<function(any): void, AnnounceSubscriber>}
+	 */
+	#records;
+
+	constructor() {
+		this.#handler = new EventTarget();
+		this.#records = new WeakMap();
+	}
+
+	/**
+	 * 推送任意数据给所有监听了指定事件的订阅者，并返回给定的数据
+	 *
+	 * 若不存在订阅指定事件的订阅者，则推送的数据将无意义
+	 *
+	 * @template T
+	 * @param {string} name - 要推送事件的名称
+	 * @param {T} values - 要推送的数据
+	 * @returns {T}
+	 */
+	publish(name, values) {
+		this.#handler.dispatchEvent(new CustomEvent(name, {
+			detail: [values, name]
+		}));
+		return values;
+	}
+
+	/**
+	 * 订阅给定名字的事件，并返回给定的函数
+	 *
+	 * 在事件触发时执行给定的函数
+	 *
+	 * 给定的函数将被存储至当前实例中，用于取消订阅时获取
+	 *
+	 * @template T
+	 * @param {string} name - 要订阅事件的名称
+	 * @param {(values: T) => void} method - 事件触发时执行的函数
+	 * @returns {(values: T) => void}
+	 */
+	subscribe(name, method) {
+		let subscriber;
+		if (this.#records.has(method))
+			subscriber = this.#records.get(method);
+		else {
+			subscriber = new AnnounceSubscriber(method, this.#handler);
+			this.#records.set(method, subscriber);
+		}
+		subscriber.subscribe(name);
+		return method;
+	}
+
+	/**
+	 * 取消指定事件某一个函数的订阅，并返回该函数
+	 *
+	 * 给定的函数将不再于事件触发时执行，其余同事件需触发的函数不受限制
+	 *
+	 * @template T
+	 * @param {string} name - 要取消订阅事件的名称
+	 * @param {(values: T) => void} method - 订阅指定事件的函数
+	 * @returns {(values: T) => void}
+	 */
+	unsubscribe(name, method) {
+		if (this.#records.has(method)) {
+			const subscriber = this.#records.get(method);
+			subscriber.unsubscribe(name);
+			if (subscriber.isEmpty)
+				this.#records.delete(method);
+		}
+		return method;
+	}
+}
+
+/**
+ * @template T
+ */
+class AnnounceSubscriber {
+	/**
+	 * @type {function(CustomEvent): void}
+	 */
+	#content;
+
+	/**
+	 * @type {string[]}
+	 */
+	#listening
+
+	/**
+	 *
+	 * @param {function(T, string): void} content
+	 * @param {EventTarget} target
+	 */
+	constructor(content, target) {
+		this.#content = function (event) {
+			content(event.detail[0], event.detail[1]);
+		}
+		this.#listening = [];
+
+		vm.set(this, target);
+	}
+
+	get isEmpty() {
+		return this.#listening.length <= 0;
+	}
+
+	/**
+	 * @param {string} name
+	 */
+	subscribe(name) {
+		vm.get(this).addEventListener(name, this.#content);
+		this.#listening.add(name);
+	}
+
+	unsubscribe() {
+		vm.get(this).removeEventListener(name, this.#content);
+		this.#listening.remove(name);
+	}
+}

--- a/game/src/lib/announce.js
+++ b/game/src/lib/announce.js
@@ -12,16 +12,28 @@ export class Announce {
 	/**
 	 * @type {EventTarget}
 	 */
-	#handler;
+	#eventTarget;
 
 	/**
 	 * @type {WeakMap<function(any): void, AnnounceSubscriber>}
 	 */
 	#records;
 
-	constructor() {
-		this.#handler = new EventTarget();
-		this.#records = new WeakMap();
+	/**
+	 * @type {FunctionConstructor}
+	 */
+	#SubscriberType;
+
+	/**
+	 *
+	 * @param {EventTarget} eventTarget
+	 * @param {WeakMap<function(any): void, AnnounceSubscriber>} records
+	 * @param {FunctionConstructor} [SubscriberType]
+	 */
+	constructor(eventTarget, records, SubscriberType = AnnounceSubscriber) {
+		this.#eventTarget = eventTarget;
+		this.#records = records;
+		this.#SubscriberType = SubscriberType;
 	}
 
 	/**
@@ -35,7 +47,7 @@ export class Announce {
 	 * @returns {T}
 	 */
 	publish(name, values) {
-		this.#handler.dispatchEvent(new CustomEvent(name, {
+		this.#eventTarget.dispatchEvent(new CustomEvent(name, {
 			detail: [values, name]
 		}));
 		return values;
@@ -58,7 +70,7 @@ export class Announce {
 		if (this.#records.has(method))
 			subscriber = this.#records.get(method);
 		else {
-			subscriber = new AnnounceSubscriber(method, this.#handler);
+			subscriber = new this.#SubscriberType(method, this.#eventTarget);
 			this.#records.set(method, subscriber);
 		}
 		subscriber.subscribe(name);


### PR DESCRIPTION
我们参考了[rxjs](https://rxjs.dev/)的思路，并结合`lib.announce`自身的需求，重写了`lib.announce`的内部逻辑，使每个函数都有其对应的订阅对象，从而方便管理事件订阅；订阅对象和`Announce`不存在依赖关系：`Announce`可自行确定需要的订阅对象，订阅对象也仅需要监听所给的`EventTarget`。话虽如此，订阅对象主要以`Announce`的需求而写，可能并不适合于其余情况；此外，`Announce`的构造函数也需要给与`EventTarget`和记录函数与订阅对象的记录器。

> 目前版本未使用重构后的`lib.annonuce`，需新版本转`ES Module`后再替换

同时，我们为切换主题增加了对应的Announce时机。现在存在三个时机用于扩展自行处理主题相关的时机：

- `Noname.Apperaence.Theme.onChanging`: 此时主题还没进行切换，`ui.css.theme`仍是原主题的样式，仅仅做了切换主题的初始操作
- `Noname.Apperaence.Theme.onChanged`: 此时主题已经完成了切换，`ui.css.theme`已经是新主题的样式，还没有显示游戏区域
- `Noname.Apperaence.Theme.onChangeFinished` 此时游戏区域已经显示出来，主题替换也宣告结束

每个事件的值均为当前主题的名称，可灵活运用这三个时机来进行扩展自身的主题适配。