### PR TITLE
bugfix，出闪ai微调

### DIFF
--- a/card/standard.js
+++ b/card/standard.js
@@ -157,11 +157,10 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 							if(target.hasSkillTag('useShan',null,event)) return true;
 							if(target.isLinked()&&game.hasNature(event.card)&&get.attitude(target,player._trueMe||player)>0) return false;
 							if(event.baseDamage+event.extraDamage<=0&&!game.hasNature(event.card,'ice')) return false;
-							if(target.hasSkillTag('freeShan',false,event,true)) return true;
-							if(event.shanRequired>1&&target.mayHaveShan(target,'use',null,'count')<event.shanRequired-(event.shanIgnored||0)) return false;
 							if(event.baseDamage+event.extraDamage>=target.hp+
 								((player.hasSkillTag('jueqing',false,target)||target.hasSkill('gangzhi'))?target.hujia:0)) return true;
 							if(!game.hasNature(event.card,'ice')&&get.damageEffect(target,player,target,get.nature(event.card))>=0) return false;
+							if(event.shanRequired>1&&target.mayHaveShan(target,'use',null,'count')<event.shanRequired-(event.shanIgnored||0)) return false;
 							return true;
 						})());
 						//next.autochoose=lib.filter.autoRespondShan;
@@ -2911,14 +2910,19 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 				},
 				audio:true,
 				check:function(event,player){
-					if(event&&(event.ai||event.ai1)){
-						var ai=event.ai||event.ai1;
+					if(!event) return true;
+					if(event.ai){
+						var ai=event.ai;
 						var tmp=_status.event;
 						_status.event=event;
 						var result=ai({name:'shan'},_status.event.player,event);
 						_status.event=tmp;
 						return result>0;
 					}
+					let evt=event.getParent();
+					if(player.hasSkillTag('noShan',null,evt)) return false;
+					if(!evt||!evt.card||!evt.player||player.hasSkillTag('useShan',null,evt)) return true;
+					if(evt.card&&evt.player&&player.isLinked()&&game.hasNature(evt.card)&&get.attitude(player,evt.player._trueMe||evt.player)>0) return false;
 					return true;
 				},
 				content:function(){
@@ -2942,8 +2946,6 @@ game.import('card',function(lib,game,ui,get,ai,_status){
 						if(player.hasSkillTag('unequip2')) return false;
 						if(!arg||!arg.player) return true;
 						if(arg.player.hasSkillTag('unequip',false,{
-							target:player
-						})||arg.player.hasSkillTag('unequip_ai',false,{
 							target:player
 						})) return false;
 						return true;

--- a/character/mobile.js
+++ b/character/mobile.js
@@ -7228,11 +7228,11 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				delay:false,
 				check:function(card){
 					var player=_status.event.player;
-					if(!player.storage.jueyong||player.storage.jueyong[0].length<Math.max(1,player.getDamagedHp())||!player.storage.jueyong[0].filter(function(card){
-						return get.effect(player,card,player.storage.jueyong[1][player.storage.jueyong[0].indexOf(card)],player)<0;
-					}).length||(player.hp<=1&&!player.storage.jueyong[0].filter(function(card){
+					if(!player.storage.jueyong||!player.storage.jueyong[0].length||player.hp<=1&&!player.storage.jueyong[0].some(function(card){
 						return get.tag(card,'damage')>0;
-					}).length)) return -1;
+					})||!player.storage.jueyong[0].some(function(card){
+						return get.effect(player,card,player.storage.jueyong[1][player.storage.jueyong[0].indexOf(card)],player)<0;
+					})) return -1;
 					return 20-get.value(card);
 				},
 				content:function(){

--- a/character/shenhua.js
+++ b/character/shenhua.js
@@ -5441,8 +5441,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						if(!arg||!arg.player) return true;
 						if(arg.player.hasSkillTag('unequip',false,{
 							target:player
-						})||arg.player.hasSkillTag('unequip_ai',false,{
-							target:player
 						})) return false;
 						return true;
 					},

--- a/character/sp.js
+++ b/character/sp.js
@@ -20128,8 +20128,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						if(!arg||!arg.player) return true;
 						if(arg.player.hasSkillTag('unequip',false,{
 							target:player
-						})||arg.player.hasSkillTag('unequip_ai',false,{
-							target:player
 						})) return false;
 						return true;
 					},

--- a/character/sp2.js
+++ b/character/sp2.js
@@ -136,12 +136,13 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 				ai:{
 					order:9,
 					result:{
+						player(player,target){
+							let res=2*get.effect(player,{name:'draw',player,player});
+							if(player!==target) res+=get.effect(player,{name:'losehp'},player,player);
+							return res;
+						},
 						target(player,target){
-							if(player.getHp()+player.countCards('hs',card=>player.canSaveCard(card,player))<=1) return 0;
-							const num=get.sgn(get.attitude(player,target));
-							if(num*get.damageEffect(target,player,player)>0) return num*get.damageEffect(target,player,player);
-							if(target==player) return 0.00001;
-							return 0;
+							return get.damageEffect(target,player,target);
 						},
 					},
 				},
@@ -292,7 +293,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 						}
 					}
 				},
-				
+
 			},
 			//星袁绍
 			starxiaoyan:{

--- a/character/xianding.js
+++ b/character/xianding.js
@@ -9529,7 +9529,24 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							if(changed2.includes(from.link)) return true;
 							return changed.includes(to.link);
 						});
+						next.set('max',Math.min(hs.length,ts.length,player.getDamagedHp()));
 						next.set('processAI',function(list){
+							if(_status.event.max){
+								let gain=list[0][1].sort((a,b)=>{
+									return player.getUseValue(b,null,true)-player.getUseValue(a,null,true);
+								}).slice(0,_status.event.max),give=list[1][1].sort((a,b)=>{
+									return get.value(a,player)-get.value(b,player);
+								}).slice(0,_status.event.max);
+								for(let i of gain){
+									if(get.value(i,player)<get.value(give[0],player)) continue;
+									let j=give.shift();
+									list[0][1].remove(i);
+									list[0][1].push(j);
+									list[1][1].remove(j);
+									list[1][1].push(i);
+									if(!give.length) break;
+								}
+							}
 							return [list[0][1],list[1][1]];
 						});
 					}

--- a/character/yijiang.js
+++ b/character/yijiang.js
@@ -2295,7 +2295,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 							return get.distance(player,current)>1;
 						})) return false;
 						if(tag=='directHit_ai') return arg.card.name=='sha';
-						if(arg.card.name!='sha'&&arg.card.name!='chuqibuyi') return false;
+						if(!arg||!arg.card||arg.card.name!='sha'&&arg.card.name!='chuqibuyi') return false;
 						var card=arg.target.getEquip(2);
 						if(card&&card.name.indexOf('bagua')!=-1) return true;
 						if(player._xinbenxi_ai) return false;


### PR DESCRIPTION
### PR受影响的平台
所有平台


### 诱因和背景
吴懿对有八卦阵效果的角色发动【奔袭】时ai必然卡死



### PR描述
修复吴懿对有八卦阵效果的角色发动【奔袭】ai卡死的bug；
微调【杀】默认出闪ai；
为【八卦阵】默认ai增加专行判断；
删除本体中不严谨易出bug且多数情况下也无效的'unequip_ai'标签检测



### PR测试
见上



### 扩展适配
无需适配



### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff