### PR TITLE
修复globalskill移除问题、attaclTo拼写错误

### DIFF
--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -4653,8 +4653,14 @@ export class Game extends Uninstantable {
 	}
 	/**
 	 * @param { string } skill 
+	 * @param { lib.element.Player } player 
 	 */
-	static removeGlobalSkill(skill) {
+	static removeGlobalSkill(skill, player) {
+		const players = lib.skill.globalmap[skill];
+		if(player && Array.isArray(players)) {
+			lib.skill.globalmap[skill].remove(player);
+			if(players.length) return;
+		}
 		lib.skill.global.remove(skill);
 		delete lib.skill.globalmap[skill];
 		for (let i in lib.hook.globalskill) {

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -2012,8 +2012,8 @@ export class Get extends Uninstantable {
 			if (info.globalTo) {
 				n += info.globalTo;
 			}
-			if (info.attaclTo) {
-				m += info.attaclTo;
+			if (info.attackTo) {
+				m += info.attackTo;
 			}
 		}
 		if (method == 'attack') {
@@ -2026,8 +2026,8 @@ export class Get extends Uninstantable {
 			// for(let i=0;i<equips2.length;i++){
 			// 	let info=get.info(equips2[i]).distance;
 			// 	if(!info) continue;
-			// 	if(info.attaclTo){
-			// 		m+=info.attaclTo;
+			// 	if(info.attackTo){
+			// 		m+=info.attackTo;
 			// 	}
 			// }
 			// return n;

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -1970,8 +1970,8 @@ export class Player extends HTMLDivElement {
 				m += info.globalTo;
 				n += info.globalTo;
 			}
-			if (info.attaclTo) {
-				m += info.attaclTo;
+			if (info.attackTo) {
+				m += info.attackTo;
 			}
 		}
 		return m <= range;


### PR DESCRIPTION
**PR受影响的平台**
所有

**诱因和背景**
globalskill问题由群友 @白银山幽灵 提出，多个玩家/技能提供相同的globalskill在移除其中一个时会导致全部失效
attaclTo问题由群友 @终日羽禁 提出，拼写错误，应该是attackTo而不是attaclTo

**PR描述**
globalskill方面：
- 为removeGlobalSkill添加了参数player，对接了player.js的调用。

attaclTo方面：
- 对接其他部分代码的attackTo，纠正原来的拼写错误。

**PR测试**
在本地运行测试无异常。
globalskill的测试结果达到预期
attackTo的测试结果达到预期

测试代码如下：
```javascript
// 测试globalskill问题
lib.skill.test_skill = {
    forced: true,
    global: 'test_skill2',
};

lib.skill.test_skill2 = {
    forced: true,
    trigger: {
        global: 'phaseBegin',
    },
    content() {
        player.say('持有技能test_skill2');
    },
};

game.players.forEach(p =>
    p.addTempSkill('test_skill', { player: 'phaseEnd' }));

// 测试结果：
// （环境：两人军争）
// 第一轮每个回合所有角色都会说话
// 第二轮不再说话
// 达到预期

// 测试attaclTo问题
lib.card.test_card = {
    type: 'equip',
    fullskin: true,
    subtype: 'equip3',
    enable: true,
    selectTarget: -1,
    modTarget: true,
    toself: true,
    allowMultiple: false,
    filterTarget: (c, p, t) => p === t,
    distance: {
        attackTo: 1,
    },
    content: lib.element.content.equipCard,
};

game.me.directgain([game.createCard('sha'), game.createCard('chitu'), game.createCard('guding')]);
game.me.next.directequip([game.createCard('test_card')]);

// 测试结果：
// （环境：两人军争）
// 在没有装备赤兔或古锭刀的情况下无法使用杀
// 装备赤兔或古锭刀的情况下可以使用杀
// 达到预期
```

**扩展适配**
无

**检查清单**
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在PR描述中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在扩展适配中写入详细文档
- [x] 如果这个PR解决了一个issue，我在诱因和背景中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff