### PR TITLE
fix：`get.is.vituralCard()`将实体牌判断为虚拟牌，以及拼写问题

### DIFF
--- a/noname/get/is.js
+++ b/noname/get/is.js
@@ -132,7 +132,7 @@ export class Is extends Uninstantable {
 	 */
 	// @ts-ignore
 	static vituralCard(card) {
-		return card.isCard || (!("cards" in card) || !Array.isArray(card.cards) || card.cards.length == 0);
+		return card.isCard && (!("cards" in card) || !Array.isArray(card.cards) || card.cards.length === 0);
 	}
 	/**
 	 * 是否是转化牌
@@ -147,7 +147,9 @@ export class Is extends Uninstantable {
 	 * @param { Card | VCard } card
 	 */
 	// @ts-ignore
-	static ordinaryCard(card) { return card.isCard && ("cards" in card) && Array.isArray(card.cards) && card.cards.length == 1 }
+	static ordinaryCard(card) {
+		return card.isCard && ("cards" in card) && Array.isArray(card.cards) && card.cards.length === 1
+	}
 	/**
 	 * 押韵判断
 	 * @param { string } str1

--- a/noname/get/is.js
+++ b/noname/get/is.js
@@ -131,7 +131,7 @@ export class Is extends Uninstantable {
 	 * @param { Card | VCard } card
 	 */
 	// @ts-ignore
-	static vituralCard(card) {
+	static virtualCard(card) {
 		return card.isCard && (!("cards" in card) || !Array.isArray(card.cards) || card.cards.length === 0);
 	}
 	/**


### PR DESCRIPTION
原函数判断逻辑为
`card.isCard || !card.cards?.length`
错误，会将实体牌判断为虚拟牌。

将逻辑修改为
`card.isCard && !card.cards?.length`
可以解决这个问题。

同时，原拼写`vituralCard`错误，修正为`virtualCard`，与`libaray/element/player.js`中的拼写相同。
由于`get.is`中关于虚拟牌、转化牌、实体牌的判断逻辑在项目中没有使用，因此不会在项目中造成兼容性问题。
如果考虑兼容扩展，可以定义别名。