### PR TITLE
[bugfix][移动端更新报错问题] this作用域未绑定

### DIFF
--- a/noname/library/init/index.js
+++ b/noname/library/init/index.js
@@ -316,7 +316,7 @@ export class LibInit extends Uninstantable {
 				if (typeof onerror == 'function') onerror(new Error(oReq.statusText || oReq.status));
 				return;
 			}
-			onload(result);
+			onload.call(oReq, result);
 		});
 		if (typeof onerror == 'function') oReq.addEventListener("error", onerror);
 		oReq.open("GET", sScriptURL);


### PR DESCRIPTION
手机更新失败，定位问题在如下行。
![image](https://github.com/libccy/noname/assets/26755276/b4b6dbc7-5b48-495b-a771-378522405b71)

进入Req发现this作用域没绑，怎么能通过`this.reponseText`取到东西呢？
![image](https://github.com/libccy/noname/assets/26755276/82951f02-b828-4ae9-b660-3853f4f09c89)

话说这问题好像好久了，今天终于找到空看一眼，下次修改时顺便也验一下移动端吧，多谢。