### PR TITLE
【决斗】AI修复，3D于禁【整军】修复

### DIFF
--- a/card/standard.js
+++ b/card/standard.js
@@ -1535,7 +1535,9 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 							if (get.damageEffect(target, player, target) >= 0) return 0;
 							let pd = get.damageEffect(player, target, player), att = get.attitude(player, target);
 							if (att > 0 && get.damageEffect(target, player, player) > pd) return 0;
-							let ts = target.mayHaveSha(player, 'respond', null, 'count'), ps = player.mayHaveSha(player, 'respond', null, 'count');
+							let ts = target.mayHaveSha(player, 'respond', null, 'count'), ps = player.mayHaveSha(player, 'respond', player.getCards('h', i => {
+								return card === i || card.cards && card.cards.includes(i) || ui.selected.cards.includes(i);
+							}), 'count');
 							if (ts < 1 && ts << 3 < Math.pow(player.hp, 2)) return 0;
 							if (att > 0) {
 								if (ts < 1) return 0;
@@ -1554,7 +1556,9 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 							if (td >= 0) return td / get.attitude(target, target);
 							let pd = get.damageEffect(player, target, player), att = get.attitude(player, target);
 							if (att > 0 && get.damageEffect(target, player, player) > pd) return -2;
-							let ts = target.mayHaveSha(player, 'respond', null, 'count'), ps = player.mayHaveSha(player, 'respond', null, 'count');
+							let ts = target.mayHaveSha(player, 'respond', null, 'count'), ps = player.mayHaveSha(player, 'respond', player.getCards('h', i => {
+								return card === i || card.cards && card.cards.includes(i) || ui.selected.cards.includes(i);
+							}), 'count');
 							if (ts < 1) return -1.5;
 							if (att > 0) return -2;
 							if (ts - ps < 1) return -2 - ts;

--- a/character/ddd.js
+++ b/character/ddd.js
@@ -1689,12 +1689,13 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							let target;
 							if(hs_targets.length==1) target=hs_targets[0];
 							else{
-								target=await player.chooseTarget(get.prompt('dddzhengjun'),'令其中一名角色摸一张牌或弃置一张牌',(card,player,target)=>{
+								let targets=await player.chooseTarget(get.prompt('dddzhengjun'),'令其中一名角色摸一张牌或弃置一张牌',(card,player,target)=>{
 									return get.event('targets').includes(target);
 								}).set('ai',target=>{
 									const player=get.event('player');
 									return Math.max(get.effect(target,{name:'guohe_copy2'},target,player),get.effect(target,{name:'draw'},player,player));
-								}).set('targets',hs_targets).forResultTargets()[0];
+								}).set('targets',hs_targets).forResultTargets();
+								if(targets&&targets.length) target=targets[0];
 							}
 							if(target){
 								let list=['摸牌'];
@@ -1722,12 +1723,13 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 								if(bool) target=hs_targets[0];
 							}
 							else{
-								target=await player.chooseTarget(get.prompt('dddzhengjun'),'移动其中一名角色的一张装备牌',(card,player,target)=>{
+								let targets=await player.chooseTarget(get.prompt('dddzhengjun'),'移动其中一名角色的一张装备牌',(card,player,target)=>{
 									return get.event('targets').includes(target);
 								}).set('ai',target=>{
 									const player=get.event('player');
 									return player.canMoveCard(true,true,target)?(1+Math.random()):0;
-								}).set('targets',es_targets).forResultTargets()[0];
+								}).set('targets',es_targets).forResultTargets();
+								if(targets&&targets.length) target=targets[0];
 							}
 							if(target){
 								map.es_target=target;


### PR DESCRIPTION
### PR受影响的平台
所有平台


### 诱因和背景
修复[OL界王异；族王沦改晋势力；bugfix；还原部分无名杀彩蛋](https://github.com/libccy/noname/pull/1106/commits/2999b19b3f382c9b63628cbb3c8ce15f45ccf3e6)中针对3D于禁的修复问题以及群友反馈的“AI使用【决斗】后因手牌数减少而使用【无懈可击】”尝试修复



### PR描述
【决斗】的ai.result排除将【决斗】作为可能的【杀】的考量；
3D于禁【整军】用targets承接forResultTargets再进行后续操作



### PR测试
用【鼓舌】创造多人同时失去牌的时机检测



### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [ ] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [ ] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff