### PR TITLE
修复Safari端的UA判断问题

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -80,15 +80,27 @@ new Promise(resolve => {
 			// @ts-ignore
 			return [result[1], parseInt(major), parseInt(minor), parseInt(patch)]
 		}
-		result = userAgent.match(/version\/(\d+(?:\.\d+)+).*safari/)
+		// 以下是所有Safari平台的判断方法
+		// macOS以及以桌面显示的移动端则直接判断
+		if (/macintosh/.test(userAgent)) {
+			result = userAgent.match(/version\/(\d+(?:\.\d+)+).*safari/)
+			if (!result) return ["other", NaN, NaN, NaN]
+		}
+		// 不然则通过OS后面的版本号来获取内容
+		else {
+			let safariRegex = /(?:iphone|ipad); cpu (?:iphone )?os (\d+(?:_\d+)+)/
+			result = userAgent.match(safariRegex)
+			if (!result) return ["other", NaN, NaN, NaN]
+		}
+		// result = userAgent.match(/version\/(\d+(?:\.\d+)+).*safari/)
 		// @ts-ignore
 		const [major, minor, patch] = result[1].split(".")
 		return ["safari", parseInt(major), parseInt(minor), parseInt(patch)]
 	}
 	const [core, major, minor, patch] = coreInfo();
 	const supportMap = {
-		"firefox": [60, 0, 0],
-		"chrome": [61, 0, 0],
+		"firefox": [77, 0, 0],
+		"chrome": [77, 0, 0],
 		"safari": [14, 5, 0]
 	}
 	const versions = [major, minor, patch]

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -29,6 +29,7 @@ export class Get extends Uninstantable {
 			return [result[1], parseInt(major), parseInt(minor), parseInt(patch)]
 		}
 		result = userAgent.match(/version\/(\d+(?:\.\d+)+).*safari/)
+		if (!result) return ["other", NaN, NaN, NaN]
 		const [major, minor, patch] = result[1].split(".")
 		return ["safari", parseInt(major), parseInt(minor), parseInt(patch)]
 	}


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
macOS, iPadOS及iOS端

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
由 #1113  提出，在iOS/iPadOS上的非Safari浏览器因苹果政策原因仍然使用Safari内核，但暴露出的UserAgent却不符合标准的Safari UserAgent，从而导致之前的代码无法正确读取UserAgent中包含的版本号

### PR描述
<!-- 详细描述您的更改 -->
在入口处重新判断Safari相关的UserAgent

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
![firefox](https://github.com/libccy/noname/assets/140149172/5ad7298b-97a8-44a9-8d30-6e40c118e10b)
![chrome](https://github.com/libccy/noname/assets/140149172/7bfc6c1a-66ae-4ae9-b2a7-fbef4b94cded)

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需扩展进行适配

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue