### PR TITLE
fix：分离丁原的“义子”标记和“叛弑”技能

### DIFF
--- a/character/sp2.js
+++ b/character/sp2.js
@@ -6599,16 +6599,16 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				direct:true,
 				filter:function(event,player){
 					if(!game.hasPlayer(function(current){
-						return current.hasSkill('panshi');
+						return current.hasSkill('cixiao_yizi');
 					})) return true;
 					return player.countCards('he')>=1&&game.hasPlayer(function(current){
-						return current!=player&&!current.hasSkill('panshi');
+						return current!=player&&!current.hasSkill('cixiao_yizi');
 					});
 				},
 				content:function(){
 					'step 0'
 					if(game.hasPlayer(function(current){
-						return current.hasSkill('panshi');
+						return current.hasSkill('cixiao_yizi');
 					})) event.goto(2);
 					else player.chooseTarget(lib.filter.notMe,get.prompt('cixiao'),'令一名其他角色获得「义子」标记').set('ai',function(target){
 						var player=_status.event.player;
@@ -6619,19 +6619,19 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 					if(result.bool){
 						var target=result.targets[0];
 						player.logSkill('cixiao',target);
-						target.addSkills('panshi');
+						target.addSkills('cixiao_yizi');
 					}
 					event.finish();
 					'step 2'
 					var list=game.filterPlayer(function(current){
-						return current.hasSkill('panshi');
+						return current.hasSkill('cixiao_yizi');
 					});
 					player.chooseCardTarget({
 						prompt:get.prompt('cixiao'),
 						prompt2:('弃置一张牌并将'+get.translation(list)+'的「义子」标记转移给其他角色'),
 						position:'he',
 						filterTarget:function(card,player,target){
-							return player!=target&&!target.hasSkill('panshi');
+							return player!=target&&!target.hasSkill('cixiao_yizi');
 						},
 						filterCard:lib.filter.cardDiscardable,
 						ai1:function(card){
@@ -6654,12 +6654,12 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						player.logSkill('cixiao');
 						player.discard(result.cards).delay=false;
 						player.line2(game.filterPlayer(function(current){
-							if(current.hasSkill('panshi')){
-								current.removeSkills('panshi');
+							if(current.hasSkill('cixiao_yizi')){
+								current.removeSkills('cixiao_yizi');
 								return true;
 							}
 						}).concat(result.targets),'green');
-						target.addSkills('panshi');
+						target.addSkills('cixiao_yizi');
 					}
 					else event.finish();
 					'step 4'
@@ -6667,11 +6667,20 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				},
 				derivation:'panshi',
 				ai:{threaten:8},
+				subSkill: {
+					yizi: {
+						mark: true,
+						charlotte: true,
+						marktext: '子',
+						intro: {
+							name: '义子',
+							content: '具有〖叛弑〗'
+						},
+						group: 'panshi'
+					}
+				}
 			},
 			panshi:{
-				mark:true,
-				marktext:'子',
-				intro:{content:'我是儿子'},
 				trigger:{player:'phaseZhunbeiBegin'},
 				forced:true,
 				filter:function(event,player){


### PR DESCRIPTION
当前版本逻辑中“义子”和“叛弑”是同一个技能，并且没有`charlotte`或者`locked`标签，导致可以被部分移除技能/技能失效效果影响。

现在将“义子”单独写成一个subSkill，原“慈孝”对“叛弑”的所有引用改为“义子”；“义子”同时赋予“叛弑”技能。从而试图修复这个问题。