### PR TITLE
AI性能优化

### DIFF
--- a/noname/ai/basic.js
+++ b/noname/ai/basic.js
@@ -86,11 +86,13 @@ export class Basic extends Uninstantable {
 				if (ui.selected.cards.length == 0) return true;
 				j = 0;
 				CacheContext.setCacheContext(new CacheContext());
+				CacheContext.setInCacheEnvironment(true);
 				for (i = 0; i < ui.selected.cards.length; i++) {
 					effect = check(ui.selected.cards[i]);
 					if (effect < 0) j -= Math.sqrt(-effect);
 					else j += Math.sqrt(effect);
 				}
+				CacheContext.setInCacheEnvironment(false);
 				CacheContext.removeCacheContext();
 				return (j > 0);
 			}
@@ -109,6 +111,7 @@ export class Basic extends Uninstantable {
 			// });
 			var ix = 0;
 			CacheContext.setCacheContext(new CacheContext());
+			CacheContext.setInCacheEnvironment(true);
 			var checkix = check(cards[0], cards2);
 			for (i = 1; i < cards.length; i++) {
 				var checkixtmp = check(cards[i], cards2);
@@ -119,10 +122,12 @@ export class Basic extends Uninstantable {
 			}
 			if (check(cards[ix]) <= 0) {
 				if (!forced || ok) {
+					CacheContext.setInCacheEnvironment(false);
 					CacheContext.removeCacheContext();
 					return ok;
 				}
 			}
+			CacheContext.setInCacheEnvironment(false);
 			CacheContext.removeCacheContext();
 			if (typeof cards[ix] == 'string') {
 				ui.click.skill(cards[ix]);
@@ -168,11 +173,13 @@ export class Basic extends Uninstantable {
 			if (range[1] <= -1) {
 				j = 0;
 				CacheContext.setCacheContext(new CacheContext());
+				CacheContext.setInCacheEnvironment(true);
 				for (i = 0; i < ui.selected.targets.length; i++) {
 					effect = check(ui.selected.targets[i]);
 					if (effect < 0) j -= Math.sqrt(-effect);
 					else j += Math.sqrt(effect);
 				}
+				CacheContext.setInCacheEnvironment(false);
 				CacheContext.removeCacheContext();
 				return (j > 0);
 			}
@@ -189,6 +196,7 @@ export class Basic extends Uninstantable {
 			// });
 			let ix = 0;
 			CacheContext.setCacheContext(new CacheContext());
+			CacheContext.setInCacheEnvironment(true);
 			let checkix = check(targets[0], targets2);
 			for (i = 1; i < targets.length; i++) {
 				let checkixtmp = check(targets[i], targets2);
@@ -199,10 +207,12 @@ export class Basic extends Uninstantable {
 			}
 			if (check(targets[ix]) <= 0) {
 				if (!forced || ok) {
+					CacheContext.setInCacheEnvironment(false);
 					CacheContext.removeCacheContext();
 					return ok;
 				}
 			}
+			CacheContext.setInCacheEnvironment(false);
 			CacheContext.removeCacheContext();
 			targets[ix].classList.add('selected');
 			ui.selected.targets.add(targets[ix]);

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -7496,7 +7496,7 @@ export class Game extends Uninstantable {
 		const argumentArray = Array.from(arguments), name = argumentArray[argumentArray.length - 2];
 		let skills = argumentArray[argumentArray.length - 1];
 		if (typeof skills.getModableSkills == 'function') {
-			skills = skills.getModableSkills(_status.event.useCache === true);
+			skills = skills.getModableSkills();
 		} else if (typeof skills.getSkills == 'function') {
 			skills = skills.getSkills().concat(lib.skill.global);
 			game.expandSkills(skills);
@@ -7510,8 +7510,8 @@ export class Game extends Uninstantable {
 		skills.forEach(value => {
 			var mod = get.info(value).mod[name];
 			if (!mod) return;
-			const result = mod.apply(this, arg);
-			if (typeof arg[arg.length - 1] != 'object' && result != undefined) arg[arg.length - 1] = result;
+			const result = mod.call(this,...arg);
+			if (result != undefined && typeof arg[arg.length - 1] != 'object') arg[arg.length - 1] = result;
 		});
 		return arg[arg.length - 1];
 	}


### PR DESCRIPTION
1、修改Player成员方法的缓存方式，不再传入代理，而用新增的CacheContext.inject方法，将多个方法注册为可缓存方法。可缓存方法仅在CacheContext._cacheEnvironment为true时生效，且只有在一个缓存上下文中才会返回相同的缓存值。
2、修改hasValueTarget的实现方式，当牌只能选择单个目标时，只要检测到有益目标就直接返回true，不进行后续计算。
3、修改部分方法（如checkMod）里的apply调用为call调用。
4、修改effect、effect_use等方法中的部分调用，改为调用缓存方法。