### PR TITLE
标签补充，部分技能描述修复

### DIFF
--- a/character/ddd.js
+++ b/character/ddd.js
@@ -3361,6 +3361,9 @@ game.import("character", function () {
 				content() {
 					player.draw(3);
 				},
+				ai: {
+					combo: "dddfusi"
+				},
 			},
 			dddchashi: {
 				trigger: { global: "phaseUseBegin" },
@@ -5113,6 +5116,9 @@ game.import("character", function () {
 						},
 					},
 				},
+				ai: {
+					combo: "dddyouxue"
+				},
 			},
 			dddyouxue_old: {
 				audio: 2,
@@ -6624,7 +6630,7 @@ game.import("character", function () {
 					"锁定技。出牌阶段开始时，你选择一名角色，其弃置两张牌，然后你对一名角色造成1点伤害。" +
 					(player.storage["dddxiaheng_del"]
 						? ""
-						: "。“若两名角色：均不为你，你失去一点体力上限；为同一名角色，你失去一点体力；然后若以此法对包括你在内三名不同的角色造成伤害，删除双引号里的描述内容”")
+						: "“若两名角色：均不为你，你失去一点体力上限；为同一名角色，你失去一点体力；然后若以此法对包括你在内三名不同的角色造成伤害，删除双引号里的描述内容”")
 				);
 			},
 			dddshichao(player) {
@@ -6638,9 +6644,8 @@ game.import("character", function () {
 				return (
 					"转换技，摸牌阶段，你" +
 					(player.hasMark("dddxuanlun_del") ? "" : "可") +
-					"展示手牌（无牌则不展示），并改为摸其中" +
-					(!player.storage["dddlanghuai"] ? "包含" : "缺少") +
-					"花色数的牌。"
+					"展示手牌（无牌则不展示），并改为摸其中：" +
+					(player.storage["dddlanghuai"] ? '阴：包含花色数的牌；<span class="bluetext">阳：缺少花色数的牌。</span>' : '<span class="bluetext">阴：包含花色数的牌；</span>阳：缺少花色数的牌。')
 				);
 			},
 			dddxuanlun(player) {

--- a/character/huicui.js
+++ b/character/huicui.js
@@ -8005,6 +8005,9 @@ game.import("character", function () {
 							return false;
 					},
 				},
+				ai: {
+					neg: true
+				},
 			},
 			//公孙度
 			dczhenze: {
@@ -10831,7 +10834,10 @@ game.import("character", function () {
 						player.addTempSkill("zhishi_mark", { player: "phaseBegin" });
 					}
 				},
-				ai: { expose: 0.3 },
+				ai: {
+					combo: "xunli",
+					expose: 0.3
+				},
 				subSkill: {
 					mark: {
 						trigger: {
@@ -12095,6 +12101,9 @@ game.import("character", function () {
 							player.recover();
 						}
 					}
+				},
+				ai: {
+					combo: "huguan"
 				},
 			},
 			mingluan: {
@@ -15060,6 +15069,10 @@ game.import("character", function () {
 				content: function () {
 					player.removeMark("recangchu", Math.min(player.countMark("recangchu"), trigger.num || 1));
 				},
+				ai: {
+					combo: "recangchu",
+					neg: true
+				},
 				group: "reshishou2",
 			},
 			reshishou2: {
@@ -15493,7 +15506,7 @@ game.import("character", function () {
 				var list = ["sha", "shan", "tao", "jiu"];
 				for (var i of list) {
 					var strx = "【" + get.translation(i) + "】";
-					if (!info || !info[0].includes(i))
+					if (info && !info[0].includes(i))
 						strx = '<span style="text-decoration:line-through;">' + strx + "</span>";
 					str += strx;
 					if (i != "jiu") str += "/";

--- a/character/jsrg.js
+++ b/character/jsrg.js
@@ -8741,6 +8741,9 @@ game.import("character", function () {
 							.set("cards", trigger.cards);
 					}
 				},
+				ai: {
+					combo: "jsrglirang"
+				},
 			},
 			//朱儁
 			jsrgfendi: {

--- a/character/offline.js
+++ b/character/offline.js
@@ -4049,6 +4049,7 @@ game.import("character", function () {
 					result: {
 						player: 1,
 					},
+					combo: "zyquanji"
 				},
 			},
 			//孙綝
@@ -6953,6 +6954,9 @@ game.import("character", function () {
 					player.addTempSkill("sptuji2");
 					player.loseToDiscardpile(cards);
 					if (num <= 1) player.draw();
+				},
+				ai: {
+					combo: "spyicong"
 				},
 			},
 			sptuji2: {

--- a/character/old.js
+++ b/character/old.js
@@ -1169,7 +1169,13 @@ game.import("character", function () {
 				content: function () {
 					player.addToExpansion(cards, player, "give").gaintag.add("old_jijun");
 				},
-				ai: { order: 1, result: { player: 1 } },
+				ai: {
+					order: 1,
+					result: {
+						player: 1
+					},
+					combo: "old_fangtong"
+				},
 			},
 			old_fangtong: {
 				trigger: {
@@ -1185,6 +1191,9 @@ game.import("character", function () {
 				content: function () {
 					var winners = player.getFriends();
 					game.over(player == game.me || winners.includes(game.me));
+				},
+				ai:{
+					combo: "oldjijun"
 				},
 			},
 			oldanxu: {

--- a/character/sp.js
+++ b/character/sp.js
@@ -32648,6 +32648,9 @@ game.import("character", function () {
 						player.gain(event.togain, "gain2");
 					}
 				},
+				ai: {
+					combo: "xinfu_falu"
+				},
 			},
 			zhenyi_spade: {
 				trigger: {


### PR DESCRIPTION
### PR受影响的平台
所有平台


### 诱因和背景
发现部分技能描述显示问题



### PR描述
【朗怀】增加另一半描述；
【遁世】开局前不划掉基本牌名；
去掉【侠横】多余句号；
combo, neg标签补充




### 扩展适配
进入游戏查看



### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`.eslintrc.json`和`.prettierrc`所规定的代码样式，并且已经通过`prettier`格式化过代码
