### PR TITLE
fix：如果英文武将名有空格资料卡会弹窗

### DIFF
--- a/game/pinyinjs.js
+++ b/game/pinyinjs.js
@@ -41588,6 +41588,10 @@ var pinyin_dict_withtone = "yī,dīng zhēng,kǎo qiǎo yú,qī,shàng,xià,hǎn
 	 * @param splitter 返回结果拼接字符
 	 */
 	function parsePolyphone(chinese, result, splitter, withtone) {
+		// 先删除中文字符之外的所有字符（包括英文字母、数字、标点符号、空格和其他非中文字符），然后再查找多音字
+		chinese = chinese.replace(/[^\u4e00-\u9fa5]/g, '');
+		if(chinese.length == 0) return result;
+		
 		var poly = window.pinyin_dict_polyphone;
 		var max = 7; // 最多只考虑7个汉字的多音字词，虽然词库里面有10个字的，但是数量非常少，为了整体效率暂时忽略之
 		var temp = poly[chinese];
@@ -41604,10 +41608,6 @@ var pinyin_dict_withtone = "yī,dīng zhēng,kǎo qiǎo yú,qī,shàng,xià,hǎn
 		for (var i = 0; i < chinese.length;(i++,m++)) {
 			temp = '';
 			for (var j = 0; j < max && (i + j) < chinese.length; j++) {
-				if (!dict.withtone[chinese[i]]) {
-					i+=(result[m].length-1);
-					break;
-				} // 如果碰到非汉字直接停止本次查找
 				temp += chinese[i + j];
 				var res = poly[temp];
 				if (res) // 如果找到了多音字词语


### PR DESCRIPTION
### PR受影响的平台
所有平台

### 诱因和背景
如果英文武将名有空格资料卡会弹窗

### PR描述
先删除中文字符之外的所有字符（包括英文字母、数字、标点符号、空格和其他非中文字符），然后再查找多音字

### PR测试
通过

### 扩展适配
无需适配

### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue