### PR TITLE
增加对Blob链接的部分支持

### DIFF
--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -1737,7 +1737,9 @@ export class Game {
 		const audio = get.dynamicVariable(lib.card[card.name].audio, card, sex);
 		if (typeof audio == "string") {
 			const audioInfo = audio.split(":");
-			if (audio.startsWith("db:"))
+			if (["blob:", "data:"].some((prefix) => audio.startsWith(prefix))) {
+				game.playAudio(audio);
+			} else if (audio.startsWith("db:"))
 				game.playAudio(
 					`${audioInfo[0]}:${audioInfo[1]}`,
 					audioInfo[2],

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -4751,7 +4751,8 @@ export class Game {
 					const audiosrc = "die:ext:" + extname + "/" + j + ".mp3";
 					if (
 						!pack[i][j][4].some(
-							(str) => typeof str == "string" && /^(?:db:extension-|ext:):(?:.+)/.test(str)
+							(str) =>
+								typeof str == "string" && /^(?:db:extension-.+?|ext|img):(?:.+)/.test(str)
 						)
 					)
 						pack[i][j][4].add(imgsrc);
@@ -4800,17 +4801,19 @@ export class Game {
 		if (info.audio == true) {
 			info.audio = "ext:" + extname;
 		}
-		if (info.fullskin) {
-			if (_status.evaluatingExtension) {
-				info.image = "db:extension-" + extname + ":" + name + ".png";
-			} else {
-				info.image = "ext:" + extname + "/" + name + ".png";
-			}
-		} else if (info.fullimage) {
-			if (_status.evaluatingExtension) {
-				info.image = "db:extension-" + extname + ":" + name + ".jpg";
-			} else {
-				info.image = "ext:" + extname + "/" + name + ".jpg";
+		if (!info.image || typeof info.image !== "string") {
+			if (info.fullskin) {
+				if (_status.evaluatingExtension) {
+					info.image = "db:extension-" + extname + ":" + name + ".png";
+				} else {
+					info.image = "ext:" + extname + "/" + name + ".png";
+				}
+			} else if (info.fullimage) {
+				if (_status.evaluatingExtension) {
+					info.image = "db:extension-" + extname + ":" + name + ".jpg";
+				} else {
+					info.image = "ext:" + extname + "/" + name + ".jpg";
+				}
 			}
 		}
 		lib.card[name] = info;
@@ -4930,10 +4933,14 @@ export class Game {
 		lib.translate[name] = info2.translate;
 		let imgsrc;
 		let extname = _status.extension || info2.extension;
-		if (_status.evaluatingExtension) {
-			imgsrc = "extension-" + extname + ":" + name + ".jpg";
+		if (info.splash) {
+			imgsrc = info.splash;
 		} else {
-			imgsrc = "ext:" + extname + "/" + name + ".jpg";
+			if (_status.evaluatingExtension) {
+				imgsrc = "extension-" + extname + ":" + name + ".jpg";
+			} else {
+				imgsrc = "ext:" + extname + "/" + name + ".jpg";
+			}
 		}
 		lib.mode[name] = {
 			name: info2.translate,

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -1776,7 +1776,9 @@ export class Game {
 					_status.currentAozhan
 				);
 			_status.currentAozhan = aozhan;
-			if (aozhan.startsWith("db:"))
+			if (["blob:", "data:"].some((prefix) => aozhan.startsWith(prefix))) {
+				ui.backgroundMusic.src = aozhan;
+			} else if (aozhan.startsWith("db:"))
 				game.getDB("image", aozhan.slice(3)).then((result) => (ui.backgroundMusic.src = result));
 			else if (aozhan.startsWith("ext:"))
 				ui.backgroundMusic.src = `${lib.assetURL}extension/${aozhan.slice(4)}`;
@@ -1799,7 +1801,9 @@ export class Game {
 				ui.backgroundMusic.src = backgroundMusicSourceConfiguration;
 			return;
 		}
-		if (music.startsWith("db:"))
+		if (["blob:", "data:"].some((prefix) => music.startsWith(prefix))) {
+			ui.backgroundMusic.src = music;
+		} else if (music.startsWith("db:"))
 			game.getDB("image", music.slice(3)).then((result) => (ui.backgroundMusic.src = result));
 		else if (music.startsWith("ext:"))
 			ui.backgroundMusic.src = `${lib.assetURL}extension/${music.slice(4)}`;

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -1469,6 +1469,7 @@ export class Game {
 					reject
 				);
 			else if (lib.path.extname(path)) resolve(`${lib.assetURL}${path}`);
+			else if (URL.canParse(path)) resolve(path);
 			else resolve(`${lib.assetURL}${path}.mp3`);
 		}).then((resolvedPath) => {
 			audio.src = resolvedPath;
@@ -1603,7 +1604,11 @@ export class Game {
 				let path = "",
 					format = "";
 				if (!/^db:|^ext:|\//.test(audioInfo)) path = "skill/";
-				if (!/\.\w+$/.test(audioInfo)) format = ".mp3";
+				if (
+					!/\.\w+$/.test(audioInfo) &&
+					!["data:", "blob:"].some((name) => audioInfo.startsWith(name))
+				)
+					format = ".mp3";
 				if (path && format) return parseAudio(audioInfo, options, [true, 2]);
 				return [`${path}${audioInfo}${format}`];
 			}

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -409,7 +409,9 @@ export class Game {
 			style.transform = "scale(1.05)";
 		}
 		document.body.insertBefore(uiBackground, document.body.firstChild);
-		if (background.startsWith("db:")) uiBackground.setBackgroundDB(background.slice(3));
+		if (background.startsWith("blob:") || background.startsWith("data:")) {
+			uiBackground.setBackgroundImage(background);
+		} else if (background.startsWith("db:")) uiBackground.setBackgroundDB(background.slice(3));
 		else if (background.startsWith("ext:"))
 			uiBackground.setBackgroundImage(`extension/${background.slice(4)}`);
 		else if (background == "default") {
@@ -1441,7 +1443,8 @@ export class Game {
 				if (_status.video) break;
 			}
 			if (path.startsWith("ext:")) path = path.replace(/^ext:/, "extension/");
-			else if (!path.startsWith("db:")) path = `audio/${path}`;
+			else if (!["db:", "blob:", "data:"].some((prefix) => path.startsWith(prefix)))
+				path = `audio/${path}`;
 			if (!lib.config.repeat_audio && _status.skillaudio.includes(path)) return;
 		}
 		const audio = document.createElement("audio");

--- a/noname/init/polyfill.js
+++ b/noname/init/polyfill.js
@@ -171,8 +171,7 @@ Reflect.defineProperty(HTMLDivElement.prototype, "setBackground", {
 					if (value.startsWith("img:")) {
 						imgPrefixUrl = value.slice(4);
 						break;
-					}
-					if (value.startsWith("ext:")) {
+					} else if (value.startsWith("ext:")) {
 						extimage = value;
 						break;
 					} else if (value.startsWith("db:")) {

--- a/noname/init/polyfill.js
+++ b/noname/init/polyfill.js
@@ -165,8 +165,13 @@ Reflect.defineProperty(HTMLDivElement.prototype, "setBackground", {
 					nameinfo = get.character(name);
 				}
 			}
-			if (!modeimage && nameinfo && nameinfo[4])
+			let imgPrefixUrl;
+			if (!modeimage && nameinfo && nameinfo[4]) {
 				for (const value of nameinfo[4]) {
+					if (value.startsWith("img:")) {
+						imgPrefixUrl = value.slice(4);
+						break;
+					}
 					if (value.startsWith("ext:")) {
 						extimage = value;
 						break;
@@ -181,7 +186,9 @@ Reflect.defineProperty(HTMLDivElement.prototype, "setBackground", {
 						break;
 					}
 				}
-			if (extimage) src = extimage.replace(/^ext:/, "extension/");
+			}
+			if (imgPrefixUrl) src = imgPrefixUrl;
+			else if (extimage) src = extimage.replace(/^ext:/, "extension/");
 			else if (dbimage) {
 				this.setBackgroundDB(dbimage.slice(3));
 				return this;
@@ -225,6 +232,8 @@ HTMLDivElement.prototype.setBackgroundImage = function (img) {
 			.unique()
 			.map((v) => `url("${lib.assetURL}${v}")`)
 			.join(",");
+	} else if (URL.canParse(img)) {
+		this.style.backgroundImage = `url("${img}")`;
 	} else {
 		this.style.backgroundImage = `url("${lib.assetURL}${img}")`;
 	}


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有平台

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
无名杀目前只支持相对地址的文件读取，但对`blob`和`http`等协议的需求却并不少见


### PR描述
<!-- 详细描述您的更改 -->
由于无名杀的特性以及个人对无名杀的思考，仅仅对部分内容增添了`blob`的相关代码

为character[4]的武将图片增加独立的`img`前缀，同时保留原有的形式不变，供`blob`链接通过`img`前缀提供


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
一个简易的读取本地文件并创建Blob链接的函数：
```javascript
async function createURL(fileLink, type = "text/plain") {
	let file = await game.promises.readFile(fileLink);
	let blob = new Blob([file], { type });
	let url = URL.createObjectURL(blob);
	return url;
}
```

创建扩展：
```javascript
export let type = "extension";

export default async function () {
	// 获取测试武将的Avatar和DieAudio，这里选用孙策的图片
	let avatar = await createURL("image/character/sunce.jpg", "image/jpeg");
	let dieAudio = await createURL("audio/die/sunce.mp3", "audio/mpeg");

	// 获取测试技能的配音，这里直接用激昂的配音
	let skillAudios = await Promise.all(
		["jiang1", "jiang2"].map((name) => createURL(`audio/skill/${name}.mp3`, "audio/mpeg"))
	);

	return {
		name: "测试扩展",
		content: true,
		package: {
			character: {
				character: {
					pr_test_character: [
						"none",
						"key",
						4,
						["pr_test_skill"],
						[`img:${avatar}`, `die:${dieAudio}`],
					],
				},
				translate: {
					pr_test_character: "测试",
				},
			},

			skill: {
				skill: {
					pr_test_skill: {
						audio: skillAudios,
						trigger: {
							global: "phaseBegin",
						},
						forced: true,
						locked: true,
						logTarget: "player",
						async content(event, trigger) {
							await trigger.player.draw();
							await trigger.player.chooseToDiscard(1, true);
						},
					},
				},
				translate: {
					pr_test_skill: "测试",
					pr_test_skill_info: "锁定技，每个回合开始时，当前回合角色摸一张牌，然后弃置一张牌。",
				},
			},
		},
	};
}
```

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
