### PR TITLE
更换武将牌补充

### DIFF
--- a/character/diy/skill.js
+++ b/character/diy/skill.js
@@ -5396,13 +5396,13 @@ const skills = {
 		unique: true,
 		forceunique: true,
 		init(player) {
-			if (player.storage.nscongjun_show) return false;
+			if (player.storage.nscongjun_show || ![player.name1, player.name2].includes("ns_huamulan")) return false;
 			var change = function (target) {
 				if (target == player) {
 					var list;
 					if (_status.connectMode) {
 						list = get.charactersOL(function (i) {
-							return lib.character[i][0] != "male";
+							return lib.character[i][0] == "male";
 						});
 					} else {
 						list = get.gainableCharacters(function (info) {
@@ -5427,7 +5427,12 @@ const skills = {
 			show: {
 				trigger: { global: "useCard" },
 				filter(event, player) {
-					return player.getEnemies().includes(event.player) && event.card.name == "wuxie" && event.getRand() < 0.1;
+					return (
+						player.storage.nscongjun_show &&
+						event.card.name == "wuxie" &&
+						event.getRand() < 0.1 &&
+						player.getEnemies().includes(event.player)
+					);
 				},
 				direct: true,
 				skillAnimation: true,

--- a/character/diy/skill.js
+++ b/character/diy/skill.js
@@ -5402,7 +5402,7 @@ const skills = {
 					var list;
 					if (_status.connectMode) {
 						list = get.charactersOL(function (i) {
-							return lib.character[i][0] == "male";
+							return lib.character[i][0] != "male";
 						});
 					} else {
 						list = get.gainableCharacters(function (info) {

--- a/character/gujian.js
+++ b/character/gujian.js
@@ -630,7 +630,7 @@ game.import("character", function () {
 							player.turnOver(false);
 							"step 3";
 							player.draw(4);
-							player.reinit("gjqt_xieyi", "gjqt_chuqi");
+							player.reinit(get.character(player.name2, 3).includes("humeng") ? player.name2 : player.name1, "gjqt_chuqi");
 							player.hp = player.maxHp;
 							"step 4";
 							if (event.yanjia) {

--- a/character/hearth.js
+++ b/character/hearth.js
@@ -2382,7 +2382,7 @@ game.import("character", function () {
 				trigger: { player: "phaseBefore" },
 				unique: true,
 				skillAnimation: true,
-				forceunique: true,
+				//forceunique: true,
 				filter() {
 					return game.roundNumber >= 3;
 				},
@@ -2407,7 +2407,7 @@ game.import("character", function () {
 					};
 					player.awakenSkill("szbianshen");
 					"step 1";
-					player.reinit("hs_shizugui", result.links[0]);
+					player.reinit(get.character(player.name2, 3).includes("szbianshen") ? player.name2 : player.name1, result.links[0]);
 					player.hp = player.maxHp;
 					player.update();
 				},

--- a/character/huicui/skill.js
+++ b/character/huicui/skill.js
@@ -12431,6 +12431,7 @@ const skills = {
 			if (evt.player != event.player) return false;
 			return true;
 		},
+		usable: 1,
 		logTarget: "player",
 		check: function (event, player) {
 			var target = event.player;

--- a/character/key/skill.js
+++ b/character/key/skill.js
@@ -7569,6 +7569,7 @@ const skills = {
 		trigger: { player: "phaseZhunbeiBegin" },
 		limited: true,
 		unique: true,
+		forceunique: true,
 		charlotte: true,
 		skillAnimation: true,
 		animationColor: "water",
@@ -7576,6 +7577,7 @@ const skills = {
 			return player.isDamaged();
 		},
 		check(event, player) {
+			if (![player.name1, player.name2].includes("key_mio")) return false;
 			return player.hp <= 1 || player.getDamagedHp() > 1;
 		},
 		content() {
@@ -7644,12 +7646,14 @@ const skills = {
 		limited: true,
 		charlotte: true,
 		unique: true,
+		forceunique: true,
 		skillAnimation: true,
 		animationColor: "water",
 		filter(event, player) {
 			return player.isDamaged();
 		},
 		check(event, player) {
+			if (![player.name1, player.name2].includes("key_midori")) return false;
 			return player.hp <= 1 || player.getDamagedHp() > 1;
 		},
 		content() {

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -19319,7 +19319,6 @@ const skills = {
 		limited: true,
 		skillAnimation: true,
 		animationColor: "orange",
-		forceunique: true,
 		filter: function (event, player) {
 			return player.storage.fanghun2 > 0;
 		},
@@ -19377,7 +19376,7 @@ const skills = {
 			player.awakenSkill("fuhan");
 			"step 1";
 			event.num = Math.min(event.num, 8);
-			player.reinitCharacter("zhaoxiang", result.links[0]);
+			player.reinitCharacter(get.character(player.name2, 3).includes("fuhan") ? player.name2 : player.name1, result.links[0]);
 			"step 2";
 			var num = event.num - player.maxHp;
 			if (num > 0) player.gainMaxHp(num);
@@ -19395,7 +19394,6 @@ const skills = {
 		limited: true,
 		skillAnimation: true,
 		animationColor: "orange",
-		forceunique: true,
 		filter: function (event, player) {
 			return player.countMark("fanghun") > 0;
 		},
@@ -24477,7 +24475,6 @@ const skills = {
 		audio: 2,
 		unique: true,
 		juexingji: true,
-		forceunique: true,
 		derivation: "xiaoji",
 		trigger: { player: "phaseZhunbeiBegin" },
 		filter: function (event, player) {

--- a/character/tw/skill.js
+++ b/character/tw/skill.js
@@ -15585,7 +15585,6 @@ const skills = {
 		limited: true,
 		skillAnimation: true,
 		animationColor: "orange",
-		forceunique: true,
 		filter: function (event, player) {
 			return player.countMark("fanghun") > 0;
 		},

--- a/character/xianjian.js
+++ b/character/xianjian.js
@@ -2811,7 +2811,7 @@ game.import("character", function () {
 				unique: true,
 				forceunique: true,
 				filter: function () {
-					return Math.random() < 0.5;
+					return Math.random() < 0.5 && [player.name1, player.name2].includes("pal_longkui");
 				},
 				derivation: ["diesha", "guijiang"],
 				content: function () {

--- a/character/yxs.js
+++ b/character/yxs.js
@@ -816,7 +816,11 @@ game.import("character", function () {
 				forceunique: true,
 				enable: "phaseUse",
 				filter: function (event, player) {
-					return !player.hasSkill("tongyu_guiyin") && !player.getStat("damage");
+					return (
+						!player.hasSkill("tongyu_guiyin") &&
+						!player.getStat("damage") &&
+						[player.name1, player.name2].includes("yxs_luobinhan")
+					);
 				},
 				derivation: ["lzhangyi", "jimin", "tongyu"],
 				content: function () {
@@ -848,7 +852,11 @@ game.import("character", function () {
 				forceunique: true,
 				enable: "phaseUse",
 				filter: function (event, player) {
-					return player.countCards("he") > 0 && !player.hasSkill("tongyu_guiyin");
+					return (
+						player.countCards("he") > 0 &&
+						!player.hasSkill("tongyu_guiyin") &&
+						[player.name1, player.name2].includes("yxs_luobinhan")
+					);
 				},
 				filterCard: true,
 				position: "he",

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -2714,7 +2714,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				inherit: "zhiwei",
 				filter: function (event, player, name) {
 					if (!game.hasPlayer(current => current != player)) return false;
-					return event.name == "showCharacter" && event.toShow(name => {
+					return event.name == "showCharacter" && event.toShow.some(name => {
 						return get.character(name, 3).includes("fakezhiwei");
 					});
 				},
@@ -6455,7 +6455,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 						})
 					)
 						return false;
-					return event.toShow.some((name) => lib.character[name][3].includes("gzjinyu"));
+					return event.toShow.some((name) => get.character(name, 3).includes("gzjinyu"));
 				},
 				logTarget: function (event, player) {
 					return game

--- a/noname/ui/create/index.js
+++ b/noname/ui/create/index.js
@@ -1042,7 +1042,7 @@ export class Create {
 						.setContent(function () {
 							game.log(player, "投降");
 							player.popup("投降");
-							player.die("nosource").includeOut = true;
+							player.die("nosource").set("_triggered", null).includeOut = true;
 						}).player = player;
 				}
 				if (_status.paused && _status.imchoosing && !_status.auto) {


### PR DESCRIPTION
### PR受影响的平台
所有平台



### PR描述
为花木兰、西园美鱼、西园美鸟以及使用setAvator方法变更武将形象的技能增加forceunique，同时要求必须为对应武将牌；
移除其余更换武将牌技能的forceunique，并按照(#1319)[https://github.com/libccy/noname/pull/1319]规矩检测其武将牌上是否拥有此技能；
【息兵】补充遗漏的usable



### 扩展适配
无需适配



### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
