### PR TITLE
回滚拆顺ai.result，bugfix，标签补充

### DIFF
--- a/card/standard.js
+++ b/card/standard.js
@@ -2989,7 +2989,7 @@ game.import("card", function () {
 								cf = Math.pow(get.threaten(target, player), 2);
 							if (!num) return -0.01 * cf;
 							if (target.hp > 2) num--;
-							let dist = Math.sqrt(get.distance(player, target, "absolute"));
+							let dist = Math.sqrt(1 + get.distance(player, target, "absolute"));
 							if (dist < 1) dist = 1;
 							if (target.isTurnedOver()) dist++;
 							return (Math.min(-0.1, -num) * cf) / dist;

--- a/card/standard.js
+++ b/card/standard.js
@@ -2146,138 +2146,48 @@ game.import("card", function () {
 					},
 					result: {
 						player: function (player, target) {
-							let att = get.attitude(player, target),
-								hs = target.hasCard(
-									(card) => lib.filter.canBeGained(card, player, target),
-									"h"
-								),
-								lose = hs,
-								gain = att > 0 ? 0.52 : 1.28;
-							if (Math.abs(att) < 5.03) {
-								let temp = 0.015 * att * att;
-								if (att < 0) gain = 0.9 + temp;
-								else gain = 0.9 - temp;
+							const hs = target.getGainableCards(player, 'h');
+							const es = target.getGainableCards(player, 'e');
+							const js = target.getGainableCards(player, 'j');
+							const att = get.attitude(player, target);
+							if (att < 0) {
+								if (!hs.length && !es.some(card => {
+									return get.value(card, target) > 0 && card != target.getEquip('jinhe');
+								}) && !js.some(card => {
+									var cardj = card.viewAs ? { name: card.viewAs } : card;
+									return get.effect(target, cardj, target, player) < 0;
+								})) return 0;
 							}
-							target.countCards("e", function (card) {
-								if (
-									card.name != "jinhe" &&
-									lib.filter.canBeGained(card, player, target) &&
-									att * get.value(card, target) < 0
-								) {
-									lose = true;
-									let val = get.value(card, player);
-									if (val > 0) gain = Math.max(gain, val / 7);
-								}
-							});
-							target.countCards("j", function (card) {
-								let cardj = card.viewAs ? new lib.element.VCard({ name: card.viewAs }) : card;
-								if (
-									lib.filter.canBeGained(card, player, target) &&
-									att * get.effect(target, cardj, target, target) < 0
-								) {
-									lose = true;
-									if (cardj.name == "lebu") {
-										let needs = target.needsToDiscard(2);
-										if (att > 0) gain = Math.max(gain, 1.6 + needs / 10);
-									} else if (
-										cardj.name == "shandian" ||
-										cardj.name == "fulei" ||
-										cardj.name == "plague"
-									)
-										gain = Math.max(gain, 1.5 / Math.max(1, target.hp));
-									else if (att > 0) gain = Math.max(gain, 1.7);
-								}
-							});
-							if (!lose) return 0;
-							return gain;
+							else if (att > 1) {
+								return (es.some(card => {
+									return get.value(card, target) <= 0;
+								}) || js.some(card => {
+									var cardj = card.viewAs ? { name: card.viewAs } : card;
+									return get.effect(target, cardj, target, player) < 0;
+								})) ? 1.5 : 0;
+							}
+							return 1;
 						},
 						target: function (player, target) {
-							let att = get.attitude(player, target),
-								hs = target.countCards("h", (card) =>
-									lib.filter.canBeGained(card, player, target)
-								),
-								es = target.countCards("e", (card) =>
-									lib.filter.canBeGained(card, player, target)
-								),
-								js = target.countCards("j", (card) =>
-									lib.filter.canBeGained(card, player, target)
-								),
-								noh = !hs || target.hasSkillTag("noh"),
-								noe = !es || target.hasSkillTag("noe"),
-								check = [-1, att > 0 ? -1.3 : 1.3, att > 0 ? -2.5 : 2.5],
-								idx = -1;
-							if (hs) {
-								idx = 0;
-								if (noh) check[0] = 0.7;
+							const hs = target.getGainableCards(player, 'h');
+							const es = target.getGainableCards(player, 'e');
+							const js = target.getGainableCards(player, 'j');
+
+							if (get.attitude(player, target) <= 0) {
+								if (hs.length > 0) return -1.5;
+								return (es.some(card => {
+									return get.value(card, target) > 0 && card != target.getEquip('jinhe');
+								}) || js.some(card => {
+									var cardj = card.viewAs ? { name: card.viewAs } : card;
+									return get.effect(target, cardj, target, player) < 0;
+								})) ? -1.5 : 1.5;
 							}
-							if (es) {
-								if (idx < 0) idx = 1;
-								if (
-									target.getEquip("baiyin") &&
-									target.isDamaged() &&
-									lib.filter.canBeGained(target.getEquip("baiyin"), player, target)
-								) {
-									let rec = get.recoverEffect(target, player, target);
-									if (es == 1 || att * rec > 0) {
-										let val = 3 - 0.6 * Math.min(5, target.hp);
-										if (rec > 0) check[1] = val;
-										else if (rec < 0) check[1] = -val;
-									}
-								}
-								target.countCards("e", function (card) {
-									let val = get.value(card, target);
-									if (
-										card.name == "jinhe" ||
-										att * val >= 0 ||
-										!lib.filter.canBeGained(card, player, target)
-									)
-										return false;
-									if (att > 0) {
-										check[1] = Math.max(1.3, check[1]);
-										return true;
-									}
-									let sub = get.subtype(card);
-									if (sub == "equip2" || sub == "equip5") val += 4;
-									else if (sub == "equip1") val *= 0.4 * Math.min(3.6, target.hp);
-									else val *= 0.6;
-									if (target.hp < 3 && sub != "equip2" && sub != "equip5") val *= 0.4;
-									check[1] = Math.min(-0.16 * val, check[1]);
-								});
-								if (noe) check[1] += 0.9;
-							}
-							if (js) {
-								let func = function (num) {
-									if (att > 0) check[2] = Math.max(check[2], num);
-									else check[2] = Math.min(check[2], 0.6 - num);
-								};
-								if (idx < 0) idx = 2;
-								target.countCards("j", function (card) {
-									let cardj = card.viewAs
-										? new lib.element.VCard({ name: card.viewAs })
-										: card;
-									if (
-										!lib.filter.canBeGained(card, player, target) ||
-										att * get.effect(target, cardj, target, target) >= 0
-									)
-										return false;
-									if (cardj.name == "lebu") func(2.1 + 0.4 * target.needsToDiscard(2));
-									else if (cardj.name == "bingliang") func(2.4);
-									else if (
-										cardj.name == "shandian" ||
-										cardj.name == "fulei" ||
-										cardj.name == "plague"
-									)
-										func(Math.abs(check[2]) / (1 + target.hp));
-									else func(2.1);
-								});
-							}
-							if (idx < 0) return 0;
-							for (let i = idx + 1; i < 3; i++) {
-								if ((i == 1 && !es) || (i == 2 && !js)) continue;
-								if ((att > 0 && check[i] > check[idx]) || (att <= 0 && check[i] < check[idx]))
-									idx = i;
-							}
-							return check[idx];
+							return (es.some(card => {
+								return get.value(card, target) <= 0;
+							}) || js.some(card => {
+								var cardj = card.viewAs ? { name: card.viewAs } : card;
+								return get.effect(target, cardj, target, player) < 0;
+							})) ? 1.5 : -1.5;
 						},
 					},
 					tag: {
@@ -2546,92 +2456,38 @@ game.import("card", function () {
 					},
 					result: {
 						target: function (player, target) {
-							let att = get.attitude(player, target),
-								hs = target.countCards("h", (card) =>
-									lib.filter.canBeDiscarded(card, player, target)
-								),
-								es = target.countCards("e", (card) =>
-									lib.filter.canBeDiscarded(card, player, target)
-								),
-								js = target.countCards("j", (card) =>
-									lib.filter.canBeDiscarded(card, player, target)
-								),
-								noh = !hs || target.hasSkillTag("noh"),
-								noe = !es || target.hasSkillTag("noe"),
-								check = [-1, att > 0 ? -1.3 : 1.3, att > 0 ? -2.5 : 2.5],
-								idx = -1;
-							if (hs) {
-								idx = 0;
-								if (noh) check[0] = 0.7;
-							}
-							if (es) {
-								if (idx < 0) idx = 1;
-								if (
-									target.getEquip("baiyin") &&
-									target.isDamaged() &&
-									lib.filter.canBeDiscarded(target.getEquip("baiyin"), player, target)
-								) {
-									let rec = get.recoverEffect(target, player, target);
-									if (es == 1 || att * rec > 0) {
-										let val = 3 - 0.6 * Math.min(5, target.hp);
-										if (rec > 0) check[1] = val;
-										else if (rec < 0) check[1] = -val;
-									}
+							const att = get.attitude(player, target);
+							const hs = target.getDiscardableCards(player, 'h');
+							const es = target.getDiscardableCards(player, 'e');
+							const js = target.getDiscardableCards(player, 'j');
+							if (!hs.length && !es.length && !js.length) return 0;
+							if (att > 0) {
+								if (js.some(card => {
+									const cardj = card.viewAs ? { name: card.viewAs } : card;
+									return get.effect(target, cardj, target, player) < 0;
+								})) return 3;
+								if (target.isDamaged() && es.some(card => card.name == 'baiyin') &&
+									get.recoverEffect(target, player, player) > 0) {
+									if (target.hp == 1 && !target.hujia) return 1.6;
 								}
-								target.countCards("e", function (card) {
-									let val = get.value(card, target);
-									if (
-										card.name == "jinhe" ||
-										att * val >= 0 ||
-										!lib.filter.canBeDiscarded(card, player, target)
-									)
-										return false;
-									if (att > 0) {
-										check[1] = Math.max(1.3, check[1]);
-										return true;
-									}
-									let sub = get.subtype(card);
-									if (sub == "equip2" || sub == "equip5") val += 4;
-									else if (sub == "equip1") val *= 0.4 * Math.min(3.6, target.hp);
-									else val *= 0.6;
-									if (target.hp < 3 && sub != "equip2" && sub != "equip5") val *= 0.4;
-									check[1] = Math.min(-0.16 * val, check[1]);
-								});
-								if (noe) check[1] += 0.9;
+								if (es.some(card => {
+									return get.value(card, target) < 0;
+								})) return 1;
+								return -1.5;
 							}
-							if (js) {
-								let func = function (num) {
-									if (att > 0) check[2] = Math.max(check[2], num);
-									else check[2] = Math.min(check[2], 0.6 - num);
-								};
-								if (idx < 0) idx = 2;
-								target.countCards("j", function (card) {
-									let cardj = card.viewAs
-										? new lib.element.VCard({ name: card.viewAs })
-										: card;
-									if (
-										!lib.filter.canBeDiscarded(card, player, target) ||
-										att * get.effect(target, cardj, target, target) >= 0
-									)
-										return false;
-									if (cardj.name == "lebu") func(2.1 + 0.4 * target.needsToDiscard(2));
-									else if (cardj.name == "bingliang") func(2.4);
-									else if (
-										cardj.name == "shandian" ||
-										cardj.name == "fulei" ||
-										cardj.name == "plague"
-									)
-										func(Math.abs(check[2]) / (1 + target.hp));
-									else func(2.1);
-								});
+							else {
+								const noh = (hs.length == 0 || target.hasSkillTag('noh'));
+								const noe = (es.length == 0 || target.hasSkillTag('noe'));
+								const noe2 = (noe || !es.some(card => {
+									return get.value(card, target) > 0;
+								}));
+								const noj = (js.length == 0 || !js.some(card => {
+									const cardj = card.viewAs ? { name: card.viewAs } : card;
+									return get.effect(target, cardj, target, player) < 0;
+								}))
+								if (noh && noe2 && noj) return 1.5;
+								return -1.5;
 							}
-							if (idx < 0) return 0;
-							for (let i = idx + 1; i < 3; i++) {
-								if ((i == 1 && !es) || (i == 2 && !js)) continue;
-								if ((att > 0 && check[i] > check[idx]) || (att <= 0 && check[i] < check[idx]))
-									idx = i;
-							}
-							return check[idx];
 						},
 					},
 					tag: {

--- a/character/extra.js
+++ b/character/extra.js
@@ -9416,6 +9416,9 @@ game.import("character", function () {
 						}
 					}
 				},
+				ai: {
+					combo: "nzry_junlve"
+				},
 			},
 			nzry_dinghuo: {
 				audio: 2,

--- a/character/huicui.js
+++ b/character/huicui.js
@@ -7987,7 +7987,7 @@ game.import("character", function () {
 				},
 				async content(event, trigger, player) {
 					if (event.cards && event.cards.length) {
-						await player.dicard(event.cards);
+						await player.discard(event.cards);
 						lib.skill.dcxieshou.change(player, 1);
 					} else {
 						player.drawTo(player.maxHp);

--- a/character/mobile.js
+++ b/character/mobile.js
@@ -672,6 +672,9 @@ game.import("character", function () {
 						player
 					);
 				},
+				ai: {
+					combo: "mbzuoyou"
+				},
 			},
 			//成济
 			mbkuangli: {
@@ -1731,6 +1734,9 @@ game.import("character", function () {
 							await game.asyncDelayx();
 						},
 					},
+				},
+				ai: {
+					combo: "mbxuetu"
 				},
 			},
 			//霍骏

--- a/character/shiji.js
+++ b/character/shiji.js
@@ -3554,6 +3554,9 @@ game.import("character", function () {
 					"step 1";
 					player.addSkills("xinmouli");
 				},
+				ai: {
+					combo: "xingqi"
+				},
 				group: ["mibei_fail", "mibei_silent"],
 				derivation: "xinmouli",
 				subSkill: {

--- a/character/sp.js
+++ b/character/sp.js
@@ -14492,6 +14492,10 @@ game.import("character", function () {
 						"的选项"
 					);
 				},
+				ai: {
+					combo: "luochong",
+					neg: true
+				},
 			},
 			//SP孟获
 			spmanwang: {
@@ -31488,6 +31492,7 @@ game.import("character", function () {
 				},
 				usable: 1,
 				direct: true,
+				derivation: ["lingren_jianxiong", "lingren_xingshang"],
 				content: function () {
 					"step 0";
 					player
@@ -32848,7 +32853,7 @@ game.import("character", function () {
 			},
 			spmanwang: function (player) {
 				var num = 4 - player.countMark("spmanwang");
-				var str = "出牌阶段，你可以弃置任意张牌。然后你依次执行以下选项中的前X项：";
+				var str = "出牌阶段，你可以弃置任意张牌。然后你依次执行以下选项中的前等量项：";
 				var list = ["⒈获得〖叛侵〗。", "⒉摸一张牌。", "⒊回复1点体力。", "⒋摸两张牌并失去〖叛侵〗。"];
 				for (var i = 0; i < 4; i++) {
 					if (i == num) {

--- a/character/sp.js
+++ b/character/sp.js
@@ -2666,18 +2666,18 @@ game.import("character", function () {
 								if (!ui.selected.targets.length) return 0;
 								const target = ui.selected.targets[0];
 								if (
-									player.getHistory("useSkill", (evt) => {
+									player.hasAllHistory("useSkill", (evt) => {
 										return (
 											evt.skill == "olgongjie" &&
 											(evt.targets || [evt.target]).includes(target)
 										);
-									}).length &&
-									player.getHistory("useSkill", (evt) => {
+									}) &&
+									player.hasAllHistory("useSkill", (evt) => {
 										return (
 											evt.skill == "olxiangxv" &&
 											(evt.targets || [evt.target]).includes(target)
 										);
-									}).length
+									})
 								) {
 									if (get.attitude(player, target) > 0) return 1;
 									if (player.canSaveCard(card, player)) return 0;
@@ -2694,18 +2694,18 @@ game.import("character", function () {
 							ai2(target) {
 								const player = get.event("player");
 								const goon =
-										player.getHistory("useSkill", (evt) => {
+										player.hasAllHistory("useSkill", (evt) => {
 											return (
 												evt.skill == "olgongjie" &&
 												(evt.targets || [evt.target]).includes(target)
 											);
-										}).length &&
-										player.getHistory("useSkill", (evt) => {
+										}) &&
+										player.hasAllHistory("useSkill", (evt) => {
 											return (
 												evt.skill == "olxiangxv" &&
 												(evt.targets || [evt.target]).includes(target)
 											);
-										}).length,
+										}),
 									att = get.attitude(player, target);
 								if (goon) return 5 * att;
 								if (!!player.countCards("he", (cardx) => player.canSaveCard(cardx, player)))
@@ -2724,12 +2724,12 @@ game.import("character", function () {
 					player.awakenSkill("olxiangzuo");
 					await player.give(cards, target);
 					if (
-						player.getHistory("useSkill", (evt) => {
+						player.hasAllHistory("useSkill", (evt) => {
 							return evt.skill == "olgongjie" && evt.targets.includes(target);
-						}).length &&
-						player.getHistory("useSkill", (evt) => {
+						}) &&
+						player.hasAllHistory("useSkill", (evt) => {
 							return evt.skill == "olxiangxv" && evt.targets.includes(target);
-						}).length
+						})
 					)
 						await player.recover(cards.length);
 				},
@@ -34530,7 +34530,7 @@ game.import("character", function () {
 				"当你的手牌数变为全场最少时，你可以获得以下效果：本回合结束时，将手牌数调整至与当前回合角色手牌数相同（至多摸至五张），然后若你以此法弃置了至少两张手牌，则你回复1点体力。",
 			olxiangzuo: "襄胙",
 			olxiangzuo_info:
-				"限定技，当你进入濒死状态时，你可以交给一名其他角色任意张牌，然后若你本回合已对其发动过〖恭节〗和〖相胥〗，你回复等量的体力。",
+				"限定技，当你进入濒死状态时，你可以交给一名其他角色任意张牌，然后若你已对其发动过〖恭节〗和〖相胥〗，你回复等量的体力。",
 			liyi: "李异",
 			olchanshuang: "缠双",
 			olchanshuang_info:

--- a/character/sp.js
+++ b/character/sp.js
@@ -18,6 +18,7 @@ game.import("character", function () {
 					"tengfanglan",
 					"ruiji",
 					"caoxiancaohua",
+					"caoyu",
 				],
 				sp_sibi: [
 					"ol_lukai",
@@ -168,7 +169,6 @@ game.import("character", function () {
 					"ol_tw_zhangji",
 					"ol_liwan",
 					"ol_liuyan",
-					"caoyu",
 					"liupan",
 					"ol_liupi",
 				],
@@ -1148,7 +1148,7 @@ game.import("character", function () {
 				enable: "phaseUse",
 				usable: 1,
 				async content(event, trigger, player) {
-					let cards = get.cards(3);
+					let num = player.maxHp, cards = get.cards(num);
 					await game.cardsGotoOrdering(cards);
 					await player.showCards(cards, get.translation(player) + "发动了【易城】");
 					if (player.countCards("h")) {
@@ -1181,7 +1181,7 @@ game.import("character", function () {
 							.set("filterOk", (moved) => moved[1].some((i) => !get.owner(i)))
 							.set("processAI", (list) => {
 								const player = get.event("player"),
-									limit = Math.min(3, player.countCards("h"));
+									limit = Math.min(get.event("num"), player.countCards("h"));
 								let cards = list[0][1].slice(),
 									hs = player.getCards("h");
 								if (
@@ -1216,7 +1216,8 @@ game.import("character", function () {
 									}
 									return list;
 								}
-							});
+							})
+							.set("num", num);
 						if (bool) {
 							const puts = player.getCards("h", (i) => moved[0].includes(i));
 							const gains = cards.filter((i) => moved[1].includes(i));
@@ -34574,7 +34575,7 @@ game.import("character", function () {
 			ol_liupi: "刘辟",
 			olyicheng: "易城",
 			olyicheng_info:
-				"出牌阶段限一次，你可以亮出牌堆顶的三张牌，然后你可以以任意手牌交换这些牌，若这三张牌的点数和因此增加，则你可以选择用所有手牌交换这三张牌。最后你将这三张牌置于牌堆顶。",
+				"出牌阶段限一次，你可以亮出牌堆顶的X张牌（X为你的体力上限），然后你可以以任意手牌交换其中等量张牌，若亮出的牌的点数和因此增加，则你可以选择用所有手牌交换亮出的牌。最后你将亮出的牌置于牌堆顶。",
 			sp_sunce: "SP孙策",
 			sp_sunce_prefix: "SP",
 			olliantao: "连讨",

--- a/character/sp2.js
+++ b/character/sp2.js
@@ -9794,6 +9794,9 @@ game.import("character", function () {
 					player.markSkill("mubing_rewrite");
 					player.chooseDrawRecover(2, true);
 				},
+				ai: {
+					combo: "mubing"
+				},
 				derivation: "mubing_rewrite",
 			},
 			refenyin_wufan: { audio: 2 },


### PR DESCRIPTION
### PR受影响的平台
所有平台


### 诱因和背景
[#677](https://github.com/libccy/noname/pull/677)AI计算乐不思蜀收益时分母为0
由于个人提的拆顺优化ai（找了几圈愣是没找到）导致经常不使用拆顺，数番测试仍未能探明原因


### PR描述
回滚拆顺ai.result，现在人机会正常拆顺了；
修复【乐不思蜀】ai.result；
【清严】bug修复；
标签补充



### 扩展适配
无需适配



### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`.eslintrc.json`和`.prettierrc`所规定的代码样式，并且已经通过`prettier`格式化过代码
