### PR TITLE
分离技能的cost选择与content执行；允许在同一个时机内多次发动同一个技能

### DIFF
--- a/character/jsrg.js
+++ b/character/jsrg.js
@@ -5861,23 +5861,23 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 										str=get.prompt(event.skill,trigger[info.logTarget],player);
 									}
 									else if(typeof info.logTarget=='function'){
-										var logTarget=info.logTarget(trigger,player);
+										var logTarget=info.logTarget(trigger,player,trigger.triggername,trigger.indexedData);
 										if(get.itemtype(logTarget).indexOf('player')==0) str=get.prompt(event.skill,logTarget,player);
 									}
 									else{
 										str=get.prompt(event.skill,null,player);
 									}
 								}
-								if(typeof str=='function'){str=str(trigger,player)}
+								if(typeof str=='function'){str=str(trigger,player,trigger.triggername,trigger.indexedData)}
 								var next=player.chooseBool('评鉴：'+str);
-								next.set('yes',!info.check||info.check(trigger,player));
+								next.set('yes',!info.check||info.check(trigger,player,trigger.triggername,trigger.indexedData));
 								next.set('hsskill',event.skill);
 								next.set('forceDie',true);
 								next.set('ai',function(){
 									return _status.event.yes;
 								});
 								if(typeof info.prompt2=='function'){
-									next.set('prompt2',info.prompt2(trigger,player));
+									next.set('prompt2',info.prompt2(trigger,player,trigger.triggername,trigger.indexedData));
 								}
 								else if(typeof info.prompt2=='string'){
 									next.set('prompt2',info.prompt2);

--- a/character/refresh.js
+++ b/character/refresh.js
@@ -11709,16 +11709,16 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				filter:function (event){
 					return (event.num>0)
 				},
+				getIndex(event, player, triggername){
+					return event.num;
+				},
 				content:function (){
 					'step 0'
-					event.count=trigger.num;
-					'step 1'
 					player.draw(2);
-					event.count--;
 					if(_status.connectMode) game.broadcastAll(function(){_status.noclearcountdown=true});
 					event.given_map={};
 					event.num=2;
-					'step 2'
+					'step 1'
 					player.chooseCardTarget({
 						filterCard:function(card){
 							return get.itemtype(card)=='card'&&!card.hasGaintag('reyiji_tag');
@@ -11737,7 +11737,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							return get.value(card,target)*get.attitude(player,target);
 						},
 					});
-					'step 3'
+					'step 2'
 					if(result.bool){
 						var res=result.cards,target=result.targets[0].playerid;
 						player.addGaintag(res,'reyiji_tag');
@@ -11750,9 +11750,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						if(_status.connectMode){
 							game.broadcastAll(function(){delete _status.noclearcountdown;game.stopCountChoose()});
 						}
-						event.goto(5);
+						event.finish();
 					}
-					'step 4'
+					'step 3'
 					if(_status.connectMode){
 						game.broadcastAll(function(){delete _status.noclearcountdown;game.stopCountChoose()});
 					}
@@ -11771,16 +11771,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						giver:player,
 						animate:'giveAuto',
 					}).setContent('gaincardMultiple');
-					'step 5'
-					if(event.count>0&&player.hasSkill('new_reyiji')){
-						player.chooseBool(get.prompt2('new_reyiji'));
-					}
-					else event.finish();
-					'step 6'
-					if(result.bool){
-						player.logSkill('new_reyiji');
-						event.goto(1);
-					}
 				},
 				ai:{
 					maixie:true,

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -13131,7 +13131,7 @@ return event.junling=='junling5'?1:0;});
 						}
 						var info=get.info(trigger.skill);
 						var next=player.chooseBool('是否明置'+get.translation(event.name)+'以发动【'+get.translation(trigger.skill)+'】？');
-						next.set('yes',!info.check||info.check(trigger._trigger,player));
+						next.set('yes',!info.check||info.check(trigger._trigger,player,trigger.triggername,trigger.indexedData));
 						next.set('hsskill',trigger.skill);
 						next.set('ai',nai);
 					}

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -4302,7 +4302,7 @@ export class Game extends Uninstantable {
 	 * @param { GameEventPromise } event 
 	 * @returns { GameEventPromise }
 	 */
-	static createTrigger(name, skill, player, event) {
+	static createTrigger(name, skill, player, event, indexedData) {
 		let info = get.info(skill);
 		if (!info) return false;
 		if ((player.isOut() || player.removed) && !info.forceOut) return;
@@ -4314,6 +4314,7 @@ export class Game extends Uninstantable {
 		next.forceDie = true;
 		next.includeOut = true;
 		next._trigger = event;
+		next.indexedData = indexedData;
 		next.setContent('createTrigger');
 		return next;
 	}

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -2176,10 +2176,10 @@ export const Content = {
 					event.doing.doneList.push(event.current);
 					event.doing.todoList.remove(event.current);
 					const result = await game.createTrigger(event.triggername, event.current.skill, event.current.player, trigger, event.current.indexedData).forResult();
-					if (result === 'cancelled'){
+					if (get.itemtype(event.doing.player) === 'player' && result === 'cancelled'){
 						for (let i = 0; i < event.doing.todoList.length; i++) {
 							if (event.current.skill === event.doing.todoList[i].skill) {
-								event.doing.todoList.splice(i--, 1);
+								event.doing.doneList.push(event.doing.todoList.splice(i--, 1)[0]);
 							}
 						}
 					}
@@ -2209,7 +2209,10 @@ export const Content = {
 		"step 1";
 		if (event.cancelled) return event.finish();
 		var info = get.info(event.skill);
-		if (event.revealed || info.forced) return;
+		if (event.revealed || info.forced) {
+			event._result = { bool: true };
+			return;
+		}
 		const checkFrequent = function (info) {
 			if (player.hasSkillTag('nofrequent', false, event.skill)) return false;
 			if (typeof info.frequent == 'boolean') return info.frequent;
@@ -3760,7 +3763,7 @@ export const Content = {
 				player.logSkill.apply(player, event.logSkill);
 			}
 		}
-		if (!game.online) {
+		if (!game.online && !event.chooseonly) {
 			if (typeof event.delay == 'boolean') {
 				event.done = player.discard(event.result.cards).set('delay', event.delay);
 			}

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -2198,7 +2198,7 @@ export const Content = {
 		game.expandSkills(invisible);
 		if (hidden.includes(event.skill)) {
 			if (!info.silent && player.hasSkillTag('nomingzhi', false, null, true)) event.finish();
-			else if (!info.direct) event.trigger('triggerHidden');
+			else if (!info.direct && typeof info.cost !== 'function') event.trigger('triggerHidden');
 			else event.skillHidden = true;
 		}
 		else if (invisible.includes(event.skill)) event.trigger('triggerInvisible');
@@ -2226,7 +2226,7 @@ export const Content = {
 			event._result = { bool: true };
 			event._direct = true;
 		}
-		else if(info.cost){
+		else if(typeof info.cost === 'function'){
 			if (checkFrequent(info)) event.frequentSkill = true;
 			if (player.isUnderControl()) game.swapPlayerAuto(player);
 			//创建cost事件

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -2306,12 +2306,10 @@ export const Content = {
 			targets = [targets];
 		}
 		if (info.popup != false && !info.direct) {
-			if (info.popup) {
-				player.popup(info.popup);
-				game.log(player, '发动了', '【' + get.skillTranslation(event.skill, player) + '】');
-			}
-			if (info.logLine === false) player.logSkill(event.skill, false, info.line);
-			else player.logSkill(event.skill, targets, info.line);
+			let popup_info = event.skill;
+			if(typeof info.popup === 'string') popup_info = [event.skill, info.popup];
+			if (info.logLine === false) player.logSkill(popup_info, false, info.line);
+			else player.logSkill(popup_info, targets, info.line);
 		}
 		var next = game.createEvent(event.skill);
 		if (typeof info.usable == 'number') {

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -2329,10 +2329,12 @@ export const Content = {
 		next.skillHidden = event.skillHidden;
 		if (info.forceDie) next.forceDie = true;
 		if (info.forceOut) next.includeOut = true;
-		//语法糖部分
-		if ('cost_data' in result) next.cost_data = result.cost_data;
+		//传入数据
 		if (get.itemtype(targets) == 'players') next.targets = targets.slice(0);
 		if (get.itemtype(result.cards) === 'cards') next.cards = result.cards.slice(0);
+		//语法糖部分
+		if ('cost_data' in result) next.cost_data = result.cost_data;
+		next.indexedData = event.indexedData;
 		"step 4";
 		if (!player._hookTrigger) return;
 		if (player._hookTrigger.some(i => {

--- a/noname/library/element/gameEvent.js
+++ b/noname/library/element/gameEvent.js
@@ -333,10 +333,10 @@ export class GameEvent {
 		this.untrigger(arg1, arg2);
 		this.finish();
 		if (notrigger != 'notrigger') {
-			this.trigger(this.name + 'Cancelled');
 			if (this.player && lib.phaseName.includes(this.name)) this.player.getHistory('skipped').add(this.name);
+			return this.trigger(this.name + 'Cancelled');
 		}
-		return this;
+		return null;
 	}
 	neutralize(event) {
 		this.untrigger();

--- a/noname/library/element/gameEvent.js
+++ b/noname/library/element/gameEvent.js
@@ -791,11 +791,36 @@ export class GameEvent {
 
 					const info = lib.skill[skill];
 					const list = info.firstDo ? firstDo.todoList : info.lastDo ? lastDo.todoList : this.todoList;
-					list.push({
-						skill: skill,
-						player: this.player,
-						priority: get.priority(skill),
-					});
+					if(info.getIndex){
+						const indexedResult = info.getIndex(event, player, name);
+						if(Array.isArray(indexedResult)){
+							indexedResult.forEach(indexedData => {
+								list.push({
+									skill: skill,
+									player: this.player,
+									priority: get.priority(skill),
+									indexedData,
+								})
+							});
+						}
+						else if (typeof indexedResult === 'number' && indexedResult>0){
+							for(let i = 0; i < indexedResult; i++){
+								list.push({
+									skill: skill,
+									player: this.player,
+									priority: get.priority(skill),
+									indexedData: true,
+								})
+							}
+						}
+					}
+					else{
+						list.push({
+							skill: skill,
+							player: this.player,
+							priority: get.priority(skill),
+						});
+					}
 					if (typeof list.player == 'string') list.sort((a, b) => (b.priority - a.priority) || (playerMap.indexOf(a) - playerMap.indexOf(b)));
 					else list.sort((a, b) => b.priority - a.priority);
 					allbool = true;

--- a/noname/library/element/gameEvent.js
+++ b/noname/library/element/gameEvent.js
@@ -791,7 +791,7 @@ export class GameEvent {
 
 					const info = lib.skill[skill];
 					const list = info.firstDo ? firstDo.todoList : info.lastDo ? lastDo.todoList : this.todoList;
-					if(info.getIndex){
+					if (typeof info.getIndex === 'function') {
 						const indexedResult = info.getIndex(event, player, name);
 						if(Array.isArray(indexedResult)){
 							indexedResult.forEach(indexedData => {

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -371,6 +371,7 @@ export class Player extends HTMLDivElement {
 	 * ```
 	 */
 	when() {
+		const player = this;
 		if (!_status.postReconnect.player_when) _status.postReconnect.player_when = [
 			function (map) {
 				"use strict";
@@ -386,7 +387,13 @@ export class Player extends HTMLDivElement {
 		];
 		let triggerNames = Array.from(arguments);
 		let trigger;
+		let instantlyAdd = true;
 		if (triggerNames.length == 0) throw 'player.when的参数数量应大于0';
+		//从triggerNames中取出instantlyAdd的部分
+		if (triggerNames.includes(false)) {
+			instantlyAdd = false;
+			triggerNames.remove(false);
+		}
 		// add other triggerNames
 		// arguments.length = 1
 		if (triggerNames.length == 1) {
@@ -506,7 +513,7 @@ export class Player extends HTMLDivElement {
 				}
 			});
 		}, skillName);
-		this.addSkill(skillName);
+		if (instantlyAdd !== false) this.addSkill(skillName);
 		_status.postReconnect.player_when[1][skillName] = true;
 		return {
 			/**
@@ -603,6 +610,14 @@ export class Player extends HTMLDivElement {
 				if (skill.contentFuns.length > 0) createContent();
 				return this;
 			},
+			/**
+			 * 获得技能
+			 * 如果instantlyAdd为false，则需要以此法获得技能
+			 **/
+			finish() {
+				player.addSkill(skillName);
+				return this;
+			}
 		};
 	}
 	/**
@@ -7877,14 +7892,14 @@ export class Player extends HTMLDivElement {
 					skillName = 'player_tempSkills_' + Math.random().toString(36).slice(-8);
 				} while (player.additionalSkills[skillName] != null);
 				player.addAdditionalSkill(skillName, skillsToAdd);
-				player.when(expire).assign({
+				player.when(expire,false).assign({
 					firstDo: true,
 					priority: Infinity,
 				}).vars({
 					skillName
 				}).then(() => {
 					player.removeAdditionalSkills(skillName);
-				});
+				}).finish();
 			}
 		});
 	}
@@ -7927,13 +7942,13 @@ export class Player extends HTMLDivElement {
 
 			if (!expire) expire = { global: ['phaseAfter', 'phaseBeforeStart'] };
 			else if (typeof expire == 'string' || Array.isArray(expire)) expire = { global: expire };
-			this.when(expire).assign({
+			this.when(expire,false).assign({
 				firstDo: true,
 			}).vars({
 				bannedSkill: skill,
 			}).then(() => {
 				delete player.storage[`temp_ban_${bannedSkill}`];
-			});
+			}).finish();
 		}
 		return skill;
 	}

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -4188,7 +4188,8 @@ export class Player extends HTMLDivElement {
 				next.filterCard = get.filter(arguments[i]);
 			}
 			else if (typeof arguments[i] == 'string') {
-				get.evtprompt(next, arguments[i]);
+				if (arguments[i]=='chooseonly') next.chooseonly=true;
+				else get.evtprompt(next, arguments[i]);
 			}
 			if (arguments[i] === null) {
 				for (var i = 0; i < arguments.length; i++) {

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -9830,7 +9830,7 @@ export class Library extends Uninstantable {
 		 * @param {string} skill
 		 * @returns {boolean}
 		 */
-		filterTrigger: function (event, player, triggername, skill) {
+		filterTrigger: function (event, player, triggername, skill, indexedData) {
 			if (player._hookTrigger && player._hookTrigger.some(i => {
 				const info = lib.skill[i].hookTrigger;
 				return info && info.block && info.block(event, player, triggername, skill);
@@ -9853,7 +9853,7 @@ export class Library extends Uninstantable {
 				if (Array.isArray(info.trigger[role])) return info.trigger[role].includes(triggername);
 				return info.trigger[role] == triggername;
 			})) return false;
-			if (info.filter && !info.filter(event, player, triggername)) return false;
+			if (info.filter && !info.filter(event, player, triggername, indexedData)) return false;
 			if (event._notrigger.includes(player) && !lib.skill.global.includes(skill)) return false;
 			if (typeof info.usable == 'number' && player.hasSkill('counttrigger') &&
 				player.storage.counttrigger && player.storage.counttrigger[skill] >= info.usable) return false;
@@ -10396,7 +10396,7 @@ export class Library extends Uninstantable {
 			return (Math.random() - 0.5);
 		},
 		seat: function (a, b) {
-			var player = lib.tempSortSeat || _status.event.player;
+			var player = lib.tempSortSeat || _status.event.player || game.me || game.players[0];
 			var delta = get.distance(player, a, 'absolute') - get.distance(player, b, 'absolute');
 			if (delta) return delta;
 			delta = parseInt(a.dataset.position) - parseInt(b.dataset.position);


### PR DESCRIPTION
- **logTarget现在生成的目标会自动传递给技能的content**

现在logTarget确定的“技能的目标角色”会自动传入技能content的event.targets中，而不需要重复调用。

- **将技能的cost选择和content执行分离，从而回避原本的含糊不清的情况。**

对于原本使用direct:true取消logSkill，然后在技能内部选择消耗，再logSkill的情况而言，虽然有效，但是难以区分“技能选择消耗的过程”和“技能本身的效果”，不是一件好事。
因此，我们决定将技能的cost和content分离（旧的写法仍然有效，不受影响）。使用例见张辽【突袭】：
```
tuxi:{
	audio:2,
	trigger:{player:'phaseDrawBegin1'},
	filter(event,player){
		return !event.numFixed;
	},
	//cost部分，选择技能的消耗
	async cost(event, trigger, player){
		let num = game.countPlayer(current => current != player && current.countCards('h') && get.attitude(player,current) <= 0);
		let check = (num >= 2);
		const {result} = await player.chooseTarget(get.prompt('tuxi'), '获得其他一至两名角色的各一张手牌', [1,2], (card, player, target) => {
			return target.countCards('h') > 0 && player != target;
		}, target => {
			if (!_status.event.aicheck) return 0;
			const att=get.attitude(_status.event.player, target);
			if (target.hasSkill('tuntian')) return att / 10;
			return 1 - att;
		}).set('aicheck', check);
		//直接将result作为结果返回给父事件。当result.bool为true时，视为“可以发动技能”。
		event.result = result;
	},
	async content(event, trigger, player){
		//cost中的result.cards和result.targets会直接赋值给事件中的event.cards和event.targets
		//如果你想要传入除此之外的数据，请在cost中赋值给result.cost_data，然后这些数据会被赋值给event.cost_data。
		player.gainMultiple(event.targets);
		trigger.changeToZero();
		game.asyncDelay();
	},
},
```
- **“按点卖血”类技能和“同时机多个目标分别结算”的技能。**

现在，无名杀的“按点卖血”技能可以和OL线上一样，在同时触发多个技能时，自选技能的顺序了。使用例见郭嘉【遗计】：
```
yiji:{
	audio:2,
	trigger:{player:'damageEnd'},
	frequent:true,
	filter(event){
		return event.num>0;
	},
	//通过设置getIndex函数，返回一个整数，作为“技能的发动次数”。
	getIndex(event, player, triggername){
		return event.num;
	},
	……content和ai已省略……
},
```
而对于一些牌移动事件的技能而言，不仅要“多次发动”，每次发动时还都有**不同的目标**。比如伊籍的【急援】，可能会出现“同时将一些牌交给了多名角色”的情况，每次的发动目标都不相同。这时请参考以下写法：
```
xinfu_jiyuan:{
	trigger:{
		global:['dying','gainAfter','loseAsyncAfter'],
	},
	audio:2,
	//getIndex函数返回一个数组，技能的总发动次数=数组长度，第X次发动的目标=数组的第X个元素
	getIndex:function(event, player){
		if (event.name !== 'loseAsync') return [event.player];
		else return game.filterPlayer(current => current != player && event.getg(current).length > 0).sortBySeat();
	},
	//filter函数添加第四个元素：本次发动技能的目标（由getIndex函数返回的数组决定具体值）
	filter(event, player, triggername, target){
		if (!target.isIn()) return false;
		if (event.name === 'dying') return true;
		if (event.giver !== player) return false;
		if (event.name === 'gain') {
			return event.player!=player&&event.getg(target).length>0;
		}
		return game.hasPlayer(current=>current!=player&&event.getg(current).length>0);
	},
	//logTarget函数，check函数，prompt函数和prompt2函数的参数也都增加至4个，格式与filter函数相同
	logTarget(event, player, triggername, target){
		return target;
	},
	check(event, player, triggername, target){
		return get.attitude(player,target) > 0;
	},
	async content(event, trigger, player){
		//请注意，这个event.targets是根据logTarget的结果生成的，而不是根据getIndex的结果传入的。
		//如果你想要直接获取到getIndex生成的目标，请改为使用event.indexedData
		event.targets[0].draw();
	},
},
```