### PR TITLE
修复神典韦无法使用部分武器牌技能的bug

### DIFF
--- a/character/sb.js
+++ b/character/sb.js
@@ -6589,7 +6589,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				forced:true,
 				locked:false,
 				filter:function(event,player){
-					return player.hasSkill('splveying',null,false,false)&&(get.type(event.card)=='trick'&&!get.tag(event.card,'damage'))&&player.countMark('splveying')>1;
+					return player.hasSkill('splveying',null,null,false)&&(get.type(event.card)=='trick'&&!get.tag(event.card,'damage'))&&player.countMark('splveying')>1;
 				},
 				content:function(){
 					player.removeMark('splveying',2);

--- a/character/standard.js
+++ b/character/standard.js
@@ -2479,7 +2479,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 			xinqicai_info:'锁定技，你使用锦囊牌无距离限制。',
 			xinqicai_info_alter:'锁定技，你使用的锦囊牌无距离限制，你装备区内的牌不能被弃置。',
 			qicai_info:'锁定技，你使用锦囊牌无距离限制。',
-			zhiheng_info:'出牌阶段一次，你可以弃置任意张牌，然后摸等量的牌。',
+			zhiheng_info:'出牌阶段限一次，你可以弃置任意张牌，然后摸等量的牌。',
 			xinzhiheng:'制衡',
 			xinzhiheng_info:'出牌阶段限1次，你可以弃置任意张牌并摸等量的牌。',
 			xinzhiheng_info_alter:'出牌阶段限1次，你可以弃置任意张牌并摸等量的牌，如果在发动制衡时弃置了所有手牌，你额外摸一张牌。',


### PR DESCRIPTION
filter中player.hasSkill参数未囊括装备技能，需将参数arg3的值改为null
已修复：莺舞
待修复：史阿心授？