### PR TITLE
扩展加载失败提示

### DIFF
--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -1880,11 +1880,17 @@ export class Game extends Uninstantable {
 				help: help,
 				config: objectConfig
 			}
-			if (precontent) {
-				_status.extension = name;
-				await (gnc.is.generatorFunc(precontent) ? gnc.of(precontent) : precontent).call(object, config);
-				delete _status.extension;
+			try{
+    			if (precontent) {
+    				_status.extension = name;
+    				
+    				await (gnc.is.generatorFunc(precontent) ? gnc.of(precontent) : precontent).call(object, config);
+    				delete _status.extension;
+    			}
+			}catch(e1){
+			    alert(`扩展${name}载入失败\nprecontentError\n${decodeURI(e1.stack)}`);
 			}
+			
 			if (content) lib.extensions.push([name, content, config, _status.evaluatingExtension, objectPackage || {}]);
 		}
 		catch (e) {

--- a/noname/init/onload.js
+++ b/noname/init/onload.js
@@ -587,7 +587,11 @@ export async function onload(resetGameTimeout) {
 					_status.extension = lib.extensions[i][0];
 					_status.evaluatingExtension = lib.extensions[i][3];
 					if (typeof lib.extensions[i][1] == "function")
-						await (gnc.is.coroutine(lib.extensions[i][1]) ? gnc.of(lib.extensions[i][1]) : lib.extensions[i][1]).call(lib.extensions[i], lib.extensions[i][2], lib.extensions[i][4]);
+					    try{
+						    await (gnc.is.coroutine(lib.extensions[i][1]) ? gnc.of(lib.extensions[i][1]) : lib.extensions[i][1]).call(lib.extensions[i], lib.extensions[i][2], lib.extensions[i][4]);
+						}catch(e){
+						    alert(`扩展${lib.extensions[i][0]}载入失败\ncontentError\n${decodeURI(e.stack)}`);
+						}
 					if (lib.extensions[i][4]) {
 						if (lib.extensions[i][4].character) {
 							for (var j in lib.extensions[i][4].character.character) {


### PR DESCRIPTION
扩展的content和precontent载入失败后会弹窗提示，显示报错信息
报错信息格式：
alert(`扩展${lib.extensions[i][0]}载入失败\ncontentError\n${decodeURI(e.stack)}`);
![demo](https://github.com/libccy/noname/assets/68995302/8d4c2d2e-df9d-4947-b8d4-6ad85d7c2400)