### PR TITLE
修正get.is虚拟牌判断逻辑

### DIFF
--- a/noname/get/is.js
+++ b/noname/get/is.js
@@ -132,7 +132,7 @@ export class Is extends Uninstantable {
 	 */
 	// @ts-ignore
 	static vituralCard(card) {
-		return card.isCard || (!("cards" in card) || !Array.isArray(card.cards) || card.cards.length == 0);
+		return card.isCard && (!("cards" in card) || !Array.isArray(card.cards) || card.cards.length === 0);
 	}
 	/**
 	 * 是否是转化牌
@@ -147,7 +147,9 @@ export class Is extends Uninstantable {
 	 * @param { Card | VCard } card
 	 */
 	// @ts-ignore
-	static ordinaryCard(card) { return card.isCard && ("cards" in card) && Array.isArray(card.cards) && card.cards.length == 1 }
+	static ordinaryCard(card) {
+		return card.isCard && ("cards" in card) && Array.isArray(card.cards) && card.cards.length === 1
+	}
 	/**
 	 * 押韵判断
 	 * @param { string } str1


### PR DESCRIPTION
原判断逻辑为
`card.isCard || !card.cards?.length`
错误，会导致实体牌被判断为虚拟牌。
修改为
`card.isCard && !card.cards?.length`
可以解决此问题。