### PR TITLE
神鲁肃榻谟修改；去除欢乐成双模式中换座位技能的禁用

### DIFF
--- a/character/extra.js
+++ b/character/extra.js
@@ -753,6 +753,7 @@ game.import("character", function () {
 				},
 				direct: true,
 				changeSeat: true,
+				derivation: "tamo_faq",
 				async content(event, trigger, player) {
 					const toSortPlayers = game.filterPlayer((current) => !current.isZhu2());
 					toSortPlayers.sortBySeat(game.findPlayer2((current) => current.getSeatNum() == 1, true));
@@ -870,7 +871,7 @@ game.import("character", function () {
 					});
 					const { result } = await next;
 					if (!result.bool) return;
-					player.logSkill("tamo");
+					await player.logSkill("tamo");
 					const resultList = result.moved[0].map((info) => {
 						return parseInt(info.split("|")[0]);
 					});
@@ -891,6 +892,25 @@ game.import("character", function () {
 							game.swapSeat(list[0], list[1], false);
 						}
 					}, toSwapList);
+					if (trigger.name === "phase" && trigger.player !== toSortPlayers[0] && !trigger._finished) {
+						trigger.finish();
+						trigger._triggered = 5;
+						const evt = toSortPlayers[0].insertPhase();
+						delete evt.skill;
+						const evt2 = trigger.getParent();
+						if (evt2.name == "phaseLoop" && evt2._isStandardLoop) {
+							evt2.player = toSortPlayers[0];
+						}
+						//跳过新回合的phaseBefore
+						evt.pushHandler("onPhase", (event, option) => {
+							if (
+								event.step === 0 &&
+								option.state === "begin"
+							) {
+								event.step = 1;
+							}
+						});
+					}
 					await game.asyncDelay();
 				},
 			},
@@ -1164,7 +1184,6 @@ game.import("character", function () {
 										default:
 											return false;
 									}
-									break;
 							}
 						},
 						forced: true,
@@ -10814,7 +10833,11 @@ game.import("character", function () {
 			dingzhou_info:
 				"出牌阶段限一次。你可以将X张牌交给一名场上有牌的角色，然后你获得其场上的所有牌（X为其场上的牌数+1）。",
 			tamo: "榻谟",
-			tamo_info: "游戏开始时，你可以重新分配除主公外所有角色的座次。",
+			tamo_info:
+				"游戏开始时，你可以重新分配除主公外所有角色的座次。",
+			tamo_faq: "FAQ",
+			tamo_faq_info:
+				"<br><li>Q：在一号位不为主公的情况下，〖榻谟〗如何结算？</li><li>A：该角色可以正常进行座次交换。若受此技能影响导致一号位角色发生了变化，则以排列后的一号位角色为起始角色开始本局游戏。</li>",
 			zhimeng: "智盟",
 			zhimeng_info:
 				"回合结束后，你可以与一名其他角色将各自所有手牌置于处理区，然后你随机获得这些牌中的一半（向上取整），其获得剩余的牌。",

--- a/character/mobile.js
+++ b/character/mobile.js
@@ -394,8 +394,6 @@ game.import("character", function () {
 				"南华老仙，是古典小说《三国演义》中的虚拟人物。其原型来自道教典籍中对庄子的封号，又称“南华仙人”、“南华真人”等。在古典小说《三国演义》通行本的第一回中，描述了南华老仙将《太平要术》赠送给张角的情节。",
 			chenzhen:
 				"陈震（？—公元235年），字孝起。荆州南阳郡（今河南南阳）人。三国时期蜀汉官员。刘备领荆州牧时，辟陈震为从事。后随刘备入蜀，为蜀郡北部都尉、汶山太守、犍为太守。建兴三年（225年），拜尚书，迁尚书令。建兴七年（229年），孙权称帝。蜀汉以陈震为卫尉，前往祝贺，与孙权开坛歃盟，交分天下。还蜀，封城阳亭侯。建兴十三年（235年），卒。",
-			nanhualaoxian:
-				"南华老仙，其原型来自道教典籍中对庄子的封号，又称“南华仙人”、“南华真人”等。在古典小说《三国演义》通行本的第一回中，描述了南华老仙将《太平要术》赠送给张角的情节。",
 			hucheer:
 				"胡车儿（生卒年不详），东汉末年武将，初从张绣，为其心腹猛将，勇冠三军，与贾诩交情甚佳。宛城大战后，张绣投降曹操，曹操爱胡车儿之骁勇，手以黄金与之。后因曹操私纳张绣亡叔张济的遗孀邹氏，张绣深感其辱，欲杀曹操，与贾诩商议后决心反曹。《三国演义》中，作者考虑到典韦的勇猛，便增加了令胡车儿盗走典韦的双戟的情节。最终典韦、曹昂（曹操长子）、曹安民（曹操侄子）皆死于此次战斗。野史说胡车儿跟随曹操征战，被赵云在长坂坡上红枪挑死。",
 			simashi:
@@ -660,7 +658,6 @@ game.import("character", function () {
 			},
 			mbshishou: {
 				audio: 2,
-				forced: true,
 				trigger: { player: "useSkillAfter" },
 				filter(event, player) {
 					return event.skill === "mbzuoyou" && !event.targets.includes(player);
@@ -2714,7 +2711,6 @@ game.import("character", function () {
 				},
 				forced: true,
 				popup: false,
-				onremove: true,
 				firstDo: true,
 				init: function (player, skill) {
 					player.storage[skill] = 0;
@@ -10578,23 +10574,6 @@ game.import("character", function () {
 			//钟会
 			requanji: {
 				audio: 2,
-				mod: {
-					aiOrder: (player, card, num) => {
-						if (
-							num <= 0 ||
-							typeof card !== "object" ||
-							!player.isPhaseUsing() ||
-							!player.hasSkill("zili") ||
-							player.needsToDiscard()
-						)
-							return num;
-						if (
-							player.getExpansions("quanji").length < 3 &&
-							player.getUseValue(card) < Math.min(4, (player.hp * player.hp) / 4)
-						)
-							return 0;
-					},
-				},
 				trigger: { player: ["damageEnd", "phaseUseEnd"] },
 				frequent: true,
 				locked: false,
@@ -10634,8 +10613,23 @@ game.import("character", function () {
 					}
 				},
 				mod: {
-					maxHandcard: function (player, num) {
+					maxHandcard(player, num) {
 						return num + player.getExpansions("quanji").length;
+					},
+					aiOrder(player, card, num) {
+						if (
+							num <= 0 ||
+							typeof card !== "object" ||
+							!player.isPhaseUsing() ||
+							!player.hasSkill("zili") ||
+							player.needsToDiscard()
+						)
+							return num;
+						if (
+							player.getExpansions("quanji").length < 3 &&
+							player.getUseValue(card) < Math.min(4, (player.hp * player.hp) / 4)
+						)
+							return 0;
 					},
 				},
 				onremove: function (player, skill) {
@@ -21077,10 +21071,6 @@ game.import("character", function () {
 			pangdegong_prefix: "手杀",
 			zhaotongzhaoguang: "手杀赵统赵广",
 			zhaotongzhaoguang_prefix: "手杀",
-			re_liru: "手杀界李儒",
-			re_liru_prefix: "手杀界",
-			re_chenqun: "手杀界陈群",
-			re_chenqun_prefix: "手杀界",
 			re_liru: "手杀界李儒",
 			re_liru_prefix: "手杀界",
 			re_chenqun: "手杀界陈群",

--- a/mode/versus.js
+++ b/mode/versus.js
@@ -1248,14 +1248,14 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				next.setContent(function () {
 					"step 0";
 					ui.arena.classList.add("choose-character");
-					for (var i in lib.skill) {
-						if (lib.skill[i].changeSeat) {
-							lib.skill[i] = {};
-							if (lib.translate[i + "_info"]) {
-								lib.translate[i + "_info"] = "此模式下不可用";
-							}
-						}
-					}
+					// for (var i in lib.skill) {
+					// 	if (lib.skill[i].changeSeat) {
+					// 		lib.skill[i] = {};
+					// 		if (lib.translate[i + "_info"]) {
+					// 			lib.translate[i + "_info"] = "此模式下不可用";
+					// 		}
+					// 	}
+					// }
 					var bool = Math.random() < 0.5;
 					var bool2 = Math.random() < 0.5;
 					var ref = game.players[0];


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有平台

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
同步手杀线上武将改动


### PR描述
<!-- 详细描述您的更改 -->
<ul>
<li>将神鲁肃〖榻谟〗修改为手杀可以换一号位版，并添加对应FAQ；</li>
<li>解除对决→欢乐成双模式中带 `changeSeat` 标签的技能的禁用。</li>
</ul>


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
身份、对决、斗地主模式测试并无问题


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [ ] 我保证该PR遵循项目中`.editorconfig`、`.eslintrc.json`和`.prettierrc`所规定的代码样式，并且已经通过`prettier`格式化过代码
