### PR TITLE
国战禁用无限制变更势力的武将/技能，combo补充

### DIFF
--- a/character/huicui.js
+++ b/character/huicui.js
@@ -678,6 +678,9 @@ game.import('character', function () {
 					await player.recover();
 					await player.addSkills('dczifu');
 				},
+				ai:{
+					combo:'dcjichou'
+				}
 			},
 			dczifu:{
 				audio:2,

--- a/character/jsrg.js
+++ b/character/jsrg.js
@@ -85,6 +85,11 @@ game.import('character', function () {
 		},
 		characterTitle:{
 		},
+		characterFilter:{
+			jsrg_jiangwei(mode){
+				return mode!=='guozhan';
+			},
+		},
 		perfectPair:{},
 		card:{
 			xumou_jsrg:{
@@ -371,7 +376,6 @@ game.import('character', function () {
 			},
 			//姜维
 			jsrgjinfa:{
-				forbid:['guozhan'],
 				audio:2,
 				enable:'phaseUse',
 				usable:1,
@@ -4457,7 +4461,6 @@ game.import('character', function () {
 			},
 			//张郃
 			jsrgqiongtu:{
-				//forbid:['guozhan'],
 				audio:2,
 				enable:'chooseToUse',
 				groupSkill:true,
@@ -5315,7 +5318,6 @@ game.import('character', function () {
 			},
 			//张辽
 			jsrgzhengbing:{
-				//forbid:['guozhan'],
 				audio:2,
 				enable:'phaseUse',
 				usable:3,

--- a/character/jsrg.js
+++ b/character/jsrg.js
@@ -371,6 +371,7 @@ game.import('character', function () {
 			},
 			//姜维
 			jsrgjinfa:{
+				forbid:['guozhan'],
 				audio:2,
 				enable:'phaseUse',
 				usable:1,
@@ -4092,6 +4093,7 @@ game.import('character', function () {
 			},
 			//许攸
 			jsrglipan:{
+				forbid:['guozhan'],
 				audio:2,
 				trigger:{
 					player:'phaseEnd',
@@ -4328,6 +4330,7 @@ game.import('character', function () {
 			},
 			//吕布
 			jsrgwuchang:{
+				forbid:['guozhan'],
 				audio:2,
 				trigger:{
 					player:'gainAfter',
@@ -4454,6 +4457,7 @@ game.import('character', function () {
 			},
 			//张郃
 			jsrgqiongtu:{
+				//forbid:['guozhan'],
 				audio:2,
 				enable:'chooseToUse',
 				groupSkill:true,
@@ -5311,6 +5315,7 @@ game.import('character', function () {
 			},
 			//张辽
 			jsrgzhengbing:{
+				//forbid:['guozhan'],
 				audio:2,
 				enable:'phaseUse',
 				usable:3,

--- a/character/old.js
+++ b/character/old.js
@@ -152,6 +152,7 @@ game.import('character', function () {
 			},
 			//魏武帝
 			junkguixin:{
+				forbid:['guozhan'],
 				init:function(){
 					if(!_status.junkguixin){
 						_status.junkguixin=[];

--- a/character/sb.js
+++ b/character/sb.js
@@ -5995,7 +5995,6 @@ game.import('character', function () {
 			},
 			//孙尚香
 			sbjieyin:{
-				//forbid:['guozhan'],
 				trigger:{player:'phaseUseBegin'},
 				forced:true,
 				locked:false,

--- a/character/sb.js
+++ b/character/sb.js
@@ -5995,6 +5995,7 @@ game.import('character', function () {
 			},
 			//孙尚香
 			sbjieyin:{
+				//forbid:['guozhan'],
 				trigger:{player:'phaseUseBegin'},
 				forced:true,
 				locked:false,

--- a/character/shenhua.js
+++ b/character/shenhua.js
@@ -2437,9 +2437,6 @@ game.import('character', function () {
 						},
 					},
 				},
-				ai:{
-					combo:'nzry_zhenliang',
-				},
 			},
 			"nzry_zhenliang":{
 				audio:"nzry_zhenliang_1",

--- a/character/sp.js
+++ b/character/sp.js
@@ -28,6 +28,9 @@ game.import('character', function () {
 			ol_dongzhao:function(mode){
 				return mode=='identity'&&['normal','zhong'].includes(_status.mode);
 			},
+			ol_mengda(mode){
+				return mode!=='guozhan';
+			},
 		},
 		character:{
 			ol_liupi:['male','qun',4,['olyicheng']],
@@ -4865,7 +4868,6 @@ game.import('character', function () {
 			},
 			//OL孟达
 			olgoude:{
-				forbid:['guozhan'],
 				audio:2,
 				trigger:{
 					global:'phaseEnd',

--- a/character/sp.js
+++ b/character/sp.js
@@ -4865,6 +4865,7 @@ game.import('character', function () {
 			},
 			//OL孟达
 			olgoude:{
+				forbid:['guozhan'],
 				audio:2,
 				trigger:{
 					global:'phaseEnd',

--- a/character/tw.js
+++ b/character/tw.js
@@ -15919,6 +15919,7 @@ game.import('character', function () {
 				}
 			},
 			renshe:{
+				forbid:['guozhan'],
 				audio:2,
 				trigger:{player:'damageEnd'},
 				direct:true,

--- a/character/yingbian.js
+++ b/character/yingbian.js
@@ -3454,6 +3454,9 @@ game.import('character', function () {
 					player.addSkills('pozhu');
 				},
 				derivation:'pozhu',
+				ai:{
+					combo:'sanchen'
+				}
 			},
 			pozhu:{
 				enable:'phaseUse',


### PR DESCRIPTION
### PR受影响的平台
所有平台



### PR描述
移除nzry_mingren的combo，因为谋卢植沿用此技能但有不为此combo的combo技能sbzhenliang；
继续补充技能combo；
国战禁用无限制变更势力的武将或技能



### 扩展适配
无需适配



### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff