### PR TITLE
Bugfix：修复可以流失负数点体力的Bug

### DIFF
--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -7955,8 +7955,10 @@ export const Content = {
 				game.playAudio('effect', 'loseHp');
 			}
 		});
-		game.log(player, '失去了' + get.cnNumber(num) + '点体力');
-		player.changeHp(-num);
+		if (num > 0) {
+			game.log(player, '失去了' + get.cnNumber(num) + '点体力');
+			player.changeHp(-num);
+		}
 		"step 1";
 		if (player.hp <= 0 && !event.nodying) {
 			game.delayx();

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -5942,6 +5942,10 @@ export class Player extends HTMLDivElement {
 		next.num = num;
 		next.player = this;
 		if (next.num == undefined) next.num = 1;
+		if (next.num <= 0) {
+			_status.event.next.remove(next);
+			next.resolve();
+		}
 		next.setContent('loseHp');
 		return next;
 	}


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
没有受到影响的平台/客户端

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
可以流失负数点体力大约是个历史遗留问题，一直没有人修。


### PR描述
<!-- 详细描述您的更改 -->
修复了可以流失负数点体力的问题。


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
修改前使用`loseHp`函数，输入值为`-1`，结果为流失`-1`点体力。
修改后使用`loseHp`函数，输入值为`-1`，结果无事发生。

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需扩展进行适配

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue