### PR TITLE
添加player.removeExpandEquip（移除扩展装备栏）

### DIFF
--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -379,6 +379,91 @@ export const Content = {
 		}
 		player.$syncExpand();
 	},
+	removeExpandEquip: function () {
+        'step 0'
+        if (!player.expandedSlots || !event.slots.length) return;
+        const slotMap = {};
+        event.slots.forEach(s => {
+            if (s in slotMap) slotMap[s]++;
+            else slotMap[s] = 1;
+        });
+        const slots = Object.keys(slotMap).sort();
+        var combinedRemoved = false;
+        var dialog = null;
+        var discardTypes = {};
+        for (var slot of slots) {
+            var subtype = slot;
+            var count;
+            if (get.is.mountCombined() && (slot == 'equip3' || slot == 'equip4')) {
+                if (combinedRemoved) continue;
+                else {
+                    combinedRemoved = true;
+                    slot = 'equip3';
+                    subtype = 'equip3_4';
+                    count = Math.max(slotMap['equip3'] || 0, slotMap['equip4'] || 0);
+                }
+            }
+            else count = slotMap[slot];
+            if (typeof player.expandedSlots[slot] != 'number' || player.expandedSlots[slot] <= 0) {
+                continue;
+            }
+            else {
+                var cards, discards;
+                if (subtype.endsWith('3_4')) cards = player.getCards('e', { subtype: ['equip3', 'equip4'] });
+                else cards = player.getCards('e', { subtype: subtype });
+                count = Math.min(count, player.expandedSlots[slot]);
+                game.log(player, '失去了' + get.cnNumber(count) + '个额外的', '#g' + get.translation(subtype) + '栏');
+                player.expandedSlots[slot] -= count;
+                discards = cards.length - player.expandedSlots[slot] - 1;
+                if (discards > 0) {
+                    if (!dialog) {
+                        dialog = ui.create.dialog('hidden', 'forcebutton');
+                        dialog.add(event.prompt || '请选择要弃置的装备');
+                    }
+                    dialog.addText(get.translation(subtype) + '栏');
+                    dialog.addText('需要弃置' + get.cnNumber(discards) + '张牌');
+                    dialog.add(cards);
+                    dialog.buttons.forEach(b => {
+                        if (!b._extraInfo)
+                            b._extraInfo = { subtype, discards };
+                    });
+                    discardTypes[subtype] = discards;
+                }
+            }
+        }
+        if (Object.values(player.expandedSlots).some(v => {
+            return typeof v == 'number' && v > 0;
+        })) player.$syncExpand();
+        else player.unmarkSkill('expandedSlots');
+        if (!dialog) event.finish();
+        else {
+            const next = player.chooseButton(dialog, true, [1, Infinity]);
+            next.set('complexSelect', true);
+            next.set('filterButton', (button) => {
+                var info = button._extraInfo;
+                var selected = ui.selected.buttons;
+                return selected.filter(b => {
+                    return b._extraInfo.subtype == info.subtype;
+                }).length < info.discards || selected.includes(button);
+            });
+            next.set('filterOk', () => {
+                var selected = ui.selected.buttons;
+                for (let st in discardTypes) {
+                    if (selected.filter(b => {
+                        return b._extraInfo.subtype == st;
+                    }).length < discardTypes[st])
+                        return false;
+                }
+                return true;
+            });
+        }
+        'step 1'
+        const source = event.source || player;
+        const next = player.discard(source, result.links);
+        if (player != source) next.notBySelf = true;
+        next.discarder = source;
+        event.done = next;
+    },
 	//选择顶装备要顶的牌
 	replaceEquip: function () {
 		'step 0';

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -1179,6 +1179,47 @@ export class Player extends HTMLDivElement {
 		return next;
 	}
 	/**
+	 * 移除扩展装备区（同时移除多余装备）
+	 *
+	 * 参数：扩展来源角色（不写默认当前事件角色），扩展区域（数字/区域字符串/数组，可以写多个，重复扩展）
+	 *（参数与expandEquip对齐，另外可以追加prompt指定弃置对话框的标题）
+	 */
+	removeExpandEquip() {
+        var next = game.createEvent('removeExpandEquip');
+        next.player = this;
+        next.slots = [];
+        for (var i = 0; i < arguments.length; i++) {
+            if (get.itemtype(arguments[i]) == 'player') {
+                next.source = arguments[i];
+            }
+            else if (Array.isArray(arguments[i])) {
+                for (var arg of arguments[i]) {
+                    if (typeof arg == 'string') {
+                        if (arg.startsWith('equip') && parseInt(arg.slice(5)) > 0) next.slots.push(arg);
+                        else next.prompt = arg;
+                    }
+                    else if (typeof arg == 'number') {
+                        next.slots.push('equip' + arg);
+                    }
+                }
+            }
+            else if (typeof arguments[i] == 'string') {
+                if (arguments[i].startsWith('equip') && parseInt(arguments[i].slice(5)) > 0) next.slots.push(arguments[i]);
+                else next.prompt = arg;
+            }
+            else if (typeof arguments[i] == 'number') {
+                next.slots.push('equip' + arguments[i]);
+            }
+        }
+        if (!next.source) next.source = _status.event.player;
+        if (!next.slots.length) {
+            _status.event.next.remove(next);
+            next.resolve();
+        }
+        next.setContent('removeExpandEquip');
+        return next;
+    }
+	/**
 	 * 判断判定区是否被废除
 	 */
 	isDisabledJudge() {


### PR DESCRIPTION
因为最近碰到不少人有需要移除扩展装备栏的需求，然后询问萌佬的时候萌佬说明了没有这类函数，故而编写了这部分代码

- 参考了扩展装备栏的流程，确保了参数与用法和扩展装备栏保持一致（初步测试完毕）
- 参考了扩展装备栏的流程，确保合并坐骑栏启用的情况也可以正常工作（初步测试完毕）
- 另外在其他人的建议下，装备区多余的装备会要求玩家弃置（初步测试完毕）