### PR TITLE
character[4]添加新标签noDefaultPicture，加上后不显示剪影原画

### DIFF
--- a/mode/brawl.js
+++ b/mode/brawl.js
@@ -618,8 +618,8 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 								character: {
 									hhzz_shiona: ["female", "key", 1, ["hhzz_huilei"]],
 									hhzz_kanade: ["female", "key", 2, ["hhzz_youlian"]],
-									hhzz_takaramono1: ["male", "qun", 5, ["hhzz_jubao", "hhzz_huizhen"]],
-									hhzz_takaramono2: ["male", "qun", 3, ["hhzz_jubao", "hhzz_zhencang"]],
+									hhzz_takaramono1: ["male", "qun", 5, ["hhzz_jubao", "hhzz_huizhen"], ["noDefaultPicture"]],
+									hhzz_takaramono2: ["male", "qun", 3, ["hhzz_jubao", "hhzz_zhencang"], ["noDefaultPicture"]],
 								},
 								skill: {
 									_lingli_damage: {
@@ -1276,12 +1276,14 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 													"qun",
 													5,
 													["hhzz_jubao", "hhzz_huizhen"],
+													["noDefaultPicture"]
 												],
 												hhzz_takaramono2: [
 													"male",
 													"qun",
 													3,
 													["hhzz_jubao", "hhzz_zhencang"],
+													["noDefaultPicture"]
 												],
 											},
 											translate: {

--- a/noname/init/polyfill.js
+++ b/noname/init/polyfill.js
@@ -196,8 +196,10 @@ Reflect.defineProperty(HTMLDivElement.prototype, "setBackground", {
 		this.style.backgroundSize = "cover";
 		if (type === "character") {
 			const nameinfo = get.character(name);
-			const sex = nameinfo && ["male", "female", "double"].includes(nameinfo[0]) ? nameinfo[0] : "male";
-			this.setBackgroundImage([src, `${lib.characterDefaultPicturePath}${sex}${ext}`]);
+			const hasNoDefaultPicture = nameinfo && nameinfo[4] && nameinfo[4].includes("noDefaultPicture");
+			const sex = (nameinfo && ["male", "female", "double"].includes(nameinfo[0])) ? nameinfo[0] : "male";
+			const backgrounds = hasNoDefaultPicture ? [src] : [src, `${lib.characterDefaultPicturePath}${sex}${ext}`];
+			this.setBackgroundImage(backgrounds);
 		} else {
 			this.setBackgroundImage(src);
 		}

--- a/noname/init/polyfill.js
+++ b/noname/init/polyfill.js
@@ -198,7 +198,7 @@ Reflect.defineProperty(HTMLDivElement.prototype, "setBackground", {
 			const nameinfo = get.character(name);
 			const hasNoDefaultPicture = nameinfo && nameinfo[4] && nameinfo[4].includes("noDefaultPicture");
 			const sex = (nameinfo && ["male", "female", "double"].includes(nameinfo[0])) ? nameinfo[0] : "male";
-			const backgrounds = hasNoDefaultPicture ? [src] : [src, `${lib.characterDefaultPicturePath}${sex}${ext}`];
+			const backgrounds = hasNoDefaultPicture ? src : [src, `${lib.characterDefaultPicturePath}${sex}${ext}`];
 			this.setBackgroundImage(backgrounds);
 		} else {
 			this.setBackgroundImage(src);


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有平台

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
部分武将不需要显示剪影原画，例如幻化之战的宝箱
![20240421173100](https://github.com/libccy/noname/assets/131325076/73f47841-4a16-4a84-bfa2-fc70f7b04056)



### PR描述
<!-- 详细描述您的更改 -->
character[4]添加新标签noDefaultPicture，加上后不显示剪影原画


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
幻化之战控制台命令
`game.players[1].init("hhzz_takaramono2");`


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
如果武将不需要显示剪影原画，可在character[4]添加新标签noDefaultPicture


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [ ] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
