### PR TITLE
使import可以解析node内部模块

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,28 @@
 	<meta name="viewport" content="user-scalable=no, viewport-fit=cover">
 	<title>无名杀</title>
 	<script>
+		if (typeof window.require == 'function' &&
+			typeof window.process == 'object' &&
+			typeof window.__dirname == 'string') {
+			// 使importMap解析node内置模块
+			const builtinModules = require('module').builtinModules;
+			if (Array.isArray(builtinModules)) {
+				const importMap = {
+					imports: {}
+				};
+				for (const module of builtinModules) {
+					importMap.imports[module] =
+						importMap.imports[`node:${module}`] =
+						`./noname-builtinModules/${module}`
+				}
+				const im = document.createElement('script');
+				im.type = 'importmap';
+				im.textContent = JSON.stringify(importMap);
+				document.currentScript.after(im);
+			}
+		}
+	</script>
+	<script>
 		"use strict";
 		(() => {
 			window.onerror = function (msg, src, line, column, err) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -59,146 +59,161 @@ self.addEventListener('fetch', event => {
 		event.respondWith(rep);
 		return;
 	}
-	if (!['.ts', '.json', '.vue', 'css'].some(ext => request.url.endsWith(ext))) return;
+	if (!['.ts', '.json', '.vue', 'css'].some(ext => request.url.endsWith(ext)) && !request.url.replace(location.origin, '').startsWith('/noname-builtinModules/')) return;
 	if (request.url.endsWith('.d.ts')) return;
 	if (request.url.endsWith('.json') || request.url.endsWith('css')) {
 		if (!event.request.headers.get('origin')) return;
 	}
-	// 请求原文件
-	const res = fetch(request.url, {
-		method: request.method,
-		mode: "no-cors",
-		headers: new Headers({
-			"Content-Type": "text/plain"
-		}),
-	});
-	// 修改请求结果
-	event.respondWith(
-		res.then(res => {
-			if (res.status != 200) return res;
-			console.log('正在编译', request.url);
-			return res.text().then(text => {
-				let js = '';
-				if (request.url.endsWith('.json')) {
-					js = `export default ${ text }`;
-				} else if (request.url.endsWith('.ts')) {
-					js = ts.transpile(text, {
-						module: ts.ModuleKind.ES2015,
-						//@todo: ES2019 -> ES2020
-						target: ts.ScriptTarget.ES2019,
-						inlineSourceMap: true,
-						resolveJsonModule: true,
-						esModuleInterop: true,
-					}, request.url);
-				} else if (request.url.endsWith('.vue')) {
-					const id = Date.now().toString();
-					const scopeId = `data-v-${ id }`;
-					// 后续处理sourceMap合并
-					const { descriptor } = sfc.parse(text, { filename: request.url, sourceMap: true });
-					// console.log({ descriptor });
-					const hasScoped = descriptor.styles.some(s => s.scoped);
-					// 编译 script，因为可能有 script setup，还要进行 css 变量注入
-					const script = sfc.compileScript(descriptor, {
-						id: scopeId,
-						inlineTemplate: true,
-						templateOptions: {
-							scoped: hasScoped,
-							compilerOptions: {
-								scopeId: hasScoped ? scopeId : undefined,
-							}
-						},
-					});
-					// 用于存放代码，最后 join('\n') 合并成一份完整代码
-					const codeList = [];
-
-					// 保存url并且拼接参数
-					const url = new URL(request.url);
-					const scriptSearchParams = new URLSearchParams(url.search.slice(1));
-					scriptSearchParams.append('type', 'script');
-
-					const templateSearchParams = new URLSearchParams(url.search.slice(1));
-					templateSearchParams.append('type', 'template');
-
-					vueFileMap.set(
-						url.origin + url.pathname + '?' + scriptSearchParams.toString(),
-						// 重写 default
-						sfc.rewriteDefault(script.attrs && script.attrs.lang == 'ts' ? ts.transpile(script.content, {
+	if (request.url.replace(location.origin, '').startsWith('/noname-builtinModules/')) {
+		const moduleName = request.url.replace(location.origin + '/noname-builtinModules/', '');
+		console.log('正在编译', moduleName);
+		let js = `const module = require('${ moduleName }');\nexport default module;`;
+		const rep = new Response(new Blob([js], { type: "text/javascript" }), {
+			status: 200,
+			statusText: "OK",
+			headers: new Headers({
+				"Content-Type": "text/javascript"
+			}),
+		});
+		console.log(moduleName, '编译成功');
+		event.respondWith(Promise.resolve(rep));
+	} else {
+		// 请求原文件
+		const res = fetch(request.url, {
+			method: request.method,
+			mode: "no-cors",
+			headers: new Headers({
+				"Content-Type": "text/plain"
+			}),
+		});
+		// 修改请求结果
+		event.respondWith(
+			res.then(res => {
+				if (res.status != 200) return res;
+				console.log('正在编译', request.url);
+				return res.text().then(text => {
+					let js = '';
+					if (request.url.endsWith('.json')) {
+						js = `export default ${ text }`;
+					} else if (request.url.endsWith('.ts')) {
+						js = ts.transpile(text, {
 							module: ts.ModuleKind.ES2015,
 							//@todo: ES2019 -> ES2020
 							target: ts.ScriptTarget.ES2019,
 							inlineSourceMap: true,
 							resolveJsonModule: true,
 							esModuleInterop: true,
-						}, url.origin + url.pathname + '?' + scriptSearchParams.toString()) : script.content, "__sfc_main__")
-							.replace(`const __sfc_main__`, `export const __sfc_main__`)
-							// import vue重新指向
+						}, request.url);
+					} else if (request.url.endsWith('.vue')) {
+						const id = Date.now().toString();
+						const scopeId = `data-v-${ id }`;
+						// 后续处理sourceMap合并
+						const { descriptor } = sfc.parse(text, { filename: request.url, sourceMap: true });
+						// console.log({ descriptor });
+						const hasScoped = descriptor.styles.some(s => s.scoped);
+						// 编译 script，因为可能有 script setup，还要进行 css 变量注入
+						const script = sfc.compileScript(descriptor, {
+							id: scopeId,
+							inlineTemplate: true,
+							templateOptions: {
+								scoped: hasScoped,
+								compilerOptions: {
+									scopeId: hasScoped ? scopeId : undefined,
+								}
+							},
+						});
+						// 用于存放代码，最后 join('\n') 合并成一份完整代码
+						const codeList = [];
+
+						// 保存url并且拼接参数
+						const url = new URL(request.url);
+						const scriptSearchParams = new URLSearchParams(url.search.slice(1));
+						scriptSearchParams.append('type', 'script');
+
+						const templateSearchParams = new URLSearchParams(url.search.slice(1));
+						templateSearchParams.append('type', 'template');
+
+						vueFileMap.set(
+							url.origin + url.pathname + '?' + scriptSearchParams.toString(),
+							// 重写 default
+							sfc.rewriteDefault(script.attrs && script.attrs.lang == 'ts' ? ts.transpile(script.content, {
+								module: ts.ModuleKind.ES2015,
+								//@todo: ES2019 -> ES2020
+								target: ts.ScriptTarget.ES2019,
+								inlineSourceMap: true,
+								resolveJsonModule: true,
+								esModuleInterop: true,
+							}, url.origin + url.pathname + '?' + scriptSearchParams.toString()) : script.content, "__sfc_main__")
+								.replace(`const __sfc_main__`, `export const __sfc_main__`)
+								// import vue重新指向
+								.replaceAll(`from "vue"`, `from "/game/vue.esm-browser.js"`)
+								.replaceAll(`from 'vue'`, `from '/game/vue.esm-browser.js'`)
+						);
+
+						codeList.push(`import { __sfc_main__ } from '${ url.origin + url.pathname + '?' + scriptSearchParams.toString() }'`);
+						codeList.push(`__sfc_main__.__scopeId = '${ scopeId }'`);
+
+						// 编译模板，转换成 render 函数
+						const template = sfc.compileTemplate({
+							source: descriptor.template ? descriptor.template.content : '',
+							filename: request.url, // 用于错误提示
+							id: scopeId,
+							scoped: hasScoped,
+							compilerOptions: {
+								scopeId: hasScoped ? scopeId : undefined,
+							}
+						});
+
+						vueFileMap.set(
+							url.origin + url.pathname + '?' + templateSearchParams.toString(),
+							template.code
+							// .replace(`function render(_ctx, _cache) {`, str => str + 'console.log(_ctx);')
 							.replaceAll(`from "vue"`, `from "/game/vue.esm-browser.js"`)
 							.replaceAll(`from 'vue'`, `from '/game/vue.esm-browser.js'`)
-					);
-
-					codeList.push(`import { __sfc_main__ } from '${ url.origin + url.pathname + '?' + scriptSearchParams.toString() }'`);
-					codeList.push(`__sfc_main__.__scopeId = '${ scopeId }'`);
-
-					// 编译模板，转换成 render 函数
-					const template = sfc.compileTemplate({
-						source: descriptor.template ? descriptor.template.content : '',
-						filename: request.url, // 用于错误提示
-						id: scopeId,
-						scoped: hasScoped,
-						compilerOptions: {
-							scopeId: hasScoped ? scopeId : undefined,
+						);
+						
+						codeList.push(`import { render } from '${ url.origin + url.pathname + '?' + templateSearchParams.toString() }'`);
+						codeList.push(`__sfc_main__.render = render;`);
+						codeList.push(`export default __sfc_main__;`);
+						// 一个 Vue 文件，可能有多个 style 标签
+						let styleIndex = 0;
+						for (const styleBlock of descriptor.styles) {
+							const styleCode = sfc.compileStyle({
+								source: styleBlock.content,
+								id,
+								filename: request.url,
+								scoped: styleBlock.scoped,
+							});
+							const varName = `el${ styleIndex }`;
+							const styleDOM = `let ${ varName } = document.createElement('style');\n${ varName }.innerHTML =  \`${ styleCode.code }\`;\ndocument.body.append(${ varName });`;
+							codeList.push(styleDOM);
 						}
-					});
-
-					vueFileMap.set(
-						url.origin + url.pathname + '?' + templateSearchParams.toString(),
-						template.code
-						// .replace(`function render(_ctx, _cache) {`, str => str + 'console.log(_ctx);')
-						.replaceAll(`from "vue"`, `from "/game/vue.esm-browser.js"`)
-						.replaceAll(`from 'vue'`, `from '/game/vue.esm-browser.js'`)
-					);
-					
-					codeList.push(`import { render } from '${ url.origin + url.pathname + '?' + templateSearchParams.toString() }'`);
-					codeList.push(`__sfc_main__.render = render;`);
-					codeList.push(`export default __sfc_main__;`);
-					// 一个 Vue 文件，可能有多个 style 标签
-					let styleIndex = 0;
-					for (const styleBlock of descriptor.styles) {
-						const styleCode = sfc.compileStyle({
-							source: styleBlock.content,
-							id,
-							filename: request.url,
-							scoped: styleBlock.scoped,
-						});
-						const varName = `el${ styleIndex }`;
-						const styleDOM = `let ${ varName } = document.createElement('style');\n${ varName }.innerHTML =  \`${ styleCode.code }\`;\ndocument.body.append(${ varName });`;
-						codeList.push(styleDOM);
+						js = codeList.join('\n');
+						// console.log(js);
+					} else if (request.url.endsWith('css')) {
+						const id = Date.now().toString();
+						const scopeId = `data-v-${ id }`;
+						js = `const style = document.createElement('style');
+						style.setAttribute('type', 'text/css');
+						style.setAttribute('data-vue-dev-id', \`${ scopeId }\`);
+						style.textContent = ${ JSON.stringify(text) };
+						document.head.appendChild(style);`;
 					}
-					js = codeList.join('\n');
-					// console.log(js);
-				} else if (request.url.endsWith('css')) {
-					const id = Date.now().toString();
-					const scopeId = `data-v-${ id }`;
-					js = `const style = document.createElement('style');
-					style.setAttribute('type', 'text/css');
-					style.setAttribute('data-vue-dev-id', \`${ scopeId }\`);
-					style.textContent = ${ JSON.stringify(text) };
-					document.head.appendChild(style);`;
-				}
-				const rep = new Response(new Blob([js], { type: "text/javascript" }), {
-					status: 200,
-					statusText: "OK",
-					headers: new Headers({
-						"Content-Type": "text/javascript"
-					}),
-				});
-				console.log(request.url, '编译成功');
-				return rep;
+					const rep = new Response(new Blob([js], { type: "text/javascript" }), {
+						status: 200,
+						statusText: "OK",
+						headers: new Headers({
+							"Content-Type": "text/javascript"
+						}),
+					});
+					console.log(request.url, '编译成功');
+					return rep;
+				})
 			})
-		})
-		.catch(e => {
-			console.error(request.url, '编译失败: ', e);
-			throw e;
-		})
-	);
+			.catch(e => {
+				console.error(request.url, '编译失败: ', e);
+				throw e;
+			})
+		);
+	}
 });


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
电脑端和手机端

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
1.使import可以解析node内部模块
2.优化素材更新机制

### PR描述
<!-- 详细描述您的更改 -->
1.使import可以解析node内部模块
**只能解析node内部自带的模块**
例如:
```js
import fs from 'node:fs';
```
2.优化素材更新机制，自动记录素材每一类的大小
### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
浏览器控制台使用await import('node:fs/promises')
和点击更新素材按钮

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
import可以解析node内部模块部分无需扩展适配，但是需要电脑客户端适配，将我改的html代码粘贴过去到电脑客户端的html
更新素材机制部分，需要覆盖更新按钮的扩展跟进

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff