### PR TITLE
增加通用性解析寻址函数

### DIFF
--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -4822,10 +4822,10 @@ export class Get {
 	 * console.assert(btoa(text) === "SGVsbG8sIFdvcmxkIQ==");
 	 *
 	 * let blob = new Blob([text], { type: "text/plain" });
-	 * let url = await get.dataUrl(blob);
+	 * let url = await get.dataUrlAsync(blob);
 	 * console.assert("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==");
 	 */
-	dataUrl(blob) {
+	dataUrlAsync(blob) {
 		return new Promise((resolve, reject) => {
 			let fileReader = new FileReader();
 			fileReader.onload = resolve;

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -4800,7 +4800,7 @@ export class Get {
 	 * @example
 	 * // 当前文件以"noname/get/index.js"举例
 	 * let parsedPath = get.relativePath(import.meta.url, true);
-	 * console.log(parsedPath == `${lib.assetURL}noname/get/index.js`) //=> true
+	 * console.assert(parsedPath == `${lib.assetURL}noname/get/index.js`);
 	 */
 	relativePath(url, addAssetURL = false) {
 		let base = lib.path.relative(decodeURI(rootURL.pathname), decodeURI(url.pathname));
@@ -4813,8 +4813,17 @@ export class Get {
 	/**
 	 * 通过`FileReader`，将Blob转换成对应内容的[Data URL](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
 	 *
+	 * @async
 	 * @param {Blob} blob - 需要转换的内容
 	 * @returns {Promise<string>} 对应Blob内容的
+	 *
+	 * @example
+	 * let text = "Hello, World!";
+	 * console.assert(btoa(text) === "SGVsbG8sIFdvcmxkIQ==");
+	 *
+	 * let blob = new Blob([text], { type: "text/plain" });
+	 * let url = await get.dataUrl(blob);
+	 * console.assert("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==");
 	 */
 	dataUrl(blob) {
 		return new Promise((resolve, reject) => {

--- a/noname/library/init/index.js
+++ b/noname/library/init/index.js
@@ -9,6 +9,7 @@ import { gnc } from "../../gnc/index.js";
 import { LibInitPromises } from "./promises.js";
 import { GameEvent } from "../element/gameEvent.js";
 import { GameEventPromise } from "../element/gameEventPromise.js";
+import { rootURL } from "../../../noname.js";
 
 export class LibInit {
 	/**
@@ -23,11 +24,7 @@ export class LibInit {
 	reset() {
 		if (window.inSplash) return;
 		if (window.resetExtension) {
-			if (
-				confirm(
-					"游戏似乎未正常载入，有可能因为部分扩展未正常载入，或者因为部分扩展未载入完毕。\n是否禁用扩展并重新打开？"
-				)
-			) {
+			if (confirm("游戏似乎未正常载入，有可能因为部分扩展未正常载入，或者因为部分扩展未载入完毕。\n是否禁用扩展并重新打开？")) {
 				window.resetExtension();
 				window.location.reload();
 			}
@@ -91,7 +88,7 @@ export class LibInit {
 		event._resultid = null;
 		event._result = null;
 		game.pause();
-		"step 1";
+		("step 1");
 		if (result) {
 			if (event._resultid) {
 				result.id = event._resultid;
@@ -176,10 +173,7 @@ export class LibInit {
 		if (path) {
 			if (path[path.length - 1] == "/") path = path.slice(0, path.length - 1);
 			if (file) path = `${path}${/^db:extension-[^:]*$/.test(path) ? ":" : "/"}${file}.css`;
-			(path.startsWith("db:")
-				? game.getDB("image", path.slice(3)).then(get.objectURL)
-				: new Promise((resolve) => resolve(path))
-			).then((resolvedPath) => {
+			(path.startsWith("db:") ? game.getDB("image", path.slice(3)).then(get.objectURL) : new Promise(resolve => resolve(path))).then(resolvedPath => {
 				style.href = resolvedPath;
 				if (typeof before == "function") {
 					style.addEventListener("load", before);
@@ -211,28 +205,19 @@ export class LibInit {
 			return;
 		}
 		if (Array.isArray(file)) {
-			file.forEach((value) => lib.init.js(path, value, onLoad, onError));
+			file.forEach(value => lib.init.js(path, value, onLoad, onError));
 			return;
 		}
 		let scriptSource = file ? `${path}${/^db:extension-[^:]*$/.test(path) ? ":" : "/"}${file}.js` : path;
 		if (path.startsWith("http")) scriptSource += `?rand=${get.id()}`;
-		else if (
-			lib.config.fuck_sojson &&
-			scriptSource.includes("extension") != -1 &&
-			scriptSource.startsWith(lib.assetURL)
-		) {
+		else if (lib.config.fuck_sojson && scriptSource.includes("extension") != -1 && scriptSource.startsWith(lib.assetURL)) {
 			const pathToRead = scriptSource.slice(lib.assetURL.length);
 			const alertMessage = `检测到您安装了使用免费版sojson进行加密的扩展。请谨慎使用这些扩展，避免游戏数据遭到破坏。\n扩展文件：${pathToRead}`;
 			if (typeof game.readFileAsText == "function")
 				game.readFileAsText(
 					pathToRead,
-					(result) => {
-						if (
-							result.includes("sojson") ||
-							result.includes("jsjiami") ||
-							result.includes("var _0x")
-						)
-							alert(alertMessage);
+					result => {
+						if (result.includes("sojson") || result.includes("jsjiami") || result.includes("var _0x")) alert(alertMessage);
 					},
 					() => void 0
 				);
@@ -241,21 +226,13 @@ export class LibInit {
 					pathToRead,
 					function () {
 						const result = this.responseText;
-						if (
-							result.includes("sojson") ||
-							result.includes("jsjiami") ||
-							result.includes("var _0x")
-						)
-							alert(alertMessage);
+						if (result.includes("sojson") || result.includes("jsjiami") || result.includes("var _0x")) alert(alertMessage);
 					},
 					() => void 0
 				);
 		}
 		const script = document.createElement("script");
-		(scriptSource.startsWith("db:")
-			? game.getDB("image", scriptSource.slice(3)).then(get.objectURL)
-			: new Promise((resolve) => resolve(scriptSource))
-		).then((resolvedScriptSource) => {
+		(scriptSource.startsWith("db:") ? game.getDB("image", scriptSource.slice(3)).then(get.objectURL) : new Promise(resolve => resolve(scriptSource))).then(resolvedScriptSource => {
 			script.src = resolvedScriptSource;
 			if (path.startsWith("http")) script.addEventListener("load", () => script.remove());
 			document.head.appendChild(script);
@@ -282,7 +259,7 @@ export class LibInit {
 			return;
 		}
 		if (Array.isArray(file)) {
-			return file.forEach((value) => lib.init.jsSync(path, value, onLoad, onError));
+			return file.forEach(value => lib.init.jsSync(path, value, onLoad, onError));
 		}
 		let scriptSource;
 		if (!file) scriptSource = path;
@@ -301,16 +278,9 @@ export class LibInit {
 				if (typeof onError == "function") onError(new Error(`${scriptSource}加载失败！`));
 				return;
 			}
-			if (
-				lib.config.fuck_sojson &&
-				scriptSource.includes("extension") != -1 &&
-				scriptSource.startsWith(lib.assetURL)
-			) {
+			if (lib.config.fuck_sojson && scriptSource.includes("extension") != -1 && scriptSource.startsWith(lib.assetURL)) {
 				const pathToRead = scriptSource.slice(lib.assetURL.length);
-				if (data.includes("sojson") || data.includes("jsjiami") || data.includes("var _0x"))
-					alert(
-						`检测到您安装了使用免费版sojson进行加密的扩展。请谨慎使用这些扩展，避免游戏数据遭到破坏。\n扩展文件：${pathToRead}`
-					);
+				if (data.includes("sojson") || data.includes("jsjiami") || data.includes("var _0x")) alert(`检测到您安装了使用免费版sojson进行加密的扩展。请谨慎使用这些扩展，避免游戏数据遭到破坏。\n扩展文件：${pathToRead}`);
 			}
 			try {
 				window.eval(data);
@@ -328,11 +298,7 @@ export class LibInit {
 		let sScriptURL;
 		if (str.startsWith("http")) sScriptURL = str;
 		else if (str.startsWith("local:")) {
-			if (
-				lib.assetURL.length == 0 &&
-				location.origin == "file://" &&
-				typeof game.readFile == "undefined"
-			) {
+			if (lib.assetURL.length == 0 && location.origin == "file://" && typeof game.readFile == "undefined") {
 				const e = new Error("浏览器file协议下无法使用此api，请在http/https协议下使用此api");
 				if (typeof onerror == "function") onerror(e);
 				else throw e;
@@ -346,7 +312,7 @@ export class LibInit {
 		}
 		const oReq = new XMLHttpRequest();
 		if (typeof onload == "function")
-			oReq.addEventListener("load", (result) => {
+			oReq.addEventListener("load", result => {
 				if (![0, 200].includes(oReq.status)) {
 					// @ts-ignore
 					if (typeof onerror == "function") onerror(new Error(oReq.statusText || oReq.status));
@@ -366,11 +332,7 @@ export class LibInit {
 		let sScriptURL;
 		if (str.startsWith("http")) sScriptURL = str;
 		else if (str.startsWith("local:")) {
-			if (
-				lib.assetURL.length == 0 &&
-				location.origin == "file://" &&
-				typeof game.readFile == "undefined"
-			) {
+			if (lib.assetURL.length == 0 && location.origin == "file://" && typeof game.readFile == "undefined") {
 				const e = new Error("浏览器file协议下无法使用此api，请在http/https协议下使用此api");
 				if (typeof onerror == "function") onerror(e);
 				else throw e;
@@ -384,7 +346,7 @@ export class LibInit {
 		}
 		const oReq = new XMLHttpRequest();
 		if (typeof onload == "function")
-			oReq.addEventListener("load", (result) => {
+			oReq.addEventListener("load", result => {
 				if (![0, 200].includes(oReq.status)) {
 					// @ts-ignore
 					if (typeof onerror == "function") onerror(new Error(oReq.statusText || oReq.status));
@@ -460,61 +422,26 @@ export class LibInit {
 			ui.css.styles.remove();
 		}
 		ui.css.styles = lib.init.sheet();
-		ui.css.styles.sheet.insertRule(
-			"#arena .player>.name,#arena .button.character>.name {font-family: " +
-				(lib.config.name_font || "xinwei") +
-				",xinwei}",
-			0
-		);
-		ui.css.styles.sheet.insertRule(
-			"#arena .player>.name,.button.character>.name {font-family: " +
-				(lib.config.name_font || "xinwei") +
-				",xinwei}",
-			0
-		);
-		ui.css.styles.sheet.insertRule(
-			"#arena .player .identity>div {font-family: " +
-				(lib.config.identity_font || "huangcao") +
-				",xinwei}",
-			0
-		);
-		ui.css.styles.sheet.insertRule(
-			".button.character.newstyle>.identity {font-family: " +
-				(lib.config.identity_font || "huangcao") +
-				",xinwei}",
-			0
-		);
+		ui.css.styles.sheet.insertRule("#arena .player>.name,#arena .button.character>.name {font-family: " + (lib.config.name_font || "xinwei") + ",xinwei}", 0);
+		ui.css.styles.sheet.insertRule("#arena .player>.name,.button.character>.name {font-family: " + (lib.config.name_font || "xinwei") + ",xinwei}", 0);
+		ui.css.styles.sheet.insertRule("#arena .player .identity>div {font-family: " + (lib.config.identity_font || "huangcao") + ",xinwei}", 0);
+		ui.css.styles.sheet.insertRule(".button.character.newstyle>.identity {font-family: " + (lib.config.identity_font || "huangcao") + ",xinwei}", 0);
 		if (lib.config.cardtext_font && lib.config.cardtext_font != "default") {
-			ui.css.styles.sheet.insertRule(
-				".card div:not(.info):not(.background) {font-family: " + lib.config.cardtext_font + ";}",
-				0
-			);
+			ui.css.styles.sheet.insertRule(".card div:not(.info):not(.background) {font-family: " + lib.config.cardtext_font + ";}", 0);
 		}
 		if (lib.config.global_font && lib.config.global_font != "default") {
 			ui.css.styles.sheet.insertRule("#window {font-family: " + lib.config.global_font + ",xinwei}", 0);
-			ui.css.styles.sheet.insertRule(
-				"#window #control{font-family: STHeiti,SimHei,Microsoft JhengHei,Microsoft YaHei,WenQuanYi Micro Hei,Suits,Helvetica,Arial,sans-serif}",
-				0
-			);
+			ui.css.styles.sheet.insertRule("#window #control{font-family: STHeiti,SimHei,Microsoft JhengHei,Microsoft YaHei,WenQuanYi Micro Hei,Suits,Helvetica,Arial,sans-serif}", 0);
 		}
 		switch (lib.config.glow_phase) {
 			case "yellow":
-				ui.css.styles.sheet.insertRule(
-					"#arena .player:not(.selectable):not(.selected).glow_phase {box-shadow: rgba(0, 0, 0, 0.3) 0 0 0 1px, rgb(217, 152, 62) 0 0 15px, rgb(217, 152, 62) 0 0 15px !important;}",
-					0
-				);
+				ui.css.styles.sheet.insertRule("#arena .player:not(.selectable):not(.selected).glow_phase {box-shadow: rgba(0, 0, 0, 0.3) 0 0 0 1px, rgb(217, 152, 62) 0 0 15px, rgb(217, 152, 62) 0 0 15px !important;}", 0);
 				break;
 			case "green":
-				ui.css.styles.sheet.insertRule(
-					"#arena .player:not(.selectable):not(.selected).glow_phase {box-shadow: rgba(0, 0, 0, 0.3) 0 0 0 1px, rgba(10, 155, 67, 1) 0 0 15px, rgba(10, 155, 67, 1) 0 0 15px !important;}",
-					0
-				);
+				ui.css.styles.sheet.insertRule("#arena .player:not(.selectable):not(.selected).glow_phase {box-shadow: rgba(0, 0, 0, 0.3) 0 0 0 1px, rgba(10, 155, 67, 1) 0 0 15px, rgba(10, 155, 67, 1) 0 0 15px !important;}", 0);
 				break;
 			case "purple":
-				ui.css.styles.sheet.insertRule(
-					"#arena .player:not(.selectable):not(.selected).glow_phase {box-shadow: rgba(0, 0, 0, 0.3) 0 0 0 1px, rgb(189, 62, 170) 0 0 15px, rgb(189, 62, 170) 0 0 15px !important;}",
-					0
-				);
+				ui.css.styles.sheet.insertRule("#arena .player:not(.selectable):not(.selected).glow_phase {box-shadow: rgba(0, 0, 0, 0.3) 0 0 0 1px, rgb(189, 62, 170) 0 0 15px, rgb(189, 62, 170) 0 0 15px !important;}", 0);
 				break;
 		}
 	}
@@ -529,7 +456,7 @@ export class LibInit {
 		if (!nosave) game.saveConfig("layout", layout);
 		game.layout = layout;
 		ui.arena.hide();
-		new Promise((resolve) => setTimeout(resolve, 500))
+		new Promise(resolve => setTimeout(resolve, 500))
 			.then(() => {
 				if (game.layout == "default") {
 					ui.css.layout.href = "";
@@ -541,12 +468,7 @@ export class LibInit {
 				} else {
 					ui.arena.classList.remove("mobile");
 				}
-				if (
-					game.layout == "mobile" ||
-					game.layout == "long" ||
-					game.layout == "long2" ||
-					game.layout == "nova"
-				) {
+				if (game.layout == "mobile" || game.layout == "long" || game.layout == "long2" || game.layout == "nova") {
 					if (game.me && game.me.node.handcards2.childNodes.length) {
 						while (game.me.node.handcards2.childNodes.length) {
 							game.me.node.handcards1.appendChild(game.me.node.handcards2.firstChild);
@@ -558,13 +480,7 @@ export class LibInit {
 				} else {
 					ui.arena.classList.remove("oldlayout");
 				}
-				if (
-					lib.config.cardshape == "oblong" &&
-					(game.layout == "long" ||
-						game.layout == "mobile" ||
-						game.layout == "long2" ||
-						game.layout == "nova")
-				) {
+				if (lib.config.cardshape == "oblong" && (game.layout == "long" || game.layout == "mobile" || game.layout == "long2" || game.layout == "nova")) {
 					ui.arena.classList.add("oblongcard");
 					ui.window.classList.add("oblongcard");
 				} else {
@@ -607,11 +523,7 @@ export class LibInit {
 				} else {
 					ui.arena.classList.remove("slim_player");
 				}
-				if (
-					lib.config.player_border == "normal" &&
-					lib.config.mode != "brawl" &&
-					(game.layout == "long" || game.layout == "long2")
-				) {
+				if (lib.config.player_border == "normal" && lib.config.mode != "brawl" && (game.layout == "long" || game.layout == "long2")) {
 					ui.arena.classList.add("lslim_player");
 				} else {
 					ui.arena.classList.remove("lslim_player");
@@ -628,24 +540,22 @@ export class LibInit {
 				}
 				ui.updatej();
 				ui.updatem();
-				return new Promise((resolve) => setTimeout(resolve, 100));
+				return new Promise(resolve => setTimeout(resolve, 100));
 			})
 			.then(() => {
 				ui.arena.show();
 				if (game.me) game.me.update();
-				return new Promise((resolve) => setTimeout(resolve, 500));
+				return new Promise(resolve => setTimeout(resolve, 500));
 			})
 			.then(() => {
 				ui.updatex();
 				ui.updatePlayerPositions();
-				return new Promise((resolve) => setTimeout(resolve, 500));
+				return new Promise(resolve => setTimeout(resolve, 500));
 			})
 			.then(() => {
 				ui.updatec();
 				loadingScreenStyle.animationName = "opacity-1-0";
-				loadingScreen.addEventListener("animationend", (animationEvent) =>
-					animationEvent.target.remove()
-				);
+				loadingScreen.addEventListener("animationend", animationEvent => animationEvent.target.remove());
 			});
 	}
 
@@ -658,11 +568,7 @@ export class LibInit {
 			}
 			list.remove(lib.config.image_background);
 			localStorage.setItem(lib.configprefix + "background", JSON.stringify(list));
-		} else if (
-			lib.config.image_background &&
-			lib.config.image_background != "default" &&
-			!lib.config.image_background.startsWith("custom_")
-		) {
+		} else if (lib.config.image_background && lib.config.image_background != "default" && !lib.config.image_background.startsWith("custom_")) {
 			localStorage.setItem(lib.configprefix + "background", lib.config.image_background);
 		} else if (lib.config.image_background == "default" && lib.config.theme == "simple") {
 			localStorage.setItem(lib.configprefix + "background", "ol_bg");
@@ -687,10 +593,7 @@ export class LibInit {
 			//移除所有注释
 			let str = func
 				.toString()
-				.replace(
-					/((?:(?:^[ \t]*)?(?:\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/(?:[ \t]*\r?\n(?=[ \t]*(?:\r?\n|\/\*|\/\/)))?|\/\/(?:[^\\]|\\(?:\r?\n)?)*?(?:\r?\n(?=[ \t]*(?:\r?\n|\/\*|\/\/))|(?=\r?\n))))+)|("(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|(?:\r?\n|[\s\S])[^/"'\\\s]*)/gm,
-					"$2"
-				)
+				.replace(/((?:(?:^[ \t]*)?(?:\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/(?:[ \t]*\r?\n(?=[ \t]*(?:\r?\n|\/\*|\/\/)))?|\/\/(?:[^\\]|\\(?:\r?\n)?)*?(?:\r?\n(?=[ \t]*(?:\r?\n|\/\*|\/\/))|(?=\r?\n))))+)|("(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|(?:\r?\n|[\s\S])[^/"'\\\s]*)/gm, "$2")
 				.trim();
 			//获取第一个 { 后的所有字符
 			str = str.slice(str.indexOf("{") + 1);
@@ -702,10 +605,7 @@ export class LibInit {
 			let debuggerResult;
 			while ((debuggerResult = str.slice(debuggerSkip).match(regex)) != null) {
 				let debuggerCopy = str;
-				debuggerCopy =
-					debuggerCopy.slice(0, debuggerSkip + debuggerResult.index) +
-					insertDebugger +
-					debuggerCopy.slice(debuggerSkip + debuggerResult.index + debuggerResult[0].length, -1);
+				debuggerCopy = debuggerCopy.slice(0, debuggerSkip + debuggerResult.index) + insertDebugger + debuggerCopy.slice(debuggerSkip + debuggerResult.index + debuggerResult[0].length, -1);
 				//测试是否有错误
 				try {
 					new GeneratorFunction(debuggerCopy);
@@ -732,10 +632,7 @@ export class LibInit {
 						insertStr = `break;case ${k}:`;
 					}
 					let copy = str;
-					copy =
-						copy.slice(0, skip + result.index) +
-						insertStr +
-						copy.slice(skip + result.index + result[0].length);
+					copy = copy.slice(0, skip + result.index) + insertStr + copy.slice(skip + result.index + result[0].length);
 					//测试是否有错误
 					try {
 						new (hasDebugger ? GeneratorFunction : Function)(copy);
@@ -750,32 +647,9 @@ export class LibInit {
 				str = `if(event.step==${k}){event.finish();return;}` + str;
 			}
 			if (!scope) {
-				return new (hasDebugger ? GeneratorFunction : Function)(
-					"event",
-					"step",
-					"source",
-					"player",
-					"target",
-					"targets",
-					"card",
-					"cards",
-					"skill",
-					"forced",
-					"num",
-					"trigger",
-					"result",
-					"_status",
-					"lib",
-					"game",
-					"ui",
-					"get",
-					"ai",
-					str
-				);
+				return new (hasDebugger ? GeneratorFunction : Function)("event", "step", "source", "player", "target", "targets", "card", "cards", "skill", "forced", "num", "trigger", "result", "_status", "lib", "game", "ui", "get", "ai", str);
 			} else {
-				return scope(`function${
-					hasDebugger ? "*" : ""
-				} anonymous(event,step,source,player,target,targets,
+				return scope(`function${hasDebugger ? "*" : ""} anonymous(event,step,source,player,target,targets,
 						card,cards,skill,forced,num,trigger,result,
 						_status,lib,game,ui,get,ai){${str}}; anonymous;`);
 			}
@@ -784,31 +658,10 @@ export class LibInit {
 			case "object":
 				if (Array.isArray(item)) {
 					let lastEvent = null;
-					return function* (
-						event,
-						step,
-						source,
-						player,
-						target,
-						targets,
-						card,
-						cards,
-						skill,
-						forced,
-						num,
-						trigger,
-						result,
-						_status,
-						lib,
-						game,
-						ui,
-						get,
-						ai
-					) {
+					return function* (event, step, source, player, target, targets, card, cards, skill, forced, num, trigger, result, _status, lib, game, ui, get, ai) {
 						if (step >= item.length) return event.finish();
 						var current = item[step];
-						if (typeof current != "function")
-							throw new Error(`content ${step} of ${event.name} is not vaild: ${current}`);
+						if (typeof current != "function") throw new Error(`content ${step} of ${event.name} is not vaild: ${current}`);
 						var currentResult = current(
 							event,
 							{
@@ -845,27 +698,7 @@ export class LibInit {
 			case "function":
 				if (gnc.is.generatorFunc(item)) {
 					// let gen, lastEvent;
-					let content = function* (
-						event,
-						step,
-						source,
-						player,
-						target,
-						targets,
-						card,
-						cards,
-						skill,
-						forced,
-						num,
-						trigger,
-						result,
-						_status,
-						lib,
-						game,
-						ui,
-						get,
-						ai
-					) {
+					let content = function* (event, step, source, player, target, targets, card, cards, skill, forced, num, trigger, result, _status, lib, game, ui, get, ai) {
 						event.step = NaN;
 						if (!this.gen)
 							this.gen = item(event, {
@@ -887,8 +720,7 @@ export class LibInit {
 						let res;
 						if (!this.last) res = this.gen.next();
 						else if (typeof this.last !== "object") res = this.gen.next(this.last);
-						else if (this.last instanceof GameEvent || this.last instanceof GameEventPromise)
-							res = this.gen.next(this.last.result);
+						else if (this.last instanceof GameEvent || this.last instanceof GameEventPromise) res = this.gen.next(this.last.result);
 						else res = this.gen.next(this.last);
 
 						if (res.done) {
@@ -952,8 +784,7 @@ export class LibInit {
 	decode(str) {
 		var strUtf = atob(str);
 		var strUni = strUtf.replace(/[\u00e0-\u00ef][\u0080-\u00bf][\u0080-\u00bf]/g, function (c) {
-			var cc =
-				((c.charCodeAt(0) & 0x0f) << 12) | ((c.charCodeAt(1) & 0x3f) << 6) | (c.charCodeAt(2) & 0x3f);
+			var cc = ((c.charCodeAt(0) & 0x0f) << 12) | ((c.charCodeAt(1) & 0x3f) << 6) | (c.charCodeAt(2) & 0x3f);
 			return String.fromCharCode(cc);
 		});
 		strUni = strUni.replace(/[\u00c0-\u00df][\u0080-\u00bf]/g, function (c) {
@@ -1004,5 +835,66 @@ export class LibInit {
 		let head = window.location.href.slice(0, window.location.href.lastIndexOf("/") + 1);
 		let ret = url.replace(head, "");
 		return decodeURIComponent(ret);
+	}
+
+	/**
+	 * @async
+	 * @param {string | URL} link - 需要解析的路径
+	 * @param {(item: string) => string} [defaultHandle] - 在给定路径不符合可用情况（或基于无名杀相关默认情况）时，处理路径的函数，返回的路径应是相对于根目录的相对路径，默认为恒等函数
+	 * @param {boolean} [forceLoadAsDataUrl] - 是否将资源加载为[Data URL](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)，默认为`false`
+	 * @param {boolean} [dbNow] - 此刻是否在解析数据库中的内容，请勿直接使用
+	 * @returns {Promise<URL>}
+	 */
+	async parseResourceAddress(link, defaultHandle = item => item, forceLoadAsDataUrl = false, dbNow = false) {
+		let linkString = link instanceof URL ? link.href : link;
+
+		// 如果传入值为Data URL，经过分析可知无需处理，故直接返回成品URL
+		if (linkString.startsWith("data:")) return new URL(linkString);
+
+		/**
+		 * @type {URL}
+		 */
+		let resultUrl;
+		if (linkString.startsWith("ext:")) {
+			let resultLink = `extension/${linkString.slice(4)}`;
+			resultUrl = new URL(resultLink, rootURL);
+		} else if (URL.canParse(linkString)) {
+			resultUrl = new URL(linkString);
+		} else if (dbNow) {
+			let content = new Blob([linkString], { type: "text/plain" });
+			resultUrl = new URL(await get.dataUrl(content));
+		} else {
+			let resultLink = defaultHandle(linkString);
+			resultUrl = new URL(resultLink, rootURL);
+		}
+
+		if (forceLoadAsDataUrl && !resultUrl.href.startsWith("data:")) {
+			if (linkString.startsWith("db:")) {
+				/**
+				 * @type {string}
+				 */
+				let storeResult = await game.getDB("image", linkString.slice(3));
+
+				// 我思索了一下，如果这玩意能造成无限递归
+				// 那么我只能说，你赢了
+				return this.parseResourceAddress(storeResult, defaultHandle, forceLoadAsDataUrl, true);
+			}
+			/**
+			 * @type {Blob}
+			 */
+			let blob;
+
+			if (linkString.startsWith("file:")) {
+				let buffer = await game.promises.readFile(get.relativePath(resultUrl));
+				blob = new Blob([buffer]);
+			} else {
+				let response = await fetch(resultUrl.href);
+				blob = await response.blob();
+			}
+
+			resultUrl.href = await get.dataUrl(blob);
+		}
+
+		return resultUrl;
 	}
 }

--- a/noname/library/init/index.js
+++ b/noname/library/init/index.js
@@ -840,12 +840,12 @@ export class LibInit {
 	/**
 	 * @async
 	 * @param {string | URL} link - 需要解析的路径
-	 * @param {(item: string) => string} [defaultHandle] - 在给定路径不符合可用情况（或基于无名杀相关默认情况）时，处理路径的函数，返回的路径应是相对于根目录的相对路径，默认为恒等函数
+	 * @param {((item: string) => string) | null} [defaultHandle] - 在给定路径不符合可用情况（或基于无名杀相关默认情况）时，处理路径的函数，返回的路径应是相对于根目录的相对路径，默认为`null`，当且仅当无法解析成`URL`时会调用该回调
 	 * @param {boolean} [forceLoadAsDataUrl] - 是否将资源加载为[Data URL](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)，默认为`false`
 	 * @param {boolean} [dbNow] - 此刻是否在解析数据库中的内容，请勿直接使用
 	 * @returns {Promise<URL>}
 	 */
-	async parseResourceAddress(link, defaultHandle = item => item, forceLoadAsDataUrl = false, dbNow = false) {
+	async parseResourceAddress(link, defaultHandle = null, forceLoadAsDataUrl = false, dbNow = false) {
 		let linkString = link instanceof URL ? link.href : link;
 
 		// 如果传入值为Data URL，经过分析可知无需处理，故直接返回成品URL
@@ -864,7 +864,7 @@ export class LibInit {
 			let content = new Blob([linkString], { type: "text/plain" });
 			resultUrl = new URL(await get.dataUrl(content));
 		} else {
-			let resultLink = defaultHandle(linkString);
+			let resultLink = defaultHandle == null ? linkString : defaultHandle(linkString);
 			resultUrl = new URL(resultLink, rootURL);
 		}
 

--- a/noname/library/init/index.js
+++ b/noname/library/init/index.js
@@ -862,7 +862,7 @@ export class LibInit {
 			resultUrl = new URL(linkString);
 		} else if (dbNow) {
 			let content = new Blob([linkString], { type: "text/plain" });
-			resultUrl = new URL(await get.dataUrl(content));
+			resultUrl = new URL(await get.dataUrlAsync(content));
 		} else {
 			let resultLink = defaultHandle == null ? linkString : defaultHandle(linkString);
 			resultUrl = new URL(resultLink, rootURL);
@@ -892,7 +892,7 @@ export class LibInit {
 				blob = await response.blob();
 			}
 
-			resultUrl.href = await get.dataUrl(blob);
+			resultUrl.href = await get.dataUrlAsync(blob);
 		}
 
 		return resultUrl;

--- a/noname/library/init/promises.js
+++ b/noname/library/init/promises.js
@@ -63,4 +63,15 @@ export class LibInitPromises {
 			style.addEventListener("error", reject);
 		});
 	}
+
+	/**
+	 * @async
+	 * @param {string | URL} link - 需要解析的路径
+	 * @param {(item: string) => string} [defaultHandle] - 在给定路径不符合可用情况（或基于无名杀相关默认情况）时，处理路径的函数，返回的路径应是相对于根目录的相对路径，默认为恒等函数
+	 * @param {boolean} [forceLoadAsDataUrl] - 是否将资源加载为[Data URL](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)，默认为`false`
+	 * @returns {Promise<URL>}
+	 */
+	parseResourceAddress(link, defaultHandle = item => item, forceLoadAsDataUrl = false) {
+		return lib.init.parseResourceAddress(link, defaultHandle, forceLoadAsDataUrl);
+	}
 }

--- a/noname/library/init/promises.js
+++ b/noname/library/init/promises.js
@@ -67,11 +67,11 @@ export class LibInitPromises {
 	/**
 	 * @async
 	 * @param {string | URL} link - 需要解析的路径
-	 * @param {(item: string) => string} [defaultHandle] - 在给定路径不符合可用情况（或基于无名杀相关默认情况）时，处理路径的函数，返回的路径应是相对于根目录的相对路径，默认为恒等函数
+	 * @param {((item: string) => string) | null} [defaultHandle] - 在给定路径不符合可用情况（或基于无名杀相关默认情况）时，处理路径的函数，返回的路径应是相对于根目录的相对路径，默认为`null`，当且仅当无法解析成`URL`时会调用该回调
 	 * @param {boolean} [forceLoadAsDataUrl] - 是否将资源加载为[Data URL](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)，默认为`false`
 	 * @returns {Promise<URL>}
 	 */
-	parseResourceAddress(link, defaultHandle = item => item, forceLoadAsDataUrl = false) {
+	parseResourceAddress(link, defaultHandle = null, forceLoadAsDataUrl = false) {
 		return lib.init.parseResourceAddress(link, defaultHandle, forceLoadAsDataUrl);
 	}
 }


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
全部平台

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
无名杀过多基础设施都会自行解析`ext:`和`db:`等前缀，且不满足则遵循惯用法解析；路径

但随着无名杀步入http时代，我们应该让所有能解析的URL都得到解析

### PR描述
<!-- 详细描述您的更改 -->
增加`lib.init.parseResourceAddress(link: string | URL, defaultHandle?: (item: string) => string, forceLoadAsDataUrl?: boolean): Promise<URL>`函数，其中参数的解释如下：

- `link`: 需要解析的路径
- `defaultHandle`: 在给定路径不符合可用情况（或基于无名杀相关默认情况）时，处理路径的函数，返回的路径应是相对于根目录的相对路径，默认为`null`，当且仅当无法解析成`URL`时会调用该回调
- `forceLoadAsDataUrl`: 是否将资源加载为[Data URL](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)，默认为`false`

考虑到后续无名杀的发展，故返回值为URL，可通过`result.href`获取到原始路径字符串，再可通过`get.relativePath`获取相对路径，但请确保该路径可用于`get.relativePath`

`defaultHandle`用于兼容无名杀以往的惯用法，如果确认传入的`link`一定为URL，可将`defaultHandle`设置为`null`

同时为了一些额外需求，增加转换成Data URL的选择

目前有个关于`db:`的问题，个人不确定无名杀数据库中会通过该函数的数据库链接是否都是Data URL，为了灵活性，故目前`db:`仅在`forceLoadAsDataUrl`为`true`时考虑拓展解析，事后可根据实际情况更改

同时为了该函数正常运行/方便测试该函数，加了一些附带的函数，这些函数分别是：

- `Get#dataUrlAsync(blob: Blob): Promise<string>`: 将Blob转换成Data URL
- `Get#objectURLAsync(dataUrl: string | URL): Promise<URL>`: 将`Data URL`转换成`Blob URL`

经过个人思考后决定将这些函数加入无名杀本体

因为`get.DB`本身就为异步函数，故目前函数设计为异步函数，由于无法直接用于无名杀原有的同步代码，故目前未使用该函数

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
由于缺乏`db:`的相关测试，我只能保证我测试下来的`db:`都能正常解析出结果

其他路径根据惯用法可知，不会出现问题

由于该函数未实装进无名杀的底层逻辑，故目前游戏无任何影响

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
除非扩展覆盖了本次增加的函数， 不然无需适配

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
