### PR TITLE
fix: 若nameinfo[0]没有对应的剪影素材，则剪影全为male

### DIFF
--- a/noname/init/polyfill.js
+++ b/noname/init/polyfill.js
@@ -196,7 +196,7 @@ Reflect.defineProperty(HTMLDivElement.prototype, 'setBackground', {
 		this.style.backgroundSize = 'cover';
 		if (type === 'character') {
 			const nameinfo = get.character(name);
-			const sex = nameinfo ? nameinfo[0] : 'male';
+			const sex = nameinfo && ['male', 'female', 'double'].includes(nameinfo[0]) ? nameinfo[0] : 'male';
 			this.setBackgroundImage([
 				src,
 				`${lib.characterDefaultPicturePath}${sex}${ext}`


### PR DESCRIPTION
### PR受影响的平台
所有平台


### 诱因和背景
这种写法的武将无剪影（无原画时）
![20240412022227](https://github.com/libccy/noname/assets/131325076/8b22c732-4605-45c7-bc21-b236612d2882)



### PR描述
若nameinfo[0]没有对应的剪影素材，则剪影全为male


### PR测试
通过


### 扩展适配
无需适配


### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff