### PR TITLE
[WIP] “获得/失去技能时”的时机

### DIFF
--- a/character/clan.js
+++ b/character/clan.js
@@ -441,9 +441,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					else event.goto(2);
 					'step 1'
 					if(result.bool){
-						player.removeSkill('clanbaozu');
-						player.popup('保族');
-						game.log(player,'失去了技能','#g【保族】');
+						player.removeSkills('clanbaozu');
 					}
 					else player.loseHp();
 					'step 2'
@@ -1542,7 +1540,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							return player.getStorage('clanfangzhen_remove').includes(game.roundNumber);
 						},
 						content(){
-							player.removeSkill('clanfangzhen');
+							player.removeSkills('clanfangzhen');
 						}
 					}
 				}
@@ -1812,9 +1810,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						event.finish();
 					}
 					'step 6'
-					player.removeSkill(result.control);
-					player.popup(result.control);
-					game.log(player,'失去了技能','#g【'+get.translation(result.control)+'】');
+					player.removeSkills(result.control);
 				},
 				ai:{
 					expose:0.1,
@@ -2392,9 +2388,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					});
 					'step 1'
 					if(result.control!='cancel2'){
-						player.removeSkill(result.control);
-						player.popup(result.control);
-						game.log(player,'失去了技能','#g【'+get.translation(result.control)+'】');
+						player.removeSkills(result.control);
 					}
 					else{
 						player.loseHp();

--- a/character/collab.js
+++ b/character/collab.js
@@ -618,7 +618,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.addMark('dcbianzhuang',1,false);
 						if(player.countMark('dcbianzhuang')>2){
 							player.storage.dcbianzhuang_inited=true;
-							player.reinit('zhutiexiong','wu_zhutiexiong');
+							player.reinitCharacter('zhutiexiong','wu_zhutiexiong');
 						}
 					}
 				},

--- a/character/ddd.js
+++ b/character/ddd.js
@@ -2812,8 +2812,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								});
 							}
 							else{
-								game.log(player,'失去了技能','#g【齐策】');
-								player.removeSkill('dddqice');
+								player.removeSkills('dddqice');
 								event.finish();
 							}
 							'step 1'
@@ -3165,8 +3164,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					else{
 						if(!targets.includes(player)) player.loseMaxHp();
 						if(targets.length==1){
-							player.removeSkill('dddxiaheng');
-							game.log(player,'失去了技能','#g【侠横】');
+							player.removeSkills('dddxiaheng');
 						}
 					}
 					'step 5'
@@ -3272,8 +3270,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}).setContent('gaincardMultiple');
 					if(!lose) event.finish();
 					'step 5'
-					player.removeSkill('dddfengzheng');
-					game.log(player,'失去了技能','#g【丰政】');
+					player.removeSkills('dddfengzheng');
 				},
 				subSkill:{
 					global:{
@@ -4435,8 +4432,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						// 	return event.source&&event.source.isIn()&&event.source.getEquips(1).length>0;
 						// },
 						content(){
-							player.removeSkill('dddxiaoxing');
-							game.log(player,'失去了技能','#g【枭行】');
+							player.removeSkills('dddxiaoxing');
 						},
 						content_old(){
 							'step 0'
@@ -4448,8 +4444,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							if(result.bool){
 								trigger.source.logSkill('dddxiaoxing',player);
 								trigger.source.disableEquip(1);
-								player.removeSkill('dddxiaoxing');
-								game.log(player,'失去了技能','#g【枭行】');
+								player.removeSkills('dddxiaoxing');
 							}
 						}
 					}
@@ -4541,8 +4536,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.gain(cards,'log');
 					}
 					'step 5'
-					player.removeSkill('dddlangzhi');
-					game.log(player,'失去了技能','#g【狼志】');
+					player.removeSkills('dddlangzhi');
 					event.finish();
 					'step 6'
 					game.broadcastAll('closeDialog',event.videoId);
@@ -4652,8 +4646,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					else event.finish();
 					'step 2'
-					player.removeSkill('dddfuyi');
-					game.log(player,'失去了技能','#g【附义】');
+					player.removeSkills('dddfuyi');
 				},
 				subSkill:{
 					sha:{
@@ -5288,8 +5281,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					else event.finish();
 					'step 3'
 					if(target.isIn()){event.finish(); return};
-					player.removeSkill('dddbailei');
-					game.log(player,'失去了技能','#g【拜泪】');
+					player.removeSkills('dddbailei');
 				},
 				subSkill:{
 					animate:{

--- a/character/ddd.js
+++ b/character/ddd.js
@@ -4610,7 +4610,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					else event.finish();
 					'step 2'
 					var skill=result.control;
-					player.addSkillLog(skill);
+					player.addSkills(skill);
 				},
 				content_old(){
 					'step 0'
@@ -4648,9 +4648,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							player.draw(3);
 						}
 						else event.finish();
-						for(var i of skills){
-							player.addSkillLog(i);
-						}
+						player.addSkills(skills);
 					}
 					else event.finish();
 					'step 2'

--- a/character/diy.js
+++ b/character/diy.js
@@ -4625,7 +4625,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content(){
 					'step 0'
 					player.awakenSkill('yukito_yaxiang');
-					player.reinit('key_yukito','key_crow');
+					player.reinitCharacter('key_yukito', 'key_crow', false);
 					'step 1'
 					if(target.hp<3) target.recover(3-target.hp);
 					'step 2'
@@ -7815,9 +7815,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.recover(num);
 					player.draw(num);
 					if(_status.characterlist&&_status.characterlist.includes('key_midori')){
-						player.reinit('key_mio','key_midori',false);
-						_status.characterlist.remove('key_midori');
-						_status.characterlist.add('key_mio');
+						player.reinitCharacter('key_mio','key_midori', false);
 					}
 				},
 			},
@@ -7890,9 +7888,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.recover(num);
 					player.draw(num);
 					if(_status.characterlist&&_status.characterlist.includes('key_mio')){
-						player.reinit('key_midori','key_mio',false);
-						_status.characterlist.remove('key_mio');
-						_status.characterlist.add('key_midori');
+						player.reinitCharacter('key_midori', 'key_mio', false);
 					}
 				},
 			},
@@ -10754,7 +10750,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content(){
 					'step 0'
 					player.awakenSkill('umi_qihuan');
-					player.reinit('key_umi','key_umi2');
+					player.reinitCharacter('key_umi', 'key_umi2', false);
 					player.recover(game.countGroup()||1);
 					if(!game.dead.length) event.finish();
 					'step 1'

--- a/character/diy.js
+++ b/character/diy.js
@@ -1774,12 +1774,12 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							player.awakenSkill('tomoyo_zhengfeng');
 							player.loseMaxHp();
 							'step 1'
-							player.removeSkill('tomoyo_wuwei');
+							player.removeSkills('tomoyo_wuwei');
 							'step 2'
 							player.draw(2);
 							player.recover();
 							'step 3'
-							player.addSkill('tomoyo_changshi');
+							player.addSkills('tomoyo_changshi');
 						},
 					},
 				},
@@ -2195,12 +2195,12 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				multiline:true,
 				line:{color:[253, 153, 182]},
 				content(){
-					game.countPlayer(function(current){
+					game.filterPlayer().sortBySeat().forEach(function(current){
 						if(!targets.includes(current)){
-							current.removeSkill('seira_yinyuan');
+							current.removeSkills('seira_yinyuan');
 						}
 						else{
-							current.addSkillLog('seira_yinyuan');
+							current.addSkills('seira_yinyuan');
 						}
 					});
 					game.delayx();
@@ -2350,7 +2350,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							player.draw(2);
 							player.markAuto('nsxingyun',[lib.skill.nsxingyun.getSixiang(trigger.card)]);
 							'step 1'
-							if(player.getStorage('nsxingyun').length>=4) player.addSkillLog('bazhen');
+							if(player.getStorage('nsxingyun').length>=4) player.addSkills('bazhen');
 						},
 					},
 					round:{
@@ -3416,8 +3416,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							if(owner&&owner!=player) owner.give(card,player);
 							'step 1'
 							if(player.hp<player.maxHp) player.recover(player.maxHp-player.hp);
-							player.removeSkill('mia_shihui');
-							player.addSkill('mia_fengfa');
+							player.changeSkills(['mia_fengfa'],['mia_shihui']);
 						},
 					},
 					fail:{
@@ -3841,7 +3840,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.storage.tenzen_lingyu=true;
 					player.loseMaxHp();
 					if(player.isHealthy()) player.draw(2);
-					player.addSkill('tenzen_tianquan');
+					player.addSkills('tenzen_tianquan');
 				},
 			},
 			tenzen_tianquan:{
@@ -4633,7 +4632,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					var cards=target.getCards('j');
 					if(cards.length) target.discard(cards);
 					'step 3'
-					target.addSkill('misuzu_zhongyuan');
+					target.addSkills('misuzu_zhongyuan');
 				},
 				derivation:'misuzu_zhongyuan',
 				ai:{
@@ -4860,7 +4859,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content(){
 					player._chihaya_liewu=true;
 					player.loseMaxHp(4);
-					player.addSkill('chihaya_huairou');
+					player.addSkills('chihaya_huairou');
 				},
 			},
 			chihaya_huairou:{
@@ -5248,7 +5247,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.logSkill('hiroto_huyu',target);
 						target.give(result.cards,player);
 						player.storage.hiroto_huyu2=target;
-						player.addSkill('hiroto_zonglve');
+						player.addSkills('hiroto_zonglve');
 						player.addSkill('hiroto_huyu2');
 					}
 				},
@@ -5348,8 +5347,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content(){
 					player.awakenSkill('hiroto_tuolao');
 					player.draw(3);
-					player.removeSkill('hiroto_huyu');
-					player.addSkill('hiroto_zonglve');
+					player.changeSkills(['hiroto_zonglve'],['hiroto_huyu']);
 				},
 			},
 			shizuku_sizhi:{
@@ -5711,7 +5709,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.recover();
 						var list=['umi_chaofan','ao_xishi','tsumugi_mugyu','kamome_jieban'];
 						var skill=list.randomGet();
-						player.addSkillLog(skill);
+						player.addSkills(skill);
 						player.flashAvatar('shiroha_jiezhao','key_'+skill.split('_')[0]);
 					}
 				},
@@ -6286,8 +6284,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							return info&&info.charlotte==true;
 						});
 						if(skills.length){
-							target.removeSkill(skills);
-							player.addSkill(skills);
+							target.removeSkills(skills);
+							player.addSkills(skills);
 							lib.translate.yuu_lveduo_info=lib.translate.yuu_lveduo_full_info;
 						}
 						if(target.name=='key_yusa'){
@@ -6882,7 +6880,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(cards.length) player.discard(cards);
 					player.removeSkill('kud_qiaoshou_equip');
 					player.draw(cards.length);
-					player.addSkill('kud_chongzhen');
+					player.addSkills('kud_chongzhen');
 					'step 1'
 					var num=2-player.hp;
 					if(num) player.recover(num);
@@ -8043,10 +8041,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				animationColor:'orange',
 				content(){
 					player.awakenSkill('yuzuru_deyi');
-					player.removeSkill('yuzuru_wuxin');
-					player.addSkillLog('yuzuru_kunfen');
-					player.addSkillLog('yuzuru_quji');
-					player.addSkillLog('yuzuru_wangsheng');
+					player.changeSkills(['yuzuru_kunfen','yuzuru_quji','yuzuru_wangsheng'],['yuzuru_wuxin']);
 					player.loseMaxHp();
 					player.recover();
 				},
@@ -8243,8 +8238,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content(){
 					player.awakenSkill('ao_shixin');
-					player.removeSkill('ao_kuihun');
-					player.addSkill('ao_diegui');
+					player.changeSkills(['ao_diegui'],['ao_kuihun']);
 					player.gainMaxHp();
 					player.recover();
 				},
@@ -8872,10 +8866,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content(){
 					player.awakenSkill('riki_mengzhong');
-					player.removeSkill('riki_spwenji');
+					player.removeSkills('riki_spwenji');
 					player.gainMaxHp();
 					player.recover();
-					player.addSkill('riki_chongzhen');
+					player.addSkills('riki_chongzhen');
 				},
 			},
 			riki_chongzhen:{
@@ -10035,7 +10029,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content(){
 					player.awakenSkill('yui_takaramono');
-					player.addSkill('yui_yinhang');
+					player.addSkills('yui_yinhang');
 					player.storage._ichiban_no_takaramono=true;
 					player.gainMaxHp();
 					player.recover();
@@ -10806,8 +10800,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.chooseControl(list).set('prompt','选择获得一个技能');
 					}
 					'step 4'
-					player.addSkill(result.control,get.groupnature(event.temp.group)||'key');
-					player.addSkill(result.control);
+					//player.addSkills(result.control,get.groupnature(event.temp.group)||'key');
+					player.addSkills(result.control);
 					var info=get.info(result.control);
 					if(info.zhuSkill){
 						if(!player.storage.zhuSkill_umi_qihuan) player.storage.zhuSkill_umi_qihuan=[];
@@ -17649,8 +17643,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 1'
 					if(result.bool){
 						var skills=lib.skill.junkyuheng.derivation.randomGets(result.cards.length);
-						player.addAdditionalSkill('junkyuheng',skills);
-						game.log(player,'获得了以下技能：','#g'+get.translation(skills));
+						player.changeSkills(skills,[]).set('$handle',(player,skills)=>{
+							player.addAdditionalSkill('junkyuheng',skills);
+							game.log(player,'获得了以下技能：','#g'+get.translation(skills));
+						});
 					}
 				},
 				group:'junkyuheng_remove',
@@ -17664,22 +17660,25 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							return player.additionalSkills.junkyuheng&&player.additionalSkills.junkyuheng.length>0;
 						},
 						content(){
-							player.draw(player.additionalSkills.junkyuheng.length);
-							game.log(player,'失去了以下技能：','#g'+get.translation(player.additionalSkills.junkyuheng));
-							player.removeAdditionalSkill('junkyuheng');
+							const skills = player.additionalSkills.junkyuheng;
+							player.draw(skills.length);
+							player.changeSkills([],skills).set('$handle',(player,addSkills,removeSkills)=>{
+								game.log(player,'失去了以下技能：','#g'+get.translation(removeSkills));
+								player.removeAdditionalSkill('junkyuheng');
+							});
 						},
 					},
 				},
 			},
 			junkdili:{
 				audio:'dili',
-				trigger:{player:'logSkill'},
+				trigger:{player:'changeSkillsAfter'},
 				forced:true,
 				juexingji:true,
 				skillAnimation:true,
 				animationColor:'wood',
 				filter(event,player){
-					if(event.skill!='junkyuheng') return false;
+					if(!event.addSkill.length) return false;
 					var skills=player.getSkills(null,false,false).filter(function(i){
 						var info=get.info(i);
 						return info&&!info.charlotte;
@@ -17734,12 +17733,11 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(result.bool){
 						var skills=result.links;
 						game.log(player,'失去了以下技能：','#g'+get.translation(skills));
-						player.removeSkill(skills.slice(0));
+						player.removeSkills(skills.slice(0));
 					}
 					var list=lib.skill.junkdili.derivation;
-					for(var i=0;i<Math.min(skills.length,list.length);i++){
-						player.addSkillLog(list[i]);
-					}
+					list=list.slice(0,Math.min(skills.length,list.length));
+					player.addSkills(list);
 				},
 				derivation:['junkshengzhi','junkquandao','junkchigang'],
 			},
@@ -18952,7 +18950,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			junkyuheng:'驭衡',
 			junkyuheng_info:'锁定技。①回合开始时，你须弃置任意张花色不同的牌，从<span style="font-family: yuanli">东吴命运线·改</span>中随机获得等量的技能。②回合结束时，你失去所有因〖驭衡①〗获得的技能，然后摸等量的牌。',
 			junkdili:'帝力',
-			junkdili_info:'觉醒技。当你发动〖驭衡①〗后，若你拥有的技能数大于你的体力上限，则你减1点体力上限，选择失去任意个其他技能，然后获得以下技能中的前等量个：〖圣质〗/〖权道〗/〖持纲〗。',
+			junkdili_info:'觉醒技。当你获得技能后，若你拥有的技能数大于你的体力上限，则你减1点体力上限，选择失去任意个其他技能，然后获得以下技能中的前等量个：〖圣质〗/〖权道〗/〖持纲〗。',
 			junkshengzhi:'圣质',
 			junkshengzhi_info:'锁定技。当你发动非锁定技后，你令你本回合使用的下一张牌无距离和次数限制。',
 			junkquandao:'权道',

--- a/character/diy.js
+++ b/character/diy.js
@@ -5258,9 +5258,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				popup:false,
 				charlotte:true,
-				content(){
+				async content(event,trigger,player){
 					player.removeSkill('hiroto_huyu2');
-					player.removeSkill('hiroto_zonglve');
+					await player.removeSkills('hiroto_zonglve');
 					player.removeGaintag('hiroto_huyu2');
 					var target=player.storage.hiroto_huyu2;
 					if(target&&target.isIn()){
@@ -6352,7 +6352,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.awakenSkill('godan_xiaoyuan');
 					player.loseMaxHp(3);
 					player.draw(3);
-					player.removeSkill('godan_feiqu');
+					player.removeSkills('godan_feiqu');
 				},
 			},
 			abyusa_jueqing:{
@@ -10670,7 +10670,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					return event.getParent(2).name=='komari_xueshang'&&event.getParent(2).player==player;
 				},
 				content(){
-					player.removeSkill('komari_xueshang');
+					player.removeSkills('komari_xueshang');
 					player.gainMaxHp(true);
 					player.recover();
 				},
@@ -17664,7 +17664,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							player.draw(skills.length);
 							player.changeSkills([],skills).set('$handle',(player,addSkills,removeSkills)=>{
 								game.log(player,'失去了以下技能：','#g'+get.translation(removeSkills));
-								player.removeAdditionalSkill('junkyuheng');
+								for(let skill of removeSkills) player.removeAdditionalSkill('junkyuheng',skill);
 							});
 						},
 					},

--- a/character/extra.js
+++ b/character/extra.js
@@ -997,12 +997,13 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					var target=trigger.player;
 					player.awakenSkill('jxzhaoluan');
 					trigger.cancel();
-					target.getSkills(null,false,false).forEach(skill=>{
+					const skills = target.getSkills(null,false,false).filter(skill=>{
 						var info=get.info(skill);
 						if(info&&!info.charlotte&&!get.is.locked(skill)){
-							target.removeSkill(skill);
+							return true;
 						}
 					});
+					if(skills.length) yield target.removeSkills(skills);
 					yield target.gainMaxHp(3);
 					var num=3-target.getHp(true);
 					if(num>0) yield target.recover(num);
@@ -3198,7 +3199,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						return info&&!info.charlotte&&!get.is.locked(i);
 					});
 					if(skills.length){
-						for(var i of skills) player.removeSkill(i);
+						player.removeSkills(skills);
 					}
 					//初始化技能库
 					var list1=['dili_shengzhi','dili_chigang','dili_qionglan','dili_quandao','dili_jiaohui','dili_yuanlv'];
@@ -3439,10 +3440,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					},'请选择火【杀】的目标（'+(event.num==9?'⑨':event.num)+'/9）',false);
 					'step 2'
 					if(result.bool&&event.num<9) event.goto(1);
-					else{
-						player.removeSkill('jiufa');
-						player.addSkill('pingxiang_effect');
-					}
+					else player.removeSkills('jiufa');
+					'step 3'
+					player.addSkill('pingxiang_effect');
 				},
 				ai:{
 					order(){
@@ -5116,7 +5116,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.loseMaxHp();
 					player.gain(player.getExpansions('chuyuan'),'gain2','fromStorage');
 					"step 1"
-					player.removeSkill('chuyuan');
+					player.removeSkills('chuyuan');
 					player.chooseControl('rerende','rezhiheng','olluanji','caopi_xingdong').set('prompt','选择获得一个技能').set('ai',function(){
 						var player=_status.event.player;
 						if(!player.hasSkill('luanji')&&!player.hasSkill('olluanji')&&player.getUseValue({name:'wanjian'})>4) return 'olluanji';
@@ -7532,7 +7532,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				popup:false,
 				content(){
-					player.removeSkill(player.storage.drlt_duorui[0]);
+					player.removeSkills(player.storage.drlt_duorui[0]);
 					delete player.storage.drlt_duorui_player;
 					player.storage.drlt_duorui=[];
 				},

--- a/character/extra.js
+++ b/character/extra.js
@@ -1629,7 +1629,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 0'
 					player.awakenSkill('dcqijing');
 					player.loseMaxHp();
-					player.addSkillLog('dccuixin');
+					player.addSkills('dccuixin');
 					'step 1'
 					if(game.countPlayer()>2){
 						if(player==trigger.player&&!trigger.skill){
@@ -3250,7 +3250,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						skills.add(fullskills.randomRemove(1)[0]);
 					}
 					for(var i of skills){
-						player.addSkillLog(i);
+						player.addSkills(i);
 					}
 					player.markAuto('yuheng',skills);
 				},
@@ -4108,7 +4108,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						content(){
 							game.log(player,'成功完成使命');
 							player.awakenSkill('tspowei');
-							player.addSkillLog('shenzhu');
+							player.addSkills('shenzhu');
 						},
 					},
 					fail:{
@@ -4350,7 +4350,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						var target=result.targets[0];
 						player.line(target,'green');
 						target.storage.zuoxing=player;
-						target.addSkill('zuoxing');
+						target.addSkills('zuoxing');
 					}
 				},
 				derivation:'zuoxing',
@@ -4771,7 +4771,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						if(lib.character[target.name]) list.addArray(lib.character[target.name][3]);
 						if(lib.character[target.name1]) list.addArray(lib.character[target.name1][3]);
 						if(lib.character[target.name2]) list.addArray(lib.character[target.name2][3]);
-						player.addSkill(list);
+						player.addSkills(list);
 						game.broadcastAll(function(list){
 							lib.character.key_shiki[3].addArray(list);
 							game.expandSkills(list);
@@ -5094,8 +5094,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content(){
 					player.awakenSkill(event.name);
-					player.addSkill('tianxing');
-					player.addSkill('new_rejianxiong');
+					player.addSkills(['tianxing','new_rejianxiong']);
 					player.loseMaxHp();
 					player.gain(player.getExpansions('chuyuan'),'gain2','fromStorage');
 				},
@@ -5126,7 +5125,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						return 'rerende';
 					});
 					'step 2'
-					player.addSkillLog(result.control);
+					player.addSkills(result.control);
 				},
 			},
 			olzhiti:{
@@ -5901,9 +5900,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					return player.countMark('renjie')>=4;
 				},
 				content(){
-					player.loseMaxHp();
-					player.addSkill('jilue');
 					player.awakenSkill('sbaiyin');
+					player.loseMaxHp();
+					player.addSkills('jilue');
 				},
 				derivation:['jilue','reguicai','fangzhu','rejizhi','rezhiheng','rewansha'],
 			},

--- a/character/huicui.js
+++ b/character/huicui.js
@@ -527,12 +527,12 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					var num=Math.min(cards.length,4-player.countMark('dcmanwang'));
-					if(num>=1) player.addSkill('dcpanqin');
+					if(num>=1) player.addSkills('dcpanqin');
 					if(num>=2) player.draw();
 					if(num>=3) player.recover();
 					if(num>=4){
 						player.draw(2);
-						player.removeSkill('dcpanqin');
+						player.removeSkills('dcpanqin');
 					}
 				},
 				ai:{
@@ -578,7 +578,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							switch(player.countMark('dcmanwang')){
 								case 1:
 									player.draw(2);
-									player.removeSkill('dcpanqin');
+									player.removeSkills('dcpanqin');
 									break;
 								case 2:
 									player.recover();
@@ -587,7 +587,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 									player.draw();
 									break;
 								case 4:
-									player.addSkill('dcpanqin');
+									player.addSkills('dcpanqin');
 									break;
 							}
 							'step 1'
@@ -3337,11 +3337,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					'step 0'
 					player.awakenSkill('dcchongxu');
+					player.removeSkills('dchuiling');
 					player.gainMaxHp(Math.min(game.countPlayer(),player.countMark('dchuiling')));
-					player.removeSkill('dchuiling');
 					'step 1'
-					player.addSkillLog('dctaji');
-					player.addSkillLog('dcqinghuang');
+					player.addSkills(['dctaji','dcqinghuang']);
 				},
 				ai:{
 					order:function(itemp,player){
@@ -7643,7 +7642,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							else event.goto(3);
 							'step 2'
 							game.broadcastAll('closeDialog',event.videoId);
-							target.addSkillLog(result.control);
+							target.addSkills(result.control);
 							'step 3'
 							var storage=player.storage.dunshi;
 							if(event.links.includes(1)){
@@ -10030,8 +10029,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(player.maxHp>player.hp) player.recover(player.maxHp-player.hp);
 					'step 2'
 					player.drawTo(Math.min(5,player.maxHp));
-					player.addSkillLog('llqshenwei');
-					player.addSkillLog('wushuang');
+					player.addSkills(['llqshenwei','wushuang']);
 				},
 			},
 			llqshenwei:{

--- a/character/huicui.js
+++ b/character/huicui.js
@@ -246,7 +246,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						if(get.type(name)==='delay') return false;
 						const card=new lib.element.VCard({name:name});
 						return get.tag(card,'damage')&&!player.getStorage('dcdehua').includes(name);
-					})) player.removeSkillLog('dcdehua');
+					})) player.removeSkills('dcdehua');
 				},
 				mod:{
 					maxHandcard(player,num){

--- a/character/jsrg.js
+++ b/character/jsrg.js
@@ -1204,7 +1204,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						if(bool){
 							player.logSkill('jsrgfangjie');
 							await player.discard(links);
-							player.removeSkillLog('jsrgfangjie');
+							player.removeSkills('jsrgfangjie');
 						}
 					}
 				},
@@ -3965,7 +3965,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					player.awakenSkill('jsrgzhasi');
 					trigger.cancel();
-					player.removeSkill();
 					player.changeSkills(['rezhiheng'],['jsrgzhiheng']);
 					player.addSkill('jsrgzhasi_undist');
 				},
@@ -6271,8 +6270,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						trigger.targets.forEach(i=>i.removeSkill('huogong2'));
 					}
 					else{
-						player.removeSkill('jsrgguanhuo');
-						game.log(player,'失去了技能','#g【观火】');
+						player.removeSkills('jsrgguanhuo');
 					}
 				},
 				ai:{

--- a/character/jsrg.js
+++ b/character/jsrg.js
@@ -3965,9 +3965,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					player.awakenSkill('jsrgzhasi');
 					trigger.cancel();
-					player.removeSkill('jsrgzhiheng');
-					game.log(player,'失去了技能','#g【猘横】');
-					player.addSkillLog('rezhiheng');
+					player.removeSkill();
+					player.changeSkills(['rezhiheng'],['jsrgzhiheng']);
 					player.addSkill('jsrgzhasi_undist');
 				},
 				derivation:'rezhiheng',
@@ -7652,8 +7651,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.awakenSkill('jsrghuilie');
 					player.loseMaxHp();
 					'step 1'
-					player.addSkillLog('jsrgpingrong');
-					player.addSkillLog('feiying');
+					player.addSkills(['jsrgpingrong','feiying']);
 				}
 			},
 			jsrgpingrong:{

--- a/character/mobile.js
+++ b/character/mobile.js
@@ -5907,7 +5907,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(result.bool){
 						var es=target.getCards('e');
 						target.give(es,player,'give');
-						player.removeSkill('mobileyanzhu');
+						player.removeSkills('mobileyanzhu');
 						player.storage.mobileyanzhu=true;
 						player.popup('兴学');
 						game.log(player,'修改了技能','#g【兴学】');
@@ -9896,7 +9896,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					player.awakenSkill('requanfeng');
-					player.removeSkill('hongyi');
+					player.removeSkills('hongyi');
 					var skills=trigger.player.getStockSkills('仲村由理','天下第一').filter(function(skill){
 						var info=get.info(skill);
 						return info&&!info.hiddenSkill&&!info.zhuSkill&&!info.charlotte;

--- a/character/mobile.js
+++ b/character/mobile.js
@@ -9783,10 +9783,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					event.skills=skills;
 					player.chooseControl(skills).set('dialog',['选择令'+get.translation(target)+'获得一个技能',[chara,'character']]);
 					'step 2'
-					target.addSkillLog(result.control);
+					target.addSkills(result.control);
 					target.setAvatarQueue(target.name1||target.name,[event.chara[event.skills.indexOf(result.control)]]);
-					'step 3'
-					if(target.isZhu2()) event.trigger('zhuUpdate');
 				},
 			},
 			hongyi:{

--- a/character/mobile.js
+++ b/character/mobile.js
@@ -6783,7 +6783,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					player.awakenSkill('moucuan');
 					player.loseMaxHp();
-					player.addSkill('binghuo');
+					player.addSkills('binghuo');
 				},
 				ai:{combo:'jibing'},
 			},
@@ -9902,7 +9902,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						return info&&!info.hiddenSkill&&!info.zhuSkill&&!info.charlotte;
 					});
 					if(skills.length){
-						for(var i of skills) player.addSkillLog(i);
+						player.addSkills(skills);
 						game.broadcastAll(function(list){
 							game.expandSkills(list);
 							for(var i of list){
@@ -9943,7 +9943,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						return list.randomGet();
 					});
 					'step 1'
-					player.addSkillLog(result.control);
+					player.addSkills(result.control);
 					game.broadcastAll(function(skill){
 						var list=[skill];game.expandSkills(list);
 						for(var i of list){
@@ -11584,8 +11584,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.gain(gains,'gain2');
 					}
 					'step 3'
-					player.addSkill('reqingce');
-					game.log(player,'获得了技能','#g【清侧】');
+					player.addSkills('reqingce');
 					player.loseMaxHp();
 				},
 			},
@@ -12960,8 +12959,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 1'
 					if(result.bool){
 						player.line(trigger.source,'fire');
-						trigger.source.addSkillLog('new_rewusheng');
-						trigger.source.addSkillLog('redangxian');
+						trigger.source.addSkills(['new_rewusheng','redangxian']);
 					}
 				},
 			},
@@ -13110,8 +13108,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				animationColor:'thunder',
 				content:function(){
 					player.awakenSkill('remoucheng');
-					player.removeSkill('relianji');
-					player.addSkill('jingong');
+					player.changeSkills(['jingong','relianji']);
 					player.gainMaxHp();
 					player.recover();
 				},

--- a/character/offline.js
+++ b/character/offline.js
@@ -5324,7 +5324,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.storage.suiren=true;
 						player.awakenSkill('suiren');
 						player.logSkill('suiren',result.targets);
-						player.removeSkill('reyicong');
+						player.removeSkills('reyicong');
 						player.gainMaxHp();
 						player.recover();
 						result.targets[0].draw(3);

--- a/character/offline.js
+++ b/character/offline.js
@@ -1075,7 +1075,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.awakenSkill('pksanchen');
 					player.gainMaxHp();
 					player.recover();
-					player.addSkillLog('pkmiewu');
+					player.addSkills('pkmiewu');
 				},
 				ai:{
 					combo:'wuku',

--- a/character/old.js
+++ b/character/old.js
@@ -200,7 +200,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 1'
 					if(result.bool){
 						player.logSkill('junkguixin');
-						player.addSkillLog(result.links[0]);
+						player.addSkills(result.links[0]);
 					}
 				},
 				content_修改势力:function(){

--- a/character/onlyOL.js
+++ b/character/onlyOL.js
@@ -519,11 +519,13 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					var trigger=map.trigger;
 					player.awakenSkill('olsbranji');
 					var num=lib.skill.olsbranji.getNum(trigger,player);
+					const skills = [];
 					if(num>=player.getHp()){
-						player.addSkillLog('kunfen');
+						skills.push('kunfen');
 						player.storage.kunfen=true;
 					}
-					if(num<=player.getHp()) player.addSkillLog('zhaxiang');
+					if(num<=player.getHp()) skills.push('zhaxiang');
+					player.addSkills(skills);
 					if(player.countCards('h')!=player.getHandcardLimit()||player.isDamaged()){
 						var result,num1=player.countCards('h')-player.getHandcardLimit();
 						if(!num1) result={index:1};

--- a/character/refresh.js
+++ b/character/refresh.js
@@ -559,8 +559,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 1'
 					player.drawTo(player.maxHp);
 					'step 2'
-					player.addSkillLog('benghuai');
-					player.addSkillLog('reweizhong');
+					player.addSkills(['benghuai','reweizhong']);
 				}
 			},
 			reweizhong:{
@@ -3861,7 +3860,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					player.awakenSkill('xsqianxin');
 					player.loseMaxHp();
-					player.addSkill('rejianyan');
+					player.addSkills('rejianyan');
 				},
 				derivation:'rejianyan',
 			},
@@ -5588,7 +5587,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.recover();
 					player.draw(2);
 					player.loseMaxHp();
-					player.addSkill('xinpaiyi');
+					player.addSkills('xinpaiyi');
 				},
 			},
 			xinpaiyi:{
@@ -6102,8 +6101,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.chooseDrawRecover(2,true);
 					"step 1"
 					player.loseMaxHp();
-					player.storage.olzhiji=true;
-					player.addSkill('reguanxing');
+					player.addSkills('reguanxing');
 				}
 			},
 			//界郭图张嶷
@@ -7733,7 +7731,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					player.awakenSkill('olzaoxian');
 					player.loseMaxHp();
-					player.addSkill('jixi');
+					player.addSkills('jixi');
 					player.insertPhase();
 				}
 			},
@@ -9603,7 +9601,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						return ['olhuoji','bazhen'].randomGet();
 					};
 					'step 6'
-					player.addSkillLog(result.control);
+					player.addSkills(result.control);
 				},
 				derivation:['bazhen','olhuoji','olkanpo'],
 				ai:{
@@ -10273,14 +10271,11 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				audioname:['re_sunyi'],
 				inherit:'hunzi',
 				content:function(){
+					player.awakenSkill(event.name);
 					player.loseMaxHp();
 					//player.recover();
-					player.addSkill('reyingzi');
-					player.addSkill('gzyinghun');
+					player.addSkills(['reyingzi','gzyinghun']);
 					player.addTempSkill('olhunzi_effect');
-					game.log(player,'获得了技能','#g【英姿】','和','#g【英魂】');
-					player.awakenSkill(event.name);
-					player.storage[event.name]=true;
 				},
 				subSkill:{
 					effect:{
@@ -11035,7 +11030,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 1'
 					if(!result.bool) target.loseHp();
 					'step 2'
-					target.addSkillLog('rechanyuan');
+					target.addSkills('rechanyuan');
 					if(targets.length) event.goto(0);
 				},
 			},
@@ -13155,7 +13150,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.awakenSkill('qinxue');
 					player.loseMaxHp();
 					player.chooseDrawRecover(2,true);
-					player.addSkill('gongxin');
+					player.addSkills('gongxin');
 				}
 			},
 			qingjian:{
@@ -14025,7 +14020,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					player.awakenSkill('qianxin');
-					player.addSkill('jianyan');
+					player.addSkills('jianyan');
 					player.loseMaxHp();
 				}
 			},

--- a/character/refresh.js
+++ b/character/refresh.js
@@ -10115,10 +10115,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.gainMaxHp();
 					'step 1'
 					if(player.hp<3) player.recover(3-player.hp);
-					player.addSkillLog('sishu');
-					player.addSkillLog('rejijiang');
-					'step 2'
-					if(player.isZhu2()) event.trigger('zhuUpdate');
+					player.addSkills(['sishu', 'rejijiang']);
 				}
 			},
 			olfangquan:{

--- a/character/sb.js
+++ b/character/sb.js
@@ -781,7 +781,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						animationColor:'thunder',
 						async content(event,trigger,player){
 							player.awakenSkill('sbsongwei_delete');
-							event.target.removeSkillLog(event.target.getStockSkills(false,true));
+							event.target.removeSkills(event.target.getStockSkills(false,true));
 						},
 						ai:{
 							order:13,
@@ -3652,8 +3652,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 0'
 					player.recover(3);
 					'step 1'
-					player.removeSkill('sbrende');
-					game.log(player,'失去了技能','#g【'+get.translation('sbrende')+'】');
+					player.removeSkills('sbrende');
 					game.delayx();
 				},
 				ai:{

--- a/character/sb.js
+++ b/character/sb.js
@@ -552,8 +552,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 													game.log(player,'选择了',target2);
 													const skills=target2.getStockSkills(true,true);
 													const skills2=player.getStockSkills(true,true);
-													player.addSkillLog(skills);
-													player.removeSkillLog(skills2);
+													player.changeSkills(skills,skills2);
 												}
 										}
 									},
@@ -1254,8 +1253,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							if(player.name2&&get.character(player.name2)[3].includes('sbhuoji')) list.add(player.name2);
 							if(list.length) list.forEach(name=>player.reinit(name,'sb_zhugeliang'));
 							else{
-								player.removeSkill(['sbhuoji','sbkanpo']);
-								player.addSkill(['sbguanxing','sbkongcheng']);
+								player.changeSKills(['sbguanxing','sbkongcheng'],['sbhuoji','sbkanpo']);
 							}
 						},
 					},
@@ -2302,8 +2300,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 2'
 					player.draw(3);
 					'step 3'
-					player.addSkillLog('sbyingzi');
-					player.addSkillLog('gzyinghun');
+					player.addSkills(['sbyingzi','gzyinghun']);
 				},
 				ai:{
 					threaten:function(player,target){
@@ -5914,7 +5911,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					player.awakenSkill('sbdujiang');
-					player.addSkillLog('sbduojing');
+					player.addSkills('sbduojing');
 					player.storage.sbkeji=true;
 				}
 			},

--- a/character/sb.js
+++ b/character/sb.js
@@ -1244,14 +1244,15 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						locked:false,
 						skillAnimation:true,
 						animationColor:'fire',
-						content:function(){
+						async content(event,trigger,player){
 							player.awakenSkill('sbhuoji');
 							game.log(player,'成功完成使命');
-							var list=[];
-							if(player.name&&get.character(player.name)[3].includes('sbhuoji')) list.add(player.name);
-							if(player.name1&&get.character(player.name1)[3].includes('sbhuoji')) list.add(player.name1);
-							if(player.name2&&get.character(player.name2)[3].includes('sbhuoji')) list.add(player.name2);
-							if(list.length) list.forEach(name=>player.reinit(name,'sb_zhugeliang'));
+							if (get.character(player.name1)[3].includes('sbhuoji')) {
+								player.reinitCharacter(player.name1, 'sb_zhugeliang', false);
+							}
+							else if (player.name2&&get.character(player.name2)[3].includes('sbhuoji')) {
+								player.reinitCharacter(player.name2, 'sb_zhugeliang', false);
+							}
 							else{
 								player.changeSKills(['sbguanxing','sbkongcheng'],['sbhuoji','sbkanpo']);
 							}

--- a/character/shenhua.js
+++ b/character/shenhua.js
@@ -667,7 +667,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.gain(gains,'gain2','log');
 					}
 					'step 2'
-					player.addSkill('qingce');
+					player.addSkills('qingce');
 					game.log(player,'获得了技能','#g【清侧】');
 					player.loseMaxHp();
 				},
@@ -808,7 +808,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.gain(gains,'gain2','log');
 					}
 					'step 2'
-					player.addSkillLog('drlt_qingce');
+					player.addSkills('drlt_qingce');
 					player.loseMaxHp();
 				},
 			},
@@ -1209,8 +1209,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					"step 1"
 					var num=player.maxHp-player.countCards('h');
 					if(num>0) player.draw(num);
-					player.removeSkill('drlt_jueyan');
-					player.addSkill('drlt_huairou');
+					player.changeSkills(['drlt_huairou'],['drlt_jueyan']);
 				},
 			},
 			"drlt_huairou":{
@@ -3345,10 +3344,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.chooseDrawRecover(2,true);
 					"step 1"
 					player.loseMaxHp();
-					player.storage.zhiji=true;
-					if(player.hp>player.maxHp) player.hp=player.maxHp;
-					player.update();
-					player.addSkill('reguanxing');
+					player.addSkills('reguanxing');
 				}
 			},
 			xiangle:{
@@ -3724,7 +3720,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					player.awakenSkill('zaoxian');
 					player.loseMaxHp();
-					player.addSkill('jixi');
+					player.addSkills('jixi');
 				}
 			},
 			jixi:{
@@ -3818,12 +3814,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				//priority:3,
 				content:function(){
-					player.loseMaxHp();
-					player.addSkill('reyingzi');
-					player.addSkill('gzyinghun');
-					game.log(player,'获得了技能','#g【英姿】和【英魂】')
 					player.awakenSkill(event.name);
-					player.storage[event.name]=true;
+					player.loseMaxHp();
+					player.addSkills(['reyingzi','gzyinghun']);
 				},
 				ai:{
 					threaten:function(player,target){
@@ -7650,7 +7643,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					else{
 						event.betrayer.popup('质疑错误','fire');
-						event.betrayer.addSkillLog('chanyuan');
+						event.betrayer.addSkills('chanyuan');
 					}
 					'step 7'
 					game.delay(2);

--- a/character/shenhua.js
+++ b/character/shenhua.js
@@ -3498,9 +3498,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.gainMaxHp();
 					player.recover();
 					'step 1'
-					player.addSkillLog('rejijiang');
-					'step 2'
-					if(player.isZhu2()) event.trigger('zhuUpdate');
+					player.addSkills('rejijiang');
 				}
 			},
 			qiaobian:{

--- a/character/shenhua.js
+++ b/character/shenhua.js
@@ -2647,13 +2647,14 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					},
 				},
 			},
-			"nzry_shenshi1":{
+			nzry_shenshi1:{
 				audio:2,
 				trigger:{
 					global:'phaseJieshuBegin',
 				},
 				forced:true,
 				popup:false,
+				charlotte:true,
 				filter:function(event,player){
 					return player.storage.nzry_shenshi1!=undefined&&player.storage.nzry_shenshi2!=undefined;
 				},

--- a/character/shiji.js
+++ b/character/shiji.js
@@ -2168,8 +2168,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							player.awakenSkill('rechuhai');
 							game.log(player,'成功完成使命');
 							if(player.isDamaged()) player.recover(player.maxHp-player.hp);
-							player.removeSkill('xianghai');
-							player.addSkill('zhangming');
+							player.changeSkills(['zhangming'],['xianghai']);
 						},
 					},
 					fail:{
@@ -2741,7 +2740,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					if(cards.length) player.gain(cards,'gain2');
 					'step 1'
-					player.addSkill('xinmouli');
+					player.addSkills('xinmouli');
 				},
 				group:['mibei_fail','mibei_silent'],
 				derivation:'xinmouli',
@@ -3179,7 +3178,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						content:function(){
 							game.log(player,'成功完成使命');
 							player.awakenSkill('qingyu');
-							player.addSkillLog('xuancun');
+							player.addSkills('xuancun');
 						},
 					},
 					fail:{
@@ -5767,7 +5766,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.awakenSkill('spsanchen');
 					player.gainMaxHp();
 					player.recover();
-					player.addSkillLog('spmiewu');
+					player.addSkills('spmiewu');
 				},
 				ai:{
 					combo:'wuku',

--- a/character/sp.js
+++ b/character/sp.js
@@ -3955,7 +3955,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					'step 0'
 					player.awakenSkill('olhuiqi');
-					player.addSkillLog('olxieju');
+					player.addSkills('olxieju');
 					player.insertPhase();
 				}
 			},
@@ -7118,9 +7118,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					game.log(player,'删除了','#g【笔心】','描述的前五个字符');
 					if(player.countMark('olbixin')==3){
 						game.log(player,'交换了','#g【笔心】','方括号中的两个数字');
-						player.removeSkill('olximo');
-						game.log(player,'失去了技能','#g【洗墨】');
-						player.addSkillLog('olfeibai');
+						//player.removeSkill('olximo');
+						//game.log(player,'失去了技能','#g【洗墨】');
+						player.changeSkills(['olfeibai'],['olximo']);
 					}
 				},
 				ai:{
@@ -8461,7 +8461,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					else event.finish();
 					'step 2'
-					target.addSkill(result.control);
+					target.addSkills(result.control);
 					'step 3'
 					var num=player.countCards('h');
 					if(num>0) player.chooseToDiscard('h',num,true);
@@ -10293,12 +10293,12 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					var num=Math.min(cards.length,4-player.countMark('spmanwang'));
-					if(num>=1) player.addSkill('sppanqin');
+					if(num>=1) player.addSkills('sppanqin');
 					if(num>=2) player.draw();
 					if(num>=3) player.recover();
 					if(num>=4){
 						player.draw(2);
-						player.removeSkill('sppanqin');
+						player.removeSkills('sppanqin');
 					}
 				},
 				intro:{content:'已经移去过#个选项'},
@@ -10385,7 +10385,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							switch(player.countMark('spmanwang')){
 								case 1:
 									player.draw(2);
-									player.removeSkill('sppanqin');
+									player.removeSkills('sppanqin');
 									break;
 								case 2:
 									player.recover();
@@ -10394,7 +10394,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 									player.draw();
 									break;
 								case 4:
-									player.addSkill('sppanqin');
+									player.addSkills('sppanqin');
 									break;
 							}
 						},
@@ -10482,7 +10482,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					for(var i of lib.skill.rebaobian.derivation){
 						if(!player.hasSkill(i,null,null,false)){
-							player.addSkillLog(i);
+							player.addSkills(i);
 							break;
 						}
 					}
@@ -11220,7 +11220,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					target.gainMaxHp();
 					target.recover();
 					target.draw(3);
-					target.addSkill('olzaowang2');
+					target.addSkills('olzaowang2');
 				},
 				ai:{
 					order:2,
@@ -11950,7 +11950,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					else event.finish();
 					'step 2'
-					target.addSkillLog(result.control);
+					target.addSkills(result.control);
 				},
 			},
 			//邓芝
@@ -12582,7 +12582,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					'step 0'
 					player.awakenSkill('olxushen');
-					player.addSkill('olzhennan');
+					player.addSkills('olzhennan');
 					player.recover(1-player.hp);
 					'step 1'
 					if(!player.isDying()&&!game.hasPlayer(function(current){
@@ -13677,7 +13677,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						return list.randomGet();
 					});
 					'step 1'
-					player.addSkillLog(result.control);
+					player.addSkills(result.control);
 					game.broadcastAll(function(skill){
 						var list=[skill];game.expandSkills(list);
 						for(var i of list){
@@ -13740,7 +13740,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(player.storage.retuogu) player.removeSkill(player.storage.retuogu);
 					player.storage.retuogu=result.control;
 					player.markSkill('retuogu');
-					player.addSkillLog(result.control);
+					player.addSkills(result.control);
 					game.broadcastAll(function(skill){
 						var list=[skill];
 						game.expandSkills(list);
@@ -14074,8 +14074,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					player.awakenSkill('xinmoucheng');
-					player.addSkill('xinjingong');
-					player.removeSkill('xinlianji');
+					player.changeSkills(['xinjingong'],['xinlianji']);
 				},
 			},
 			xinjingong:{
@@ -16276,9 +16275,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						animationColor:'gray',
 						content:function(){
 							player.awakenSkill('moucheng');
-							player.removeSkill('wylianji');
 							game.log(player,'失去了技能','#g【连计】');
-							player.addSkillLog('jingong');
+							player.changeSkills(['jingong'],['wylianji']);
 						}
 					}
 				}
@@ -17681,7 +17679,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 2'
 					var map=event.result||result;
 					if(map&&map.skills&&map.skills.length){
-						for(var i of map.skills) player.addSkillLog(i);
+						player.addSkils(map.skills);
 					}
 					game.broadcastAll(function(list){
 						game.expandSkills(list);
@@ -17689,7 +17687,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							var info=lib.skill[i];
 							if(!info) continue;
 							if(!info.audioname2) info.audioname2={};
-							info.audioname2.old_yuanshu='weidi';
+							info.audioname2.zhaoxiang='fuhan';
 						}
 					},map.skills);
 					'step 3'
@@ -17906,12 +17904,12 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}).set('choiceList',['获得技能〖妄尊〗',str]).set('choice',choice);
 					'step 2'
 					if(result.control=='选项一'){
-						player.addSkillLog('rewangzun');
+						player.addSkills('rewangzun');
 					}
 					else{
 						player.draw(2);
 						if(event.list){
-							for(var i of event.list) player.addSkillLog(event.list);
+							player.addSkills(event.list);
 							game.broadcastAll(function(list){
 								game.expandSkills(list);
 								for(var i of list){
@@ -19419,9 +19417,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					});
 					'step 2'
 					if(result.control=='xindangxian') player.storage.xinfuli=true;
-					player.addSkill(result.control);
-					player.popup(result.control);
-					game.log(player,'获得了技能','#g【'+get.translation(result.control)+'】');
+					player.addSkills(result.control);
 				},
 				ai:{threaten:2.5},
 				intro:{
@@ -19449,8 +19445,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					else event.finish();
 					'step 2'
 					if(result.control){
-						player.addSkillLog(result.control);
-						player.popup(result.control);
+						player.addSkills(result.control);
 					}
 				},
 				ai:{threaten:2},
@@ -20287,10 +20282,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					return player.getExpansions('fentian').length>=3;
 				},
 				content:function(){
-					player.loseMaxHp();
-					player.addSkill('xintan');
-					player.storage.zhiri=true;
 					player.awakenSkill('zhiri');
+					player.loseMaxHp();
+					player.storage.zhiri=true;
 				}
 			},
 			xintan:{
@@ -20339,11 +20333,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					return !player.storage.danji&&player.countCards('h')>player.hp;
 				},
 				content:function(){
-					player.storage.danji=true;
-					player.loseMaxHp();
-					player.addSkill('mashu');
-					player.addSkill('nuzhan');
 					player.awakenSkill('danji');
+					player.loseMaxHp();
+					player.addSkills(['mashu','nuzhan']);
 				},
 				ai:{
 					maixie:true,
@@ -21727,15 +21719,14 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					"step 0"
+					player.awakenSkill('fengliang');
 					player.loseMaxHp();
 					"step 1"
 					if(player.hp<2){
 						player.recover(2-player.hp);
 					}
 					"step 2"
-					player.addSkill('oltiaoxin');
-					player.storage.kunfen=true;
-					player.awakenSkill('fengliang');
+					player.addSkills('oltiaoxin');
 				},
 			},
 			zhuiji:{
@@ -22492,12 +22483,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				forced:true,
 				content:function(){
-					player.storage.fanxiang=true;
+					player.awakenSkill('fanxiang');
 					player.gainMaxHp();
 					player.recover();
-					player.removeSkill('liangzhu');
-					player.addSkill('xiaoji');
-					player.awakenSkill('fanxiang');
+					player.changeSkills(['xiaoji'],['liangzhu']);
 				},
 			},
 			mingshi:{
@@ -23072,11 +23061,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.awakenSkill('cunsi');
 					var cards=player.getCards('h');
 					player.give(cards,target);
-					player.storage.cunsi=true;
-					game.delay();
-					target.addSkill('yongjue');
-					target.markSkillCharacter('yongjue',player,'存嗣','<div class="skill">【勇决】</div><div>每当其他角色于回合内使用一张杀，若目标不是你，你可以获得之，每回合限一次</div>');
 					"step 1"
+					target.addSkills('yongjue');
+					"step 2"
+					target.markSkillCharacter('yongjue',player,'存嗣','<div class="skill">【勇决】</div><div>每当其他角色于回合内使用一张杀，若目标不是你，你可以获得之，每回合限一次</div>');
 					player.turnOver();
 				},
 				intro:{
@@ -24689,11 +24677,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				unique:true,
 				juexingji:true,
 				content:function(){
-					player.draw(player.maxHp);
-					player.addSkill('benghuai');
-					player.addSkill('weizhong');
-					player.storage.juyi=true;
 					player.awakenSkill('juyi');
+					player.draw(player.maxHp);
+					player.addSkills(['benghuai','weizhong']);
 				}
 			},
 			weizhong:{
@@ -25547,7 +25533,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						_status.characterlist.remove('guansuo');
 					}
 					player.recover();
-					player.addSkill('xinfu_zhennan');
+					player.addSkills('xinfu_zhennan');
 				},
 				mark:true,
 				intro:{

--- a/character/sp.js
+++ b/character/sp.js
@@ -5854,9 +5854,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								});
 							}
 							'step 1'
-							player.removeSkill(result.control);
-							player.popup(result.control);
-							game.log(player,'失去了技能','#g【'+get.translation(result.control)+'】');
+							player.removeSkills(result.control);
 						}
 					}
 				},
@@ -23557,7 +23555,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					"step 0"
-					player.removeSkill('huxiao');
+					player.removeSkills('huxiao');
 					player.gainMaxHp();
 					"step 1"
 					player.recover();
@@ -23644,7 +23642,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				animationColor:'orange',
 				content:function(){
 					'step 0'
-					player.removeSkill('oldhuxiao');
+					player.removeSkills('oldhuxiao');
 					player.gainMaxHp();
 					'step 1'
 					player.recover();

--- a/character/sp.js
+++ b/character/sp.js
@@ -1852,8 +1852,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(result.bool){
 						var target=result.targets[0];
 						event.target=target;
-						var num=target.maxHp;
-						event.num=num;
 						player.logSkill('skill_zhangji_B',target);
 						var list=[];
 						for(var i=0;i<_status.characterlist.length;i++){
@@ -1872,10 +1870,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 2'
 					if(result.bool){
 						event.character=result.links[0];
-						if(target.name2!=undefined) target.chooseControl(target.name,target.name2).set('prompt','请选择要更换的武将牌').set('ai',function(){
+						if(target.name2!=undefined) target.chooseControl(target.name1,target.name2).set('prompt','请选择要更换的武将牌').set('ai',function(){
 							return lib.skill.skill_zhangji_B.getNum(target.name)<lib.skill.skill_zhangji_B.getNum(target.name2)?target.name:target.name2;
 						});
-						else result.control=target.name;
+						else result.control=target.name1;
 					}
 					else{
 						target.chat('拒绝');
@@ -1883,10 +1881,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						event.finish();
 					}
 					'step 3'
-					if(result.control==target.name) target.changeGroup('wei',false);
-					game.log(target,'将','#g'+get.translation(result.control),'替换为了','#g'+get.translation(event.character));
-					target.reinit(result.control,event.character,false);
-					target.maxHp=num;
+					target.reinitCharacter(result.control,event.character);
 					target.update();
 				},
 				subSkill:{
@@ -12611,12 +12606,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					else event.finish();
 					'step 4'
-					target.reinit(result.control,'guansuo');
-					if(target.name=='guansuo'&&target.group!='shu') target.changeGroup('shu');
-					if(_status.characterlist){
-						_status.characterlist.add(result.control);
-						_status.characterlist.remove('guansuo');
-					}
+					target.reinitCharacter(result.control,'guansuo');
 				},
 			},
 			olzhennan:{
@@ -17528,11 +17518,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.awakenSkill('fuhan');
 					'step 1'
 					event.num=Math.min(event.num,8);
-					player.reinit('zhaoxiang',result.links[0],false);
-					if(_status.characterlist){
-						_status.characterlist.add('zhaoxiang');
-						_status.characterlist.remove(result.links[0]);
-					}
+					player.reinitCharacter('zhaoxiang',result.links[0]);
 					'step 2'
 					var num=event.num-player.maxHp;
 					if(num>0) player.gainMaxHp(num);
@@ -25520,16 +25506,12 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.awakenSkill('xinfu_xushen');
 						player.logSkill('xinfu_xushen',trigger.source);
 						if(trigger.source.name2!=undefined){
-							trigger.source.chooseControl(trigger.source.name,trigger.source.name2).set('prompt','请选择要更换的武将牌');
-						}else event._result={control:trigger.source.name};
+							trigger.source.chooseControl(trigger.source.name1,trigger.source.name2).set('prompt','请选择要更换的武将牌');
+						}else event._result={control:trigger.source.name1};
 					}
 					else event.finish();
 					"step 2"
-					trigger.source.reinit(result.control,'guansuo');
-					if(_status.characterlist){
-						_status.characterlist.add(result.control);
-						_status.characterlist.remove('guansuo');
-					}
+					trigger.source.reinitCharacter(result.control,'guansuo');
 					player.recover();
 					player.addSkills('xinfu_zhennan');
 				},

--- a/character/sp.js
+++ b/character/sp.js
@@ -18535,16 +18535,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				charlotte:true,
 			},
 			weidi:{
-				trigger:{global:['gameStart','zhuUpdate']},
-				forced:true,
-				audio:2,
-				filter:function(event,player){
-					var mode=get.mode();
-					return (mode=='identity'||(mode=='versus'&&_status.mode=='four'));
-				},
-				content:function(){
-					var list=[];
-					var zhu=get.zhu(player);
+				init(player){
+					const list=[];
+					const zhu=get.zhu(player);
 					if(zhu&&zhu!=player&&zhu.skills){
 						for(var i=0;i<zhu.skills.length;i++){
 							if(lib.skill[zhu.skills[i]]&&lib.skill[zhu.skills[i]].zhuSkill){
@@ -18562,6 +18555,24 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							info.audioname2.yuanshu='weidi';
 						}
 					},list);
+				},
+				trigger:{global:['gameStart','changeSkills']},
+				forced:true,
+				audio:2,
+				filter:function(event,player){
+					const mode = get.mode();
+					if (mode != 'identity' && (mode != 'versus' || _status.mode != 'four')) return false;
+					const zhu = get.zhu(player);
+					if (!zhu || zhu == player) return false;
+					if(event.name == 'gameStart') return true;
+					return event.player == zhu && (event.addSkill.some(skill => {
+						return lib.skill[skill] && lib.skill[skill].zhuSkill;
+					}) || event.addSkill.some(skill => {
+						return lib.skill[skill] && lib.skill[skill].zhuSkill;
+					}));
+				},
+				async content (event, trigger, player) {
+					lib.skill.weidi.init(player);
 				}
 			},
 			zhenlue:{
@@ -18694,9 +18705,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							return info&&info.zhuSkill;
 						});
 						if(skills.length){
-							for(var i of skills) target.addSkillLog(i);
+							target.addSkills(skills);
 						}
-						if(target.isZhu2()) event.trigger('zhuUpdate');
 					}
 				},
 				ai:{expose:0.2},

--- a/character/sp.js
+++ b/character/sp.js
@@ -18556,7 +18556,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						}
 					},list);
 				},
-				trigger:{global:['gameStart','changeSkills']},
+				trigger:{global:['gameStart','changeSkillsAfter']},
 				forced:true,
 				audio:2,
 				filter:function(event,player){
@@ -18573,7 +18573,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				async content (event, trigger, player) {
 					lib.skill.weidi.init(player);
-				}
+				},
 			},
 			zhenlue:{
 				audio:2,

--- a/character/sp2.js
+++ b/character/sp2.js
@@ -6476,7 +6476,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.discard(result.cards).delay=false;
 						player.line2(game.filterPlayer(function(current){
 							if(current.hasSkill('panshi')){
-								current.removeSkill('panshi');
+								current.removeSkills('panshi');
 								return true;
 							}
 						}).concat(result.targets),'green');
@@ -6738,7 +6738,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				onremove:function(player){
 					delete player.storage.zhihu_mark;
-					player.removeSkill('zhihu');
+					player.removeSkills('zhihu');
 				},
 				trigger:{global:'phaseBeginStart'},
 				firstDo:true,

--- a/character/sp2.js
+++ b/character/sp2.js
@@ -6605,16 +6605,11 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						if(target.name2!=undefined){
 							target.chooseControl(target.name1,target.name2).set('prompt','请选择要更换的武将牌');
 						}
-						else event._result={control:target.name};
+						else event._result={control:target.name1};
 					}
 					else event.goto(4);
 					'step 3'
-					target.reinit(result.control,'dc_guansuo');
-					if(target.name=='dc_guansuo'&&target.group!='shu') target.changeGroup('shu');
-					if(_status.characterlist){
-						_status.characterlist.add(result.control);
-						_status.characterlist.remove('dc_guansuo');
-					}
+					target.reinitCharacter(result.control,'dc_guansuo');
 					'step 4'
 					target.draw(3);
 				},

--- a/character/standard.js
+++ b/character/standard.js
@@ -2103,8 +2103,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					const cards=player.getEquips(1);
 					if(cards.length) player.discard(cards);
 					player.loseMaxHp();
-					player.addSkill('mashu');
-					player.addSkill('shenji');
+					player.addSkills(['mashu','shenji']);
 				},
 				derivation:['mashu','shenji'],
 			},

--- a/character/tw.js
+++ b/character/tw.js
@@ -2594,10 +2594,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						forced:true,
 						locked:false,
 						content:function(){
-							for(var i of player.getStorage('twduoren')){
-								player.removeSkill(i);
-								game.log(player,'失去了技能','#g【'+get.translation(i)+'】');
-							}
+							player.removeSkills(player.getStorage('twduoren'));
 							delete player.storage.twduoren;
 						}
 					}
@@ -5326,7 +5323,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 0'
 					player.awakenSkill('twneirao');
 					player.removeSkills('twjiekuang');
-					game.log(player,'失去了技能','#g【竭匡】');
 					'step 1'
 					var num=player.countCards('he'),cards=[];
 					player.discard(player.getCards('he'));
@@ -8580,8 +8576,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				multiline:true,
 				content:function(){
 					'step 0'
-					game.countPlayer(function(current){
-						current.removeSkill('twgonghuan');
+					game.filterPlayer().sortBySeat().forEach(function(current){
+						current.removeSkills('twgonghuan');
 					});
 					'step 1'
 					targets.sortBySeat();
@@ -12572,9 +12568,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								break;
 							default:
 								player.logSkill('twlingfa');
-								player.removeSkill('twlingfa');
-								game.log(player,'失去了技能','#g【令法】');
-								player.addSkills('twzhian');
+								player.addSkills(['twzhian'],['twlingfa']);
 								break;
 						}
 					}

--- a/character/tw.js
+++ b/character/tw.js
@@ -2569,7 +2569,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						return info&&!info.hiddenSkill&&!info.zhuSkill&&!info.charlotte;
 					});
 					if(skills.length){
-						for(var i of skills) player.addSkillLog(i);
+						//for(var i of skills) player.addSkillLog(i);
+						player.addSkills(skills);
 						player.markAuto('twduoren',skills);
 						game.broadcastAll(function(list){
 							game.expandSkills(list);
@@ -3235,7 +3236,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(result.bool){
 						var target=result.targets[0];
 						player.logSkill('twjuntun',target);
-						target.addSkillLog('twxiongjun');
+						target.addSkills('twxiongjun');
 						if(target!=player) player.addExpose(0.25);
 					}
 				},
@@ -4313,7 +4314,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.awakenSkill('twmibei');
 					player.logSkill('twmibei_achieve');
 					game.log(player,'成功完成使命');
-					player.addSkillLog('twmouli');
+					player.addSkils('twmouli');
 				},
 				intro:{content:'已使用牌名：$'},
 				subSkill:{
@@ -5324,7 +5325,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					'step 0'
 					player.awakenSkill('twneirao');
-					player.removeSkill('twjiekuang');
+					player.removeSkills('twjiekuang');
 					game.log(player,'失去了技能','#g【竭匡】');
 					'step 1'
 					var num=player.countCards('he'),cards=[];
@@ -5337,7 +5338,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					if(cards.length) player.gain(cards,'gain2');
 					'step 2'
-					player.addSkillLog('twluanlve');
+					player.addSkills('twluanlve');
 				},
 			},
 			twluanlve:{
@@ -6830,12 +6831,12 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.gain(gains,'gain2');
 					}
 					'step 3'
-					player.addSkillLog('twqingce');
+					player.addSkills('twqingce');
 					player.chooseBool('是否减1点体力上限并获得〖扫讨〗？').set('ai',()=>_status.event.bool).set('bool',player.isDamaged()&&player.countCards('h')>=3?(Math.random()<0.5?true:false):false);
 					'step 4'
 					if(result.bool){
 						player.loseMaxHp();
-						player.addSkillLog('twsaotao');
+						player.addSkills('twsaotao');
 						game.delayx();
 					}
 				},
@@ -8584,7 +8585,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					});
 					'step 1'
 					targets.sortBySeat();
-					for(var i of targets) i.addSkillLog('twgonghuan');
+					for(var i of targets) i.addSkills('twgonghuan');
 				},
 				derivation:'twgonghuan',
 				ai:{
@@ -11534,10 +11535,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				logTarget:()=>game.filterPlayer().sortBySeat(),
 				content:function(){
 					'step 0'
-					game.countPlayer(function(current){
-						current.addSkill('twfeifu');
+					game.filterPlayer().sortBySeat().forEach(function(current){
+						current.addSkills('twfeifu');
 					});
-					game.log(player,'令所有其他角色获得了技能','#g【非服】')
+					//game.log(player,'令所有其他角色获得了技能','#g【非服】')
 					game.delayx();
 					'step 1'
 					player.chooseTarget('是否减1点体力上限，并令一名其他角色获得技能【复纂】？',lib.filter.notMe).set('ai',function(target){
@@ -11551,7 +11552,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.loseMaxHp();
 						var target=result.targets[0];
 						player.line(target,'fire');
-						target.addSkillLog('twfuzuan');
+						target.addSkills('twfuzuan');
 						game.delayx();
 					}
 				},
@@ -12041,7 +12042,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}).set('choice',skills.sort((a,b)=>(map[b](target,player)||0.5)-(map[a](target,player)||0.5))[0]);
 					'step 1'
 					var skill=result.control;
-					player.addSkillLog(skill);
+					player.addSkills(skill);
 					event.twbudao_skill=skill;
 					player.chooseTarget(lib.filter.notMe,'是否令一名其他角色也获得【'+get.translation(skill)+'】？').set('ai',function(target){
 						var player=_status.event.player;
@@ -12053,7 +12054,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						var target=result.targets[0];
 						event.target=target;
 						player.line(target,'green');
-						target.addSkillLog(event.twbudao_skill);
+						target.addSkills(event.twbudao_skill);
 						var cards=target.getCards('he');
 						if(!cards.length) event.finish();
 						else if(cards.length==1) event._result={bool:true,cards:cards};
@@ -12573,7 +12574,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								player.logSkill('twlingfa');
 								player.removeSkill('twlingfa');
 								game.log(player,'失去了技能','#g【令法】');
-								player.addSkillLog('twzhian');
+								player.addSkills('twzhian');
 								break;
 						}
 					}
@@ -13076,7 +13077,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							var info=get.info(skill);
 							return info&&info.zhuSkill;
 						});
-						for(var i of skills) target.addSkillLog(i);
+						target.addSkills(skills);
+						//for(var i of skills) target.addSkillLog(i);
 					}
 				},
 			},
@@ -13470,7 +13472,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					target.disableJudge();
 					player.markAuto('twjuezhu_restore',[[target,result.control]]);
 					player.addSkill('twjuezhu_restore');
-					target.addSkill('feiying');
+					target.addSkills('feiying');
 				},
 				subSkill:{
 					restore:{
@@ -13931,7 +13933,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						var name=result.links[0];
 						player.flashAvatar('twhuashen',name);
 						game.log(player,'获得了','#y'+get.translation(name),'的所有技能');
-						player.addSkill(lib.character[name][3])
+						player.addSkills(lib.character[name][3])
 					}
 					'step 2'
 					var num=event.num-player.maxHp;

--- a/character/xianding.js
+++ b/character/xianding.js
@@ -6029,9 +6029,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					player.awakenSkill('dcmoucheng');
-					player.removeSkill('dclianji');
-					game.log(player,'失去了技能','#g【连计】');
-					player.addSkillLog('xinjingong');
+					player.changeSkills(['xinjingong'],['dclianji']);
 				},
 			},
 			//周宣
@@ -6462,8 +6460,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							if(result.bool){
 								var target=result.targets[0];
 								player.logSkill('dclianzhi_reproach',target);
-								player.addSkillLog('dcshouze');
-								target.addSkillLog('dcshouze');
+								player.addSkills('dcshouze');
+								target.addSkills('dcshouze');
 								target.addMark('dclingfang',Math.max(1,player.countMark('dclingfang')));
 							}
 						},
@@ -7494,7 +7492,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					var targets=lib.skill.dcyaoyi.logTarget().sortBySeat();
-					for(var target of targets) target.addSkill('dcshoutan');
+					for(var target of targets) target.addSkills('dcshoutan');
 					game.delayx();
 				},
 				global:'dcyaoyi_blocker',
@@ -8247,8 +8245,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					'step 3'
 					var map=event.result||result;
 					if(map.skills&&map.skills.length){
-						player.removeSkill('dchuishu');
-						for(var i of map.skills) player.addSkillLog(i);
+						//player.removeSkill('dchuishu');
+						//for(var i of map.skills) player.addSkillLog(i);
+						player.changeSkills(map.skills, ['dchuishu']);
 						player.markAuto('zhuSkill_dcligong',map.skills);
 					}
 					else{
@@ -9377,8 +9376,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						targets.sortBySeat();
 						player.logSkill('dcpijing',targets);
 						game.countPlayer(function(current){
-							if(!targets.includes(current)) current.removeSkill('dczimu');
-							else current.addSkill('dczimu');
+							if(!targets.includes(current)) current.removeSkills('dczimu');
+							else current.addSkills('dczimu');
 						});
 						game.delayx();
 					}
@@ -9580,7 +9579,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						return info&&!info.charlotte;
 					});
 					if(skills.length){
-						for(var i of skills) player.addSkillLog(i);
+						//for(var i of skills) player.addSkillLog(i);
+						player.addSkills(skills);
 					}
 					player.removeSkill('xiaowu');
 					var num=player.countMark('shawu');
@@ -9611,7 +9611,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								var target=result.targets[0];
 								player.awakenSkill('huaping');
 								player.logSkill('huaping_give',target);
-								target.addSkill('shawu');
+								target.addSkills('shawu');
 								var num=player.countMark('shawu');
 								if(num>0){
 									player.removeMark('shawu',num);
@@ -10445,7 +10445,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.reinit('re_sunyi','xushi',false);
 					}
 					else{
-						player.addSkillLog('olhunzi');
+						player.addSkills('olhunzi');
 						event.goto(2);
 					}
 					'step 1'
@@ -10689,8 +10689,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.awakenSkill('mengqing');
 					player.gainMaxHp(3);
 					player.recover(3);
-					player.removeSkill('zhukou');
-					player.addSkill('yuyun');
+					//player.removeSkill('zhukou');
+					//player.addSkill('yuyun');
+					player.changeSkills(['yuyun'],['zhukou']);
 				},
 				derivation:'yuyun',
 			},
@@ -12065,7 +12066,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						var target=result.targets[0];
 						player.logSkill('dushi',target);
 						target.markSkill('dushi');
-						target.addSkillLog('dushi');
+						target.addSkills('dushi');
 					}
 				},
 				intro:{content:'您已经获得弘农王的诅咒'},
@@ -12403,7 +12404,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.awakenSkill('choujue');
 					player.storage.choujue=true;
 					player.loseMaxHp();
-					player.addSkill('beishui');
+					player.addSkills('beishui');
 				},
 			},
 			beishui:{
@@ -12425,7 +12426,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.awakenSkill('beishui');
 					player.storage.beishui=true;
 					player.loseMaxHp();
-					player.addSkill('qingjiao');
+					player.addSkills('qingjiao');
 				},
 			},
 			qingjiao:{
@@ -12699,9 +12700,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(result.bool){
 						var target=result.targets[0];
 						player.line(target,'fire');
-						player.addSkill('hmxili');
-						target.addSkill('hmxili');
-						player.removeSkill('mansi');
+						player.addSkills(['hmxili'],['mansi']);
+						target.addSkills('hmxili');
 					}
 				},
 			},

--- a/character/xianding.js
+++ b/character/xianding.js
@@ -3208,9 +3208,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(!_status.characterlist){
 						lib.skill.pingjian.initList();
 					}
-					_status.characterlist.remove(character);
-					_status.characterlist.add('ganfurenmifuren');
-					player.reinit('ganfurenmifuren',character,false);
+					player.reinitCharacter('ganfurenmifuren',character);
 					'step 2'
 					player.recover(1-player.hp);
 					player.addTempSkill('dcxunbie_muteki',{player:'phaseAfter'});
@@ -10426,37 +10424,25 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(player!=event.dying) return false;
 					return true;
 				},
-				content:function(){
+				async content(event,trigger,player){
 					'step 0'
 					player.awakenSkill('syxiongyi');
 					if(!_status.characterlist){
 						lib.skill.pingjian.initList();
 					}
-					event.hp=1-player.hp;
 					if(_status.characterlist.includes('xushi')){
-						if(player.name1=='re_sunyi'||player.name2=='re_sunyi') event._result={control:'re_sunyi'};
-						else if(player.name2!=undefined){
-							player.chooseControl(player.name1,player.name2).set('prompt','请选择要更换的武将牌');
+						if (player.name2&&get.character(player.name2)[3].includes('syxiongyi')) {
+							await player.reinitCharacter(player.name2, 'xushi');
 						}
-						else event._result={control:player.name1};
-						hp+=2;
-						_status.characterlist.remove('xushi');
-						_status.characterlist.add('re_sunyi');
-						player.reinit('re_sunyi','xushi',false);
+						else {
+							await player.reinitCharacter(player.name1, 'xushi');
+						}
+						if(player.hp<3) await player.recover(3-player.hp);
 					}
 					else{
-						player.addSkills('olhunzi');
-						event.goto(2);
+						await player.addSkills('olhunzi');
+						if(player.hp<1) await player.recover(1-player.hp);
 					}
-					'step 1'
-					event.hp+=2;
-					var name=result.control;
-					_status.characterlist.remove('xushi');
-					_status.characterlist.add(name);
-					player.reinit(name,'xushi',false);
-					'step 2'
-					var hp=event.hp;
-					if(hp>0) player.recover(hp);
 				},
 				ai:{
 					order:1,

--- a/character/xianding.js
+++ b/character/xianding.js
@@ -8120,7 +8120,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.gainMaxHp();
 					player.recover();
 					'step 1'
-					player.removeSkill('dcyishu');
+					player.removeSkills('dcyishu');
 					'step 2'
 					var list;
 					if(_status.characterlist){
@@ -9407,7 +9407,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						}
 					}
 					'step 1'
-					player.removeSkill('dczimu');
+					player.removeSkills('dczimu');
 					if(event.delay) game.delayx();
 				},
 				marktext:'牧',
@@ -9582,7 +9582,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						//for(var i of skills) player.addSkillLog(i);
 						player.addSkills(skills);
 					}
-					player.removeSkill('xiaowu');
+					player.removeSkills('xiaowu');
 					var num=player.countMark('shawu');
 					if(num>0){
 						player.removeMark('shawu',num);

--- a/character/xinghuoliaoyuan.js
+++ b/character/xinghuoliaoyuan.js
@@ -217,13 +217,13 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				derivation:"xinfu_zhanji",
 				trigger:{global:"dieAfter"},
 				logTarget:'player',
-				content:function (){
+				async content(e,t,player){
 					player.awakenSkill('xinfu_songsang');
 					if(player.isDamaged()){
 						player.recover();
 					}
 					else player.gainMaxHp();
-					player.addSkill('xinfu_zhanji');
+					player.addSkills('xinfu_zhanji');
 				},
 			},
 			"xinfu_jixu":{

--- a/character/yijiang.js
+++ b/character/yijiang.js
@@ -3590,7 +3590,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					'step 3'
 					if(result.bool&&result.autochoose&&result.cards.length==result.rawcards.length){
-						player.removeSkill('jiexun');
+						player.removeSkills('jiexun');
 						player.addSkill('funan_jiexun');
 					}
 				}
@@ -8142,7 +8142,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(result.bool){
 						var es=target.getCards('e');
 						target.give(es,player,'give');
-						player.removeSkill('yanzhu');
+						player.removeSkills('yanzhu');
 					}
 					else{
 						target.chooseToDiscard(true,'he');
@@ -13718,10 +13718,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					player.awakenSkill('zbaijiang');
 					player.gainMaxHp();
-					player.removeSkill('zquanji');
-					player.removeSkill('zzhenggong');
-					game.log(player,'失去了技能','#g【权计】、【争功】');
-					player.addSkills(['zyexin','zzili']);
+					player.changeSkills(['zyexin','zzili'],['zquanji','zzhenggong']);
 				}
 			},
 			zyexin:{

--- a/character/yijiang.js
+++ b/character/yijiang.js
@@ -3026,7 +3026,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						var target=result.targets[0];
 						event.target=target;
 						player.line(target,'thunder');
-						target.addSkill('new_canyun');
+						target.addSkills('new_canyun');
 						target.discardPlayerCard('是否弃置自己区域内的一张梅花牌，获得技能〖绝响〗？',target,'hej').set('ai',function(card){
 							if(get.position(card)=='j') return 100+get.value(card);
 							return 100-get.value(card);
@@ -3036,7 +3036,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					}
 					else event.finish();
 					"step 3"
-					if(result.bool) target.addSkill('new_juexiang');
+					if(result.bool) target.addSkills('new_juexiang');
 				},
 			},
 			"new_canyun":{
@@ -4013,7 +4013,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(result.bool){
 						var target=result.targets[0]
 						player.logSkill('juexiang',target);
-						target.addSkill(lib.skill.juexiang.derivation.randomGet());
+						target.addSkills(lib.skill.juexiang.derivation.randomGet());
 						target.addTempSkill('juexiang_club',{player:'phaseZhunbeiBegin'});
 					}
 				},
@@ -10927,14 +10927,14 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				content:function(){
 					"step 0"
+					player.awakenSkill('zili');
 					player.chooseDrawRecover(2,true,function(event,player){
 						if(player.hp==1&&player.isDamaged()) return 'recover_hp';
 						return 'draw_card';
 					});
 					"step 1"
 					player.loseMaxHp();
-					player.addSkill('paiyi');
-					player.awakenSkill('zili');
+					player.addSkills('paiyi');
 				}
 			},
 			paiyi:{
@@ -13721,8 +13721,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					player.removeSkill('zquanji');
 					player.removeSkill('zzhenggong');
 					game.log(player,'失去了技能','#g【权计】、【争功】');
-					player.addSkillLog('zyexin');
-					player.addSkillLog('zzili');
+					player.addSkills(['zyexin','zzili']);
 				}
 			},
 			zyexin:{
@@ -13780,10 +13779,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					return player.getExpansions('zyexin').length>=4;
 				},
 				forced:true,
-				content:function(){
+				async content(e,t,player){
 					player.awakenSkill('zzili');
 					player.loseMaxHp();
-					player.addSkill('zpaiyi');
+					player.addSkills('zpaiyi');
 				},
 				// intro:{
 				// 	content:'limited'

--- a/character/yingbian.js
+++ b/character/yingbian.js
@@ -867,7 +867,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					player.awakenSkill('dezhang');
 					player.loseMaxHp();
-					player.addSkill('weishu');
+					player.addSkills('weishu');
 				},
 			},
 			weishu:{
@@ -3445,7 +3445,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				content:function(){
 					player.awakenSkill('zhaotao');
 					player.loseMaxHp();
-					player.addSkillLog('pozhu');
+					player.addSkills('pozhu');
 				},
 				derivation:'pozhu',
 			},

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -2169,7 +2169,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 						event.finish();
 					}
 					else{
-						target.addSkillLog(result.control);
+						target.addSkills(result.control);
 						target.line(player);
 						player.recover(player.maxHp-player.hp);
 					}
@@ -3914,7 +3914,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					if(result.bool){
 						var target=result.targets[0];
 						player.logSkill('gzlianyou',target);
-						target.addSkillLog('gzxinghuo');
+						target.addSkills('gzxinghuo');
 						game.delayx();
 					}
 				},
@@ -10828,8 +10828,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					if(list.length){
 						player.gain(list,'gain2');
 						if(list.length>=3&&player.hasStockSkill('lianzi')){
-							player.removeSkill('lianzi');
-							player.addSkill('gzzhiheng');
+							player.changeSkills(['gzzhiheng'],['lianzi']);
 						}
 					}
 				},
@@ -11997,9 +11996,8 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 						player.recover(2-player.hp);
 					}
 					'step 2'
-					player.removeSkill('shouyue');
 					player.removeSkill('wuhujiangdaqi');
-					player.addSkill('rerende');
+					player.changeSkills(['rerende'],['shouyue']);
 				},
 				ai:{
 					order:1,
@@ -12420,7 +12418,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 						player.removeCharacter(1);
 					}
 					'step 1'
-					target.addSkill('gzyongjue');
+					target.addSkills('gzyongjue');
 					if(target!=player){
 						target.draw(2);
 					}
@@ -12504,11 +12502,11 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					'step 0'
 					player.removeCharacter(1);
 					'step 1'
-					player.removeSkill('baoling');
+					player.removeSkills('baoling');
 					player.gainMaxHp(3,true);
 					'step 2'
 					player.recover(3);
-					player.addSkill('benghuai');
+					player.addSkills('benghuai');
 				},
 				derivation:'benghuai'
 			},
@@ -15523,7 +15521,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					if(event.hidden) game.log(player,'替换了副将','#g'+get.translation(player.name2));
 					else game.log(player,'将副将从','#g'+get.translation(player.name2),'变更为','#g'+get.translation(name));
 					player.viceChanged=true;
-					player.reinit(player.name2,name,false);
+					player.reinitCharacter(player.name2,name,false);
 				},
 				changeVice:function(){
 					'step 0'
@@ -15579,7 +15577,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					if(event.hidden) game.log(player,'替换了副将','#g'+get.translation(player.name2));
 					else game.log(player,'将副将从','#g'+get.translation(player.name2),'变更为','#g'+get.translation(name));
 					player.viceChanged=true;
-					player.reinit(player.name2,name,false);
+					player.reinitCharacter(player.name2,name,false);
 				},
 				/*----分界线----*/
 				mayChangeVice:function(){

--- a/mode/identity.js
+++ b/mode/identity.js
@@ -3874,12 +3874,13 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 					'step 2'
 					player.recover();
 					player.draw();
-					player.getStockSkills(true,true).forEach(stockSkill=>{
+					const skills = player.getStockSkills(true,true).forEach(stockSkill=>{
 						if(player.hasSkill(stockSkill)) return;
 						var info=get.info(stockSkill);
 						if(!info||!info.zhuSkill) return;
-						player.addSkillLog(stockSkill);
+						return true;
 					});
+					if(skills.length) player.addSkills(skills)
 				}
 			},
 			stratagem_revitalization:{

--- a/mode/identity.js
+++ b/mode/identity.js
@@ -2785,7 +2785,7 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 								return info&&info.zhuSkill;
 							});
 							if(skills.length){
-								for(var i of skills) player.addSkillLog(i);
+								player.addSkills(skills);
 							}
 							game.zhu.node.identity.classList.remove('guessing');
 							if(lib.config.animation&&!lib.config.low_performance) game.zhu.$legend();
@@ -2800,7 +2800,6 @@ game.import('mode',function(lib,game,ui,get,ai,_status){
 						},game.zhu);
 						game.delay(2);
 						game.zhu.playerfocus(1000);
-						_status.event.trigger('zhuUpdate');
 					}
 
 					if(!_status.over){

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -12,7 +12,7 @@ export const Content = {
 		event.trigger(event.name);
 	},
 	//变更技能
-	changeSkills: async function (event,trigger,player) {
+	async changeSkills (event,trigger,player) {
 		//去重检查
 		event.addSkill.unique();
 		event.removeSkill.unique();
@@ -26,8 +26,14 @@ export const Content = {
 		await event.trigger('changeSkillsBefore');
 		await event.trigger('changeSkillsBegin');
 		//处理失去和获得的技能
-		if(event.addSkill.length) player.addSkillLog(event.addSkill);
-		if(event.removeSkill.length) player.removeSkillLog(event.removeSkill);
+		if(event.$handle){
+			event.$handle(player,event.addSkill,event.removeSkill,event);
+		}
+		else{
+			if(event.addSkill.length) player.addSkillLog(event.addSkill);
+			if(event.removeSkill.length) player.removeSkillLog(event.removeSkill);
+		}
+		//手动触发时机
 		await event.trigger('changeSkillsEnd');
 		await event.trigger('changeSkillsAfter');
 	},

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -19,7 +19,7 @@ export const Content = {
 		const newPairs = event.newPairs;
 		for(let name of newPairs){
 			if(!lib.character[name]){
-				console.warn(`警告：Player[${player.name}]试图将武将牌变更为不存在的武将“${name}”`);
+				console.warn(`警告：Player[${player.name}]试图将武将牌变更为不存在的武将`,name);
 				return;
 			}
 		}

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -11,6 +11,26 @@ export const Content = {
 	emptyEvent: () => {
 		event.trigger(event.name);
 	},
+	//变更技能
+	changeSkills: async function (event,trigger,player) {
+		//去重检查
+		event.addSkill.unique();
+		event.removeSkill.unique();
+		const duplicatedSkills = event.addSkill.filter(skill => event.removeSkill.includes(skill));
+		if(duplicatedSkills.length){
+			event.addSkill.removeArray(duplicatedSkills);
+			event.removeSkill.removeArray(duplicatedSkills);
+		}
+		if(!event.addSkill.length&&!event.removeSkill.length) return;
+		//手动触发时机
+		await event.trigger('changeSkillsBefore');
+		await event.trigger('changeSkillsBegin');
+		//处理失去和获得的技能
+		if(event.addSkill.length) player.addSkillLog(event.addSkill);
+		if(event.removeSkill.length) player.removeSkillLog(event.removeSkill);
+		await event.trigger('changeSkillsEnd');
+		await event.trigger('changeSkillsAfter');
+	},
 	//增加明置手牌
 	addShownCards: () => {
 		const hs = player.getCards('h'), showingCards = event._cards.filter(showingCard => hs.includes(showingCard)), shown = player.getShownCards();

--- a/noname/library/element/gameEvent.js
+++ b/noname/library/element/gameEvent.js
@@ -731,8 +731,8 @@ export class GameEvent {
 		}
 	}
 	trigger(name) {
-		if (_status.video) return this;
-		if ((this.name === 'gain' || this.name === 'lose') && !_status.gameDrawed) return this;
+		if (_status.video) return;
+		if ((this.name === 'gain' || this.name === 'lose') && !_status.gameDrawed) return;
 		if (name === 'gameDrawEnd') _status.gameDrawed = true;
 		if (name === 'gameStart') {
 			lib.announce.publish('gameStart', {});
@@ -741,11 +741,11 @@ export class GameEvent {
 			_status.gameStarted = true;
 			game.showHistory();
 		}
-		if (!lib.hookmap[name] && !lib.config.compatiblemode) return this;
-		if (!game.players || !game.players.length) return this;
+		if (!lib.hookmap[name] && !lib.config.compatiblemode) return;
+		if (!game.players || !game.players.length) return;
 		const event = this;
 		let start = [_status.currentPhase, event.source, event.player, game.me, game.players[0]].find(i => get.itemtype(i) == 'player');
-		if (!start) return this;
+		if (!start) return;
 		if (!game.players.includes(start) && !game.dead.includes(start)) start = game.findNext(start);
 		const firstDo = {
 			player: "firstDo",
@@ -836,8 +836,9 @@ export class GameEvent {
 			next.triggername = name;
 			next.playerMap = playerMap;
 			event._triggering = next;
+			return next;
 		}
-		return this;
+		return null;
 	}
 	untrigger(all = true, player) {
 		const evt = this._triggering;

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -7200,8 +7200,8 @@ export class Player extends HTMLDivElement {
 	changeSkills(addSkill = [], removeSkill = []){
 		const next = game.createEvent('changeSkills', false);
 		next.player = this;
-		next.addSkill = addSkill.unique();
-		next.removeSkill = removeSkill.unique();
+		next.addSkill = addSkill.slice(0).unique();
+		next.removeSkill = removeSkill.slice(0).unique();
 		next.setContent('changeSkills');
 		return next;
 	}

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -7189,6 +7189,22 @@ export class Player extends HTMLDivElement {
 		}
 		return skill;
 	}
+	addSkills(skill){
+		if(!skill) return;
+		return this.changeSkills(Array.isArray(skill) ? skill : [skill], []);
+	}
+	removeSkills(skill){
+		if(!skill) return;
+		return this.changeSkills([], Array.isArray(skill) ? skill : [skill]);
+	}
+	changeSkills(addSkill = [], removeSkill = []){
+		const next = game.createEvent('changeSkills', false);
+		next.player = this;
+		next.addSkill = addSkill.unique();
+		next.removeSkill = removeSkill.unique();
+		next.setContent('changeSkills');
+		return next;
+	}
 	addSkill(skill, checkConflict, nobroadcast, addToSkills) {
 		if (Array.isArray(skill)) {
 			_status.event.clearStepCache();

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -1560,7 +1560,7 @@ export class Player extends HTMLDivElement {
 	 * @param { String } to
 	 * @returns { GameEventPromise }
 	 */
-	reinitCharacter(from, to){
+	reinitCharacter(from, to, log = true){
 		const rawPairs = [this.name1];
 		if (this.name2) rawPairs.push(this.name2);
 		for (let i=0; i<rawPairs.length; i++){
@@ -1569,16 +1569,27 @@ export class Player extends HTMLDivElement {
 				break;
 			}
 		}
-		return this.changeCharacter(rawPairs);
+		return this.changeCharacter(rawPairs, log);
 	}
 	/**
 	 * @param { String[] } newPairs
 	 * @returns { GameEventPromise }
 	 */
-	changeCharacter(newPairs){
+	changeCharacter(newPairs, log = true){
+		if (!Array.isArray(newPairs)){
+			console.warn(`警告：Player[${this.name}].changeCharacter填写了一个错误的参数:`,newPairs);
+			return;
+		}
+		for(let name of newPairs){
+			if(!lib.character[name]){
+				console.warn(`警告：Player[${this.name}]试图将武将牌变更为不存在的武将:`,name);
+				return;
+			}
+		}
 		const next = game.createEvent('changeCharacter');
 		next.player = this;
 		next.newPairs = newPairs;
+		next.log = log;
 		next.setContent('changeCharacter');
 		return next;
 	}


### PR DESCRIPTION
将**GameEvent#trigger的返回值**改为新触发的arrangeTrigger事件，从而可以在async content里面进行等待。

此外，添加**事件化版本**的”技能变化“事件，从而实现“获得技能时”和”失去技能时“的时机。
添加函数`Player#changeSkills([要获得的技能], [要失去的技能])`，用于进行技能的获得和移除。使用例：
```
//令player失去”激昂“和”魂姿“并获得“英姿”和“英魂”
player.changeSkills(['jiang', 'hunzi'], ['reyingzi', 'gzyinghun']);
```
changeSkills事件拥有四个标准的时机（changeSkillsBefore/changeSkillsBegin/changeSkillsEnd/changeSkillsAfter），且在触发时机前会自动去重。在该GameEvent中，`event.addSkill`为本次事件中，角色获得的技能；`event.removeSkill`为本次事件中，角色失去的技能。默认为先获得技能，后失去技能。
如果有特殊的需求（比如需要使用addAdditionalSkill，或者自行决定失去/获得技能的先后顺序），可以给changeSkills事件触发自定义的`$handle流程`。使用例：
```
//神孙权“驭衡”
const skills = player.additionalSkills.junkyuheng;
player.draw(skills.length);
player.changeSkills([],skills).set('$handle',(player,addSkills,removeSkills)=>{
	game.log(player,'失去了以下技能：','#g'+get.translation(removeSkills));
	for(let skill of removeSkills) player.removeAdditionalSkill('junkyuheng',skill);
});
```
如果你只需要获得技能/只需要失去技能，那么可以直接使用`Player#addSkills`和`Player#removeSkills`。使用例：
```
player.removeSkills('rende'); //一次失去单个技能
player.addSkills(['jianxiong','hujia']); //一次获得多个技能
```
这两个函数会直接调用changeSkills事件。
**注意！！！** 如果你只是想获得一个“效果”（比如天义拼点成功之后多刀的效果），而不是**像觉醒技一样**获得一个“技能”，请继续使用addSkill/removeSkill，而不是使用新的函数！

此外，还添加了`Player#changeCharacter`的函数，触发一个**变更武将牌**的事件，并在事件内部触发“变更势力”和“变更技能”的事件。但该事件**不会变更角色的体力值和体力上限**，请自行手动判断和手动变更。使用例：
```
//让player变身为文鸯单将。如果有副将，则移除副将。由于文鸯是双势力武将，变身之后会让玩家选择变为魏势力还是吴势力。
player.changeCharacter(['db_wenyang']); 
//让player变身为主将刘备，副将孙权的组合。如果没有副将，则添加副将；且将势力变更为新主将刘备对应的蜀势力。
player.changeCharacter(['liubei','sunquan']); 
```
无论角色原本有没有副将，或者原本的副将是否为目标角色，该函数都可以自行判断并处理。如果你想和reinit函数一样，写成旧武将→新武将的一对一替换，那么可以使用`Player#reinitCharacter`，该函数会自动生成对应的changeCharacter事件。使用例：
```
player.reinitCharacter('dc_sunyi','xushi'); //让孙翊变身为徐氏
```