### PR TITLE
增加异步content以及GameEvent#toPromise，郭嘉和二张作为测试

### DIFF
--- a/character/shenhua.js
+++ b/character/shenhua.js
@@ -3952,13 +3952,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(target.isMin()) return false;
 					return player!=target&&target.canEquip(card);
 				},
-				content2:function(){
-					target.equip(cards[0]);
-					player.draw();
-				},
 				async content(event, trigger, player){
 					await event.target.promises.equip(event.cards[0]);
-					game.log('老子装完了，还没摸牌')
 					await player.promises.draw();
 				},
 				discard:false,

--- a/character/shenhua.js
+++ b/character/shenhua.js
@@ -3952,9 +3952,14 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(target.isMin()) return false;
 					return player!=target&&target.canEquip(card);
 				},
-				content:function(){
+				content2:function(){
 					target.equip(cards[0]);
 					player.draw();
+				},
+				async content(event, trigger, player){
+					await event.target.promises.equip(event.cards[0]);
+					game.log('老子装完了，还没摸牌')
+					await player.promises.draw();
 				},
 				discard:false,
 				lose:false,

--- a/character/standard.js
+++ b/character/standard.js
@@ -588,90 +588,16 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				filter:function(event){
 					return (event.num>0)
 				},
-				content2:function(){
-					'step 0'
-					event.count=trigger.num;
-					'step 1'
-					event.count--;
-					event.cards=game.cardsGotoOrdering(get.cards(2)).cards;
-					if(_status.connectMode) game.broadcastAll(function(){_status.noclearcountdown=true});
-					event.given_map={};
-					'step 2'
-					if(event.cards.length>1){
-						player.chooseCardButton('遗计：请选择要分配的牌',true,event.cards,[1,event.cards.length]).set('ai',function(button){
-							if(ui.selected.buttons.length==0) return 1;
-							return 0;
-						});
-					}
-					else if(event.cards.length==1){
-						event._result={links:event.cards.slice(0),bool:true};
-					}
-					else{
-						event.finish();
-					}
-					'step 3'
-					if(result.bool){
-						event.cards.removeArray(result.links);
-						event.togive=result.links.slice(0);
-						player.chooseTarget('选择一名角色获得'+get.translation(result.links),true).set('ai',function(target){
-							var att=get.attitude(_status.event.player,target);
-							if(_status.event.enemy){
-								return -att;
-							}
-							else if(att>0){
-								return att/(1+target.countCards('h'));
-							}
-							else{
-								return att/100;
-							}
-						}).set('enemy',get.value(event.togive[0],player,'raw')<0);
-					}
-					'step 4'
-					if(result.targets.length){
-						var id=result.targets[0].playerid,map=event.given_map;
-						if(!map[id]) map[id]=[];
-						map[id].addArray(event.togive);
-					}
-					if(cards.length>0) event.goto(2);
-					'step 5'
-					if(_status.connectMode){
-						game.broadcastAll(function(){delete _status.noclearcountdown;game.stopCountChoose()});
-					}
-					var list=[];
-					for(var i in event.given_map){
-						var source=(_status.connectMode?lib.playerOL:game.playerMap)[i];
-						player.line(source,'green');
-						list.push([source,event.given_map[i]]);
-					}
-					game.loseAsync({
-						gain_list:list,
-						giver:player,
-						animate:'draw',
-					}).setContent('gaincardMultiple');
-					'step 6'
-					if(event.count>0&&player.hasSkill(event.name)&&!get.is.blocked(event.name,player)){
-						player.chooseBool(get.prompt2(event.name)).set('frequentSkill',event.name);
-					}
-					else event.finish();
-					'step 7'
-					if(result.bool){
-						player.logSkill(event.name);
-						event.goto(1);
-					}
-				},
 				async content(event, trigger, player) {
-					console.log('step 0');
 					event.count = trigger.num;
 					while (event.count > 0) {
-						console.log('step 1');
 						event.count--;
 						const { cards } = await game.cardsGotoOrdering(get.cards(2)).toPromise();
 						if (_status.connectMode) game.broadcastAll(function () { _status.noclearcountdown = true });
 						event.given_map = {};
 
-						if (!cards.length) return event.finish();
+						if (!cards.length) return;
 						do {
-							console.log('step 2');
 							const { result: { bool, links } } =
 								cards.length == 1 ?
 									{ result: { links: cards.slice(0), bool: true } } :
@@ -680,8 +606,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 											if (ui.selected.buttons.length == 0) return 1;
 											return 0;
 										});
-							if (!bool) return event.finish();
-							console.log('step 3');
+							if (!bool) return;
 							cards.removeArray(links);
 							event.togive = links.slice(0);
 							const { result: { targets } } = await player.promises.chooseTarget('选择一名角色获得' + get.translation(links), true)
@@ -698,7 +623,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 									}
 								})
 								.set('enemy', get.value(event.togive[0], player, 'raw') < 0);
-							console.log('step 4');
 							if (targets.length) {
 								const id = targets[0].playerid,
 									map = event.given_map;
@@ -706,7 +630,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								map[id].addArray(event.togive);
 							}
 						} while (cards.length > 0);
-						console.log('step 5');
 						if (_status.connectMode) {
 							game.broadcastAll(function () { delete _status.noclearcountdown; game.stopCountChoose() });
 						}
@@ -721,15 +644,13 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							giver: player,
 							animate: 'draw',
 						}).setContent('gaincardMultiple').toPromise();
-						console.log('step 6');
 						if (event.count > 0 && player.hasSkill(event.name) && !get.is.blocked(event.name, player)) {
 							const { result: { bool: repeat } } = await player.promises.chooseBool(get.prompt2(event.name)).set('frequentSkill', event.name);
-							console.log('step 7');
 							if (repeat) {
 								player.logSkill(event.name);
-							}
+							} else return;
 						}
-						else return event.finish();
+						else return;
 					}
 				},
 				ai:{

--- a/character/standard.js
+++ b/character/standard.js
@@ -586,17 +586,18 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				trigger:{player:'damageEnd'},
 				frequent:true,
 				filter:function(event){
-					return (event.num>0)
+					return event.num>0;
 				},
 				async content(event, trigger, player) {
 					event.count = trigger.num;
+					// event.goto -> while
 					while (event.count > 0) {
 						event.count--;
 						const { cards } = await game.cardsGotoOrdering(get.cards(2)).toPromise();
 						if (_status.connectMode) game.broadcastAll(function () { _status.noclearcountdown = true });
 						event.given_map = {};
-
 						if (!cards.length) return;
+						// event.goto -> do while
 						do {
 							const { result: { bool, links } } =
 								cards.length == 1 ?

--- a/character/standard.js
+++ b/character/standard.js
@@ -644,7 +644,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							gain_list: list,
 							giver: player,
 							animate: 'draw',
-						}).setContent('gaincardMultiple').toPromise();
+						}).toPromise().setContent('gaincardMultiple');
 						if (event.count > 0 && player.hasSkill(event.name) && !get.is.blocked(event.name, player)) {
 							const { result: { bool: repeat } } = await player.promises.chooseBool(get.prompt2(event.name)).set('frequentSkill', event.name);
 							if (repeat) {

--- a/game/game.js
+++ b/game/game.js
@@ -32131,7 +32131,6 @@ new Promise(resolve=>{
 						event.resolve=resolve;
 						//如果父级事件也是一个异步的话，那应该立即执行这个事件的
 						if(_status.event.next.includes(event)&&_status.event.content instanceof AsyncFunction){
-							// console.log(event, '的父级事件也是一个异步,立即执行这个事件');
 							if (_status.event != event) {
 								event.parent = _status.event;
 								_status.event = event;
@@ -41409,13 +41408,6 @@ new Promise(resolve=>{
 					if(lib.status.dateDelaying){
 						lib.status.dateDelayed+=lib.getUTC(new Date())-lib.getUTC(lib.status.dateDelaying);
 						delete lib.status.dateDelaying;
-					}
-					if (belongAsyncEvent) {
-						console.log('-----------------------');
-						console.log(event);
-						console.log('event.finished', event.finished);
-						console.log('event.after:', [...event.after]);
-						console.log('event.next:', [...event.next]);
 					}
 					if(event.next.length>0){
 						var next=event.next.shift();

--- a/game/game.js
+++ b/game/game.js
@@ -32114,7 +32114,9 @@ new Promise(resolve=>{
 				}
 			},
 			/**
-			 * 对于事件Promise化后，需要既能使用await等待事件完成，
+			 * 将事件Promise化以使用async异步函数来执行事件。
+			 * 
+			 * 事件Promise化后，需要既能使用await等待事件完成，
 			 * 又需要在执行之前对事件进行配置。
 			 * 
 			 * 所以这个类的实例集成了事件和Promise二者的所有属性，
@@ -32128,9 +32130,9 @@ new Promise(resolve=>{
 			 * ```js
 			 * await game.xxx().toPromise().setContent('yyy').set(zzz, 'i');
 			 * ```
-			 * 使用player.promises.xxx()函数将对于player的普通事件转换为异步事件：
+			 * 使用player.promises.xxx()函数将对于player的普通事件转换为异步事件并执行：
 			 * ```js
-			 * await player.draw(2);
+			 * await player.promises.draw(2);
 			 * game.log('等待', player, '摸牌完成执行log');
 			 * ```
 			 */

--- a/game/game.js
+++ b/game/game.js
@@ -32188,7 +32188,7 @@ new Promise(resolve=>{
 							return Reflect.set(event,prop,newValue);
 						},
 						deleteProperty(target,prop){
-							return Reflect.set(event,prop);
+							return Reflect.deleteProperty(event,prop);
 						},
 						defineProperty(target,prop,attributes){
 							return Reflect.defineProperty(event,prop,attributes);


### PR DESCRIPTION
[实现此议题的异步函数](https://github.com/libccy/noname/issues/654)

注: async content中无法使用跳步(event.goto，event.redo)等函数。

注2: async content中不需要调用event.finish，直接使用return结束函数执行即可

使用示例:
```js
skill = {
    // 二张直谏例子
    async content(event, trigger, player){
        await event.target.promises.equip(event.cards[0]);
        game.log('装完了，还没摸牌')
        await player.promises.draw();
    },
}

skill = {
    // 普通event转promise例子(郭嘉遗计)
    async content(event, trigger, player){
        // 事件函数(参数).toPromise().set(xx).setContent(yy);
        await game.loseAsync({
            gain_list: list,
            giver: player,
            animate: 'draw',
        }).toPromise().setContent('gaincardMultiple');
    },
}
```

新增类lib.element.GameEventPromise:
对于事件Promise化后，需要既能使用await等待事件完成，又需要在执行之前对事件进行配置。
所以这个类的实例集成了事件和Promise二者的所有属性，且Promise的原有属性无法被修改，一切对这个类实例的属性修改，删除，再配置等操作都会转发到事件对应的属性中。
使用示例：
使用toPromise()函数将普通事件转换为异步事件：
```js
await game.xxx().toPromise().setContent('yyy').set(zzz, 'i');
```
使用player.promises.xxx()函数将对于player的普通事件转换为异步事件：
```js
await player.promises.draw(2);
game.log('等待', player, '摸牌完成执行log');
```
新增GameEvent#toPromise方法，把一个事件转换为异步事件，可以使用await等待事件执行完成。

修改game#loop方法，接受一个异步事件参数(lib.element.GameEventPromise类是实例)，来执行这个事件的所有内容。