### PR TITLE
recover事件和loseHp事件增加检验

### DIFF
--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -7922,20 +7922,20 @@ export const Content = {
 		if (!event.notrigger) event.trigger('damageSource');
 	},
 	recover: function () {
-		if (lib.config.background_audio) {
-			game.playAudio('effect', 'recover');
-		}
-		game.broadcast(function () {
-			if (lib.config.background_audio) {
-				game.playAudio('effect', 'recover');
-			}
-		});
 		if (num > player.maxHp - player.hp) {
 			num = player.maxHp - player.hp;
 			event.num = num;
 		}
 		if (num > 0) {
-			player.changeHp(num, false);
+			delete event.filterStop();
+			if (lib.config.background_audio) {
+				game.playAudio('effect', 'recover');
+			}
+			game.broadcast(function () {
+				if (lib.config.background_audio) {
+					game.playAudio('effect', 'recover');
+				}
+			});
 			game.broadcastAll(function (player) {
 				if (lib.config.animation && !lib.config.low_performance) {
 					player.$recover();
@@ -7943,10 +7943,18 @@ export const Content = {
 			}, player);
 			player.$damagepop(num, 'wood');
 			game.log(player, '回复了' + get.cnNumber(num) + '点体力');
+			
+			player.changeHp(num, false);
 		}
+		else event._triggered = null;
 	},
 	loseHp: function () {
 		"step 0";
+		if (event.num <= 0){
+			event.finish();
+			event._triggered = null;
+			return;
+		}
 		if (lib.config.background_audio) {
 			game.playAudio('effect', 'loseHp');
 		}

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -7927,7 +7927,7 @@ export const Content = {
 			event.num = num;
 		}
 		if (num > 0) {
-			delete event.filterStop();
+			delete event.filterStop;
 			if (lib.config.background_audio) {
 				game.playAudio('effect', 'recover');
 			}

--- a/noname/library/element/gameEvent.js
+++ b/noname/library/element/gameEvent.js
@@ -171,6 +171,10 @@ export class GameEvent {
 	 */
 	name;
 	/**
+	 * @type { Function | void | null }
+	 */
+	filterStop;
+	/**
 	 * @param {keyof this} key
 	 * @param {number} [value]
 	 * @param {number} [baseValue]
@@ -760,6 +764,7 @@ export class GameEvent {
 		if (!lib.hookmap[name] && !lib.config.compatiblemode) return;
 		if (!game.players || !game.players.length) return;
 		const event = this;
+		if (event.filterStop && event.filterStop()) return;
 		let start = [_status.currentPhase, event.source, event.player, game.me, game.players[0]].find(i => get.itemtype(i) == 'player');
 		if (!start) return;
 		if (!game.players.includes(start) && !game.dead.includes(start)) start = game.findNext(start);

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -5929,9 +5929,11 @@ export class Player extends HTMLDivElement {
 		if (next.cards == undefined && !nocard) next.cards = event.cards;
 		if (next.source == undefined && !nosource) next.source = event.customSource || event.player;
 		if (next.num == undefined) next.num = (event.baseDamage || 1) + (event.extraDamage || 0);
-		if (next.num <= 0) {
-			_status.event.next.remove(next);
-			next.resolve();
+		next.filterStop = function(){
+			if (this.num <= 0 || this.player.isHealthy()){
+				delete this.filterStop;
+				return true;
+			}
 		}
 		next.setContent('recover');
 		return next;
@@ -5949,6 +5951,14 @@ export class Player extends HTMLDivElement {
 		next.player = this;
 		if (next.num == undefined) next.num = 1;
 		next.setContent('loseHp');
+		next.filterStop = function(){
+			if (this.num <= 0){
+				delete this.filterStop;
+				this.finish();
+				this._triggered = null;
+				return true;
+			}
+		}
 		return next;
 	}
 	loseMaxHp() {

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -5932,6 +5932,8 @@ export class Player extends HTMLDivElement {
 		next.filterStop = function(){
 			if (this.num <= 0 || this.player.isHealthy()){
 				delete this.filterStop;
+				this.finish();
+				this._triggered = null;
 				return true;
 			}
 		}

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -11303,7 +11303,10 @@ export class Library extends Uninstantable {
 				}
 			}
 		},
-		_recovercheck: {
+		/**
+		 * @deprecated
+		 */
+		/*_recovercheck: {
 			trigger: { player: 'recoverBefore' },
 			forced: true,
 			priority: 100,
@@ -11316,7 +11319,7 @@ export class Library extends Uninstantable {
 			content: function () {
 				trigger.cancel();
 			},
-		},
+		},*/
 		/**
 		 * @deprecated
 		 */


### PR DESCRIPTION
### PR受影响的平台
全部


### 诱因和背景
避免有人闲的没事回复/失去负数点体力；同时取消掉原本使用全局技能，屏蔽满血角色的体力回复事件的方法。


### PR描述
给recover事件和loseHp事件增加了filterStop，用于随时判断这些事件的当前数值是否小于0，并在事件本身的content内部进行判断。
扩大了filterStop的执行范围，在GameEventPromise.trigger中增加了一次filterStop的执行，避免在不恰当的时机清除tempSkill。


### PR测试
测了，暂时没问题。


### 扩展适配
对于那些直接修改recover和loseHp事件的content，从而实现回复/失去体力特效的扩展而言，该Pull Request会导致这些扩展产生bug。


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff