### PR TITLE
W.I.P | Fix a group of bugs of onload before cordova.

### DIFF
--- a/noname/init/cordova.js
+++ b/noname/init/cordova.js
@@ -7,7 +7,6 @@ import { UI as ui } from '../ui/index.js';
 import { nonameInitialized } from '../util/index.js';
 
 export async function cordovaReady() {
-	lib.path = (await import('../library/path.js')).default;
 	if (lib.device == 'android') {
 		document.addEventListener("pause", function () {
 			if (!_status.paused2 && (typeof _status.event.isMine == 'function' && !_status.event.isMine())) {


### PR DESCRIPTION
# Progress
- 等待有效的测试

---

在一开始，无名杀手机端加载`cordova`的时机是`window.onload`，在拆分时也如此造做；由于`cordova`对于无名杀来说是手机端必然执行的代码，故跟手机端需要额外执行的代码均被放置在`cordovaReady`下。故此时的逻辑顺序是: 

- `await window.onload`
- `await cordovaReady()`
- `...(无名杀剩余逻辑代码)`

然而在考虑优化异步效率时，未考虑到扩展对`lib.path`的需求，将等待`window.onload`的时机提后到所有模块均加载完毕，故逻辑顺序变成了: 

- `window.onload(无名杀剩余逻辑代码)`
- `...`
- `await window.onload`
- ?

导致了存在扩展在`cordova`加载前便开始加载，从而使扩展无法正常读取到`lib.path`。

故我们首先将656行的`await waitDomLoad;`提前到550行，保证`window.onload`的内容一定位于扩展加载前执行完毕。

基于此，我们注意到，`cordova`的加载并不依赖`window.onload`，故我们令cordova的加载脱离`window.onload`
