### PR TITLE
fix之fix：`get.is.virtualCard()`

### DIFF
--- a/noname/get/is.js
+++ b/noname/get/is.js
@@ -132,7 +132,7 @@ export class Is extends Uninstantable {
 	 */
 	// @ts-ignore
 	static virtualCard(card) {
-		return card.isCard && (!("cards" in card) || !Array.isArray(card.cards) || card.cards.length === 0);
+		return (!("cards" in card) || !Array.isArray(card.cards) || card.cards.length === 0);
 	}
 	/**
 	 * 是否是转化牌

--- a/noname/get/is.js
+++ b/noname/get/is.js
@@ -132,7 +132,7 @@ export class Is extends Uninstantable {
 	 */
 	// @ts-ignore
 	static virtualCard(card) {
-		return !card.isCard || (!("cards" in card) || !Array.isArray(card.cards) || card.cards.length === 0);
+		return card.isCard && (!("cards" in card) || !Array.isArray(card.cards) || card.cards.length === 0);
 	}
 	/**
 	 * 是否是转化牌


### PR DESCRIPTION
还是决定`get.is.virtualCard()`应该改成
`!card.cards?.length`
不再检查“card.isCard”，这样行为与“流兵”技能和“怒气”当中的逻辑统一。

原本改成
`!card.isCard || !card.cards?.length`
考虑不周，会把转化牌判断成虚拟牌，这是错误的。