### PR TITLE
修复【桃】ai

### DIFF
--- a/card/standard.js
+++ b/card/standard.js
@@ -469,13 +469,13 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 							return 2;
 						},
 						target_use:(player,target,card)=>{
-							if(!player.isPhaseUsing()||player.hasSkillTag('nokeep',true,{
-								card:card,
-								target:target
-							},true)) return 2;
 							let mode = get.mode(),
 								taos = player.getCards('hs',i=>get.name(i)==='tao'&&lib.filter.cardEnabled(i,target,'forceEnable'));
-							if(target.hp>0){
+							if(target!==_status.event.dying){
+								if(!player.isPhaseUsing() || player.hasSkillTag('nokeep',true,{
+									card:card,
+									target:target
+								},true)) return 2;
 								let min = 7.2-4*player.hp/player.maxHp,
 									nd = player.needsToDiscard(0,(i,player)=>{
 										return !player.canIgnoreHandcard(i)&&(taos.includes(i)||get.value(i)>=min);

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -53,10 +53,13 @@ export class Get extends Uninstantable {
 		return list;
 	}
 	/**
-	 * 根据座次数n（从0开始）获取对应的“n+1号位”翻译
-	 * @param {number} seat
+	 * 根据(Player的)座次数n（从1开始）获取对应的“n号位”翻译
+	 * @param {number | Player} seat
 	 */
-	static seatTranslation(seat) { return `${get.cnNumber(seat + 1, true)}号位`; }
+	static seatTranslation(seat) {
+		if (get.itemtype(seat) === 'player') seat = seat.getSeatNum();
+		return `${get.cnNumber(seat, true)}号位`;
+	}
 	/**
 	 * @param {number} numberOfPlayers
 	 * @returns {string[]}
@@ -4685,7 +4688,7 @@ export class Get extends Uninstantable {
 		return eff;
 	}
 	/**
-	 * 
+	 *
 	 * @param {any} source 如果参数是function，执行此函数并返回结果，传参为此方法剩余的参数。如果参数不是function，直接返回结果。
 	 * @returns 返回的结果
 	 */


### PR DESCRIPTION
### PR受影响的平台
所有平台


### 诱因和背景
修复[修复【逊贤】【崖柴】【桃】](https://github.com/libccy/noname/pull/1114)中针对【桃】AI的不完全修复


### PR描述
为“无脑使用【桃】”策略增加约束条件*【桃】目标非当前_status.event.dying角色*



### PR测试
【桃】不足的情况下托管观察AI是否救队友；
多人濒死的情况下观察约束条件是否仍发挥作用



### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff