### PR TITLE
使用牌类技能ai.effect改为effect_use，其他ai相关调整

### DIFF
--- a/card/extra.js
+++ b/card/extra.js
@@ -922,7 +922,7 @@ game.import("card", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target_use(card, player, target, current) {
 							if (target.hasSkillTag("unequip2")) return;
 							if (
 								player.hasSkillTag("unequip", false, {

--- a/card/guozhan.js
+++ b/card/guozhan.js
@@ -1523,7 +1523,7 @@ game.import("card", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target_use(card, player, target, current) {
 							if (
 								["huoshaolianying", "huogong"].includes(card.name) ||
 								(card.name == "sha" && game.hasNature(card, "fire"))
@@ -1575,7 +1575,7 @@ game.import("card", function () {
 			g_dinglanyemingzhu_ai: {
 				ai: {
 					effect: {
-						player: function (card, player) {
+						player_use(card, player) {
 							if (player.hasSkill("jubao")) return;
 							if (
 								card.name == "dinglanyemingzhu" &&
@@ -1592,7 +1592,7 @@ game.import("card", function () {
 			g_feilongduofeng_ai: {
 				ai: {
 					effect: {
-						player: function (card, player) {
+						player_use(card, player) {
 							if (player.hasSkill("zhangwu")) return;
 							if (
 								card.name == "feilongduofeng" &&
@@ -1609,7 +1609,7 @@ game.import("card", function () {
 			g_taipingyaoshu_ai: {
 				ai: {
 					effect: {
-						player: function (card, player) {
+						player_use(card, player) {
 							if (player.hasSkill("wendao")) return;
 							if (
 								card.name == "taipingyaoshu" &&
@@ -1620,7 +1620,7 @@ game.import("card", function () {
 								return [0, 0, 0, 0];
 							}
 						},
-						target: (card, player, target) => {
+						target_use(card, player, target) {
 							if (target._g_taipingyaoshu_temp) return;
 							if (
 								get.subtype(card) === "equip2" &&

--- a/card/gwent.js
+++ b/card/gwent.js
@@ -2001,7 +2001,7 @@ game.import("card", function () {
 				ai: {
 					weather: true,
 					effect: {
-						player: function (card, player) {
+						player_use(card, player) {
 							if (!player.needsToDiscard()) return "zeroplayertarget";
 						},
 					},

--- a/card/standard.js
+++ b/card/standard.js
@@ -3117,7 +3117,7 @@ game.import("card", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target_use(card, player, target) {
 							if (typeof card !== "object" || target.hasSkillTag("unequip2")) return;
 							if (
 								player.hasSkillTag("unequip", false, {

--- a/card/standard.js
+++ b/card/standard.js
@@ -2083,7 +2083,7 @@ game.import("card", function () {
 				},
 				ai: {
 					wuxie: function (target, card, player, viewer) {
-						if (get.attitude(viewer, player._trueMe || player) > 0) return 0;
+						if (!target.countCards("hej") ||get.attitude(viewer, player._trueMe || player) > 0) return 0;
 					},
 					basic: {
 						order: 7.5,
@@ -2366,6 +2366,7 @@ game.import("card", function () {
 				ai: {
 					wuxie: (target, card, player, viewer, status) => {
 						if (
+							!target.countCards("hej") ||
 							status * get.attitude(viewer, player._trueMe || player) > 0 ||
 							(target.hp > 2 &&
 								!target.hasCard((i) => {

--- a/card/swd.js
+++ b/card/swd.js
@@ -5030,8 +5030,10 @@ game.import("card", function () {
 					player.updateMarks();
 				},
 				ai: {
-					effect: function (card, player, target) {
-						if (get.tag(card, "damage") && !target.hujia) return [1, 0.5];
+					effect: {
+						target(card, player, target) {
+							if (get.tag(card, "damage") && !target.hujia) return [1, 0.5];
+						}
 					},
 				},
 				intro: {
@@ -5133,9 +5135,11 @@ game.import("card", function () {
 					player.recover(trigger.num);
 				},
 				ai: {
-					effect: function (card) {
-						if (get.tag(card, "thunderDamage")) return [0, 2];
-					},
+					effect: {
+						target(card) {
+							if (get.tag(card, "thunderDamage")) return [0, 2];
+						},
+					}
 				},
 			},
 			guiyanfadao: {

--- a/card/yingbian.js
+++ b/card/yingbian.js
@@ -754,7 +754,7 @@ game.import("card", function () {
 			heiguangkai_ai: {
 				ai: {
 					effect: {
-						player: function (card, player, target) {
+						player_use(card, player, target) {
 							if (
 								typeof card !== "object" ||
 								!target ||

--- a/character/clan/skill.js
+++ b/character/clan/skill.js
@@ -932,7 +932,7 @@ const skills = {
 		ai: {
 			threaten: 3,
 			effect: {
-				player(card, player, target) {
+				player_use(card, player, target) {
 					if (!target || typeof card !== "object" || player._clanjiejian_mod_temp || get.type(card) === "equip" || get.attitude(player, target) <= 0 || get.cardNameLength(card) !== player.getHistory("useCard").length + 1) return;
 					let targets = [target],
 						evt = _status.event.getParent("useCard");
@@ -2705,7 +2705,7 @@ const skills = {
 				if (player.getHistory("useCard", evt => get.type(evt.card) == "equip").length > 0) return false;
 			},
 			effect: {
-				target(card, player, target) {
+				target_use(card, player, target) {
 					if (player == target && get.type(card) == "equip" && !player.getHistory("useCard", evt => get.type(evt.card) == "equip").length == 0) return [1, 3];
 				},
 			},

--- a/character/collab/skill.js
+++ b/character/collab/skill.js
@@ -759,7 +759,7 @@ const skills = {
 				},
 			},
 			effect: {
-				target(card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (player == target && player.isPhaseUsing() && get.type(card) == "equip") {
 						if (player.hasValueTarget("sha", false) && typeof player.getStat("skill").dcbianzhuang == "number") return [1, 3];
 					}
@@ -1645,7 +1645,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player(card, player, target) {
+				player_use(card, player, target) {
 					if (player !== target && get.type2(card) === "trick") {
 						let tars = [target];
 						if (ui.selected.targets.length) tars.addArray(ui.selected.targets.filter(i => i !== player && i !== target));

--- a/character/ddd/skill.js
+++ b/character/ddd/skill.js
@@ -2619,7 +2619,7 @@ const skills = {
 			order: 10,
 			result: { player: 1 },
 			effect: {
-				target: (card, player, target) => {
+				target_use(card, player, target) {
 					if (card.name === "sha" && target.getExpansions("ddddongcha_effect").length < 2 && lib.skill["dddzhijie"].hiddenCard(target, "shan")) return [1, 1, 1, -get.sgn(get.attitude(player, _status.currentPhase))];
 				},
 			},

--- a/character/diy/skill.js
+++ b/character/diy/skill.js
@@ -1918,6 +1918,13 @@ const skills = {
 		},
 	},
 	nszhihuang: {
+		available(mode) {
+			return (
+				mode == "identity" ||
+				mode == "versus" && (_status.mode == "four" || _status.mode == "guandu") ||
+				mode == "guozhan"
+			);
+		},
 		group: "nszhihuang_damage",
 		trigger: { global: "useCard" },
 		usable: 1,

--- a/character/diy/skill.js
+++ b/character/diy/skill.js
@@ -3176,7 +3176,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target(card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (get.type(card, "trick") == "trick" && get.distance(player, target) > 1) return "zeroplayertarget";
 				},
 			},
@@ -4609,7 +4609,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						target(card, player, target, current) {
+						target_use(card, player, target, current) {
 							if (get.type(card, "trick") == "trick" && _status.currentPhase == player) return "zeroplayertarget";
 						},
 					},
@@ -6238,7 +6238,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target(card, player, target) {
+				target_use(card, player, target) {
 					if (get.tag(card, "multineg")) {
 						return "zerotarget";
 					}

--- a/character/diy/skill.js
+++ b/character/diy/skill.js
@@ -4494,7 +4494,7 @@ const skills = {
 		content() {
 			"step 0";
 			player
-				.chooseTarget("恭俭：将置的牌交给一名体力值大于你的角色", function (card, player, target) {
+				.chooseTarget("恭俭：将弃置的牌交给一名体力值大于你的角色", function (card, player, target) {
 					return target.hp > player.hp;
 				})
 				.set("ai", function (target) {
@@ -4505,6 +4505,9 @@ const skills = {
 				player.line(result.targets, "green");
 				result.targets[0].gain(trigger.cards, "gain2");
 			}
+		},
+		ai: {
+			halfneg: true
 		},
 	},
 	nscaijian: {

--- a/character/diy/skill.js
+++ b/character/diy/skill.js
@@ -6728,9 +6728,11 @@ const skills = {
 			player.draw();
 		},
 		ai: {
-			effect(card, player, target) {
-				if (get.color(card) == "red") return [1, 1];
-			},
+			effect: {
+				target_use(card, player, target) {
+					if (get.color(card) == "red") return [1, 1];
+				},
+			}
 		},
 	},
 	zaiqix: {

--- a/character/extra/skill.js
+++ b/character/extra/skill.js
@@ -2327,7 +2327,7 @@ const skills = {
 		ai: {
 			threaten: 1.5,
 			effect: {
-				target(card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (get.type(card) == "equip" && !get.cardtag(card, "gifts")) return [1, 0.1];
 				},
 			},
@@ -3297,7 +3297,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player: (card, player, target) => {
+				player_use(card, player, target) {
 					if (typeof card !== "object") return;
 					let suit = get.suit(card);
 					if (
@@ -4286,7 +4286,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						target(card, player, target) {
+						target_use(card, player, target) {
 							if (card && card.name == "qizhengxiangsheng") return "zeroplayertarget";
 						},
 					},
@@ -4413,7 +4413,7 @@ const skills = {
 			global: {
 				ai: {
 					effect: {
-						player: (card, player, target) => {
+						player_use(card, player, target) {
 							let num = 0,
 								nohave = true;
 							game.countPlayer(i => {
@@ -4529,7 +4529,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target(card, player, target, current, isLink) {
+				target_use(card, player, target, current, isLink) {
 					if (card.name == "sha" && !isLink && player.hp > target.hp) return 0.5;
 				},
 			},

--- a/character/gujian.js
+++ b/character/gujian.js
@@ -1289,7 +1289,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target(card, player, target, current) {
+						target_use(card, player, target, current) {
 							if (get.color(card) == "red" && target.isDamaged()) return [1, 1];
 						},
 					},
@@ -1480,7 +1480,7 @@ game.import("character", function () {
 				ai: {
 					halfneg: true,
 					effect: {
-						player(card, player, target, current) {
+						player_use(card, player, target, current) {
 							if (get.color(card) == "red") return [1, 0, 1, -2];
 						},
 					},

--- a/character/hearth.js
+++ b/character/hearth.js
@@ -2517,7 +2517,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target(card, player, target) {
+						target_use(card, player, target) {
 							if (get.type(card, "trick") == "trick" && player == target) return [1, 1];
 						},
 					},

--- a/character/huicui/skill.js
+++ b/character/huicui/skill.js
@@ -9820,7 +9820,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player: function (card, player, target) {
+						player_use(card, player, target) {
 							if (player !== target && get.itemtype(target) === "player" && (card.name === "sha" || get.type(card, false) === "trick") && target.countCards("he") && !target.hasSkillTag("noh")) return [1, 0, 1, -1];
 						},
 					},
@@ -10483,7 +10483,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					if (typeof card == "object" && player != target) {
 						var suit = get.suit(card);
 						if (suit == "none") return;
@@ -13093,7 +13093,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target_use(card, player, target) {
 							if (_status._dcdanying_aiChecking) return;
 							_status._dcdanying_aiChecking = true;
 							let eff = get.effect(target, { name: "guohe_copy2" }, player, player);

--- a/character/huicui/skill.js
+++ b/character/huicui/skill.js
@@ -13362,6 +13362,9 @@ const skills = {
 				}
 			}
 		},
+		ai: {
+			combo: "recangchu"
+		},
 	},
 	reshishou: {
 		audio: 2,

--- a/character/jsrg/skill.js
+++ b/character/jsrg/skill.js
@@ -137,6 +137,9 @@ const skills = {
 		},
 	},
 	jsrgchushi: {
+		available(mode) {
+			return mode == "identity" || mode == "versus" && (_status.mode == "four" || _status.mode == "guandu");
+		},
 		audio: 2,
 		enable: "phaseUse",
 		usable: 1,

--- a/character/jsrg/skill.js
+++ b/character/jsrg/skill.js
@@ -5964,7 +5964,7 @@ const skills = {
 		ai: {
 			halfneg: true,
 			effect: {
-				player_use: function (card, player, target) {
+				player_use(card, player, target) {
 					if (card.name == "jiu") return [1, 1];
 				},
 			},
@@ -6773,7 +6773,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					if (lib.skill.jsrgjuxia.countSkill(target) >= lib.skill.jsrgjuxia.countSkill(player)) return;
 					if (card && (card.cards || card.isCard) && get.attitude(target, player) > 0 && (!target.storage.counttrigger || !target.storage.counttrigger.jsrgjuxia)) return [0, 0.5, 0, 0.5];
 				},
@@ -8034,7 +8034,7 @@ const skills = {
 			pretao: true,
 			threaten: 1.8,
 			effect: {
-				player(card, player, target) {
+				player_use(card, player, target) {
 					if (
 						typeof card === "object" &&
 						card.name !== "shan" &&

--- a/character/key/skill.js
+++ b/character/key/skill.js
@@ -2250,7 +2250,7 @@ const skills = {
 		ai: {
 			threaten: 0.7,
 			effect: {
-				target(card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (card.name == "sha") return 0.7;
 				},
 			},
@@ -9797,10 +9797,10 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target(card, player, target) {
+				target_use(card, player, target) {
 					if (card.name == "sha" && get.color(card) == "red") return [1, 0.6];
 				},
-				player(card, player, target) {
+				player_use(card, player, target) {
 					if (card.name == "sha" && get.color(card) == "red") return [1, 1];
 				},
 			},

--- a/character/key/skill.js
+++ b/character/key/skill.js
@@ -6484,6 +6484,9 @@ const skills = {
 			"step 2";
 			event.cards = result.cards;
 		},
+		ai: {
+			halfneg: true
+		},
 	},
 	//乙坂有宇
 	yuu_lveduo: {
@@ -6626,6 +6629,9 @@ const skills = {
 			player.loseMaxHp(3);
 			player.draw(3);
 			player.removeSkills("godan_feiqu");
+		},
+		ai: {
+			halfneg: true
 		},
 	},
 	//游佐
@@ -8785,6 +8791,7 @@ const skills = {
 			else trigger.directHit.add(player);
 		},
 		ai: {
+			halfneg: true,
 			directHit_ai: true,
 			skillTagFilter(player, tag, arg) {
 				return arg.card.name == "sha";

--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -119,7 +119,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player(card, player, target, current) {
+						player_use(card, player, target, current) {
 							if (!target) return;
 							const counttrigger = player.storage.counttrigger;
 							if (counttrigger && counttrigger.mbkuangli_target && counttrigger.mbkuangli_target >= lib.skill.mbkuangli_target.usable) return;
@@ -5176,7 +5176,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target_use(card, player, target) {
 							if (player.canUse(card, target) && get.distance(player, target) != 1) return 1.2;
 						},
 					},
@@ -7599,7 +7599,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (card.name == "sha" && current < 0) return 0.7;
 				},
 			},
@@ -8046,7 +8046,7 @@ const skills = {
 		ai: {
 			reverseEquip: true,
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (get.type(card) == "equip" && !get.tag(card, "gifts") && target.storage.jueyong && target.storage.jueyong[1].length) {
 						var result1 = get.equipResult(player, target, card.name),
 							subtype = get.subtype(card);
@@ -10239,7 +10239,7 @@ const skills = {
 		ai: {
 			expose: 0.2,
 			effect: {
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					if (card.name != "sha") return;
 					var players = game.filterPlayer();
 					if (get.attitude(player, target) <= 0) {
@@ -15180,7 +15180,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (["tiesuo", "lulitongxin"].includes(card.name)) {
 						return "zerotarget";
 					}
@@ -15205,7 +15205,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					if (typeof card !== "object" || target.hasSkillTag("unequip2")) return;
 					if (
 						player.hasSkillTag("unequip", false, {
@@ -15238,7 +15238,7 @@ const skills = {
 		inherit: "rw_minguangkai_link",
 		ai: {
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (["tiesuo", "lulitongxin"].includes(card.name)) {
 						return "zeroplayertarget";
 					}

--- a/character/offline/skill.js
+++ b/character/offline/skill.js
@@ -442,7 +442,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target(card, player, target) {
+				target_use(card, player, target) {
 					if (card.name == "sha" && !game.hasNature(card) && game.countPlayer(targetx => player.inRange(targetx)) >= 3) return "zerotarget";
 				},
 			},
@@ -1487,7 +1487,7 @@ const skills = {
 			threaten: 100,
 			reverseEquip: true,
 			effect: {
-				player: (card, player, target) => {
+				player_use(card, player, target) {
 					if (typeof card !== "object") return;
 					let suit = get.suit(card);
 					if (
@@ -1506,7 +1506,7 @@ const skills = {
 						}),
 					];
 				},
-				target: (card, player, target) => {
+				target(card, player, target) {
 					if (
 						card.name === "sha" &&
 						!player.hasSkillTag(
@@ -1580,7 +1580,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					if (card.name === "sha" && game.hasNature(card) && target.hasEmptySlot(2)) return "zeroplayertarget";
 					if (get.subtype(card) == "equip2" && target.isEmpty(2)) return [0.6, -0.8];
 				},
@@ -2290,7 +2290,7 @@ const skills = {
 			threaten: 1.1,
 			combo: "psshiyin",
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					var list = target.getExpansions("psshiyin");
 					for (var cardx of list) {
 						if (get.suit(cardx) == get.suit(card)) return "zeroplayertarget";
@@ -6442,7 +6442,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					var type = get.type2(card);
 					var list = target.getExpansions("zuixiang2");
 					for (var i of list) {

--- a/character/onlyOL/skill.js
+++ b/character/onlyOL/skill.js
@@ -432,7 +432,7 @@ const skills = {
 		subSkill: {
 			ai: {
 				effect: {
-					player(card, player) {
+					player_use(card, player) {
 						if (
 							!game.hasPlayer(target => {
 								return target.hasSkill("olsbhetao") && (get.attitude(player, target) < 0 || get.attitude(target, player) < 0);

--- a/character/ow.js
+++ b/character/ow.js
@@ -180,7 +180,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target_use(card, player, target) {
 							if (_status.woliu2_temp) return;
 							if (card.name == "sha" && target.storage.woliu2) {
 								_status.woliu2_temp = true;
@@ -266,7 +266,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target_use(card, player, target, current) {
 							if (card.name == "sha") {
 								if (_status.event.name == "qianggu2") return;
 								if (get.attitude(player, target) > 0) return;

--- a/character/refresh/skill.js
+++ b/character/refresh/skill.js
@@ -14582,27 +14582,29 @@ const skills = {
 		},
 		ai: {
 			maihp: true,
-			effect: function (card, player, target) {
-				if (get.tag(card, "damage")) {
-					if (player.hasSkillTag("jueqing", false, target)) return [1, 1];
-					return 1.2;
-				}
-				if (get.tag(card, "loseHp")) {
-					if (target.hp <= 1) return;
-					var using = target.isPhaseUsing();
-					if (target.hp <= 2) return [1, player.countCards("h") <= 1 && using ? 3 : 0];
-					if (using && target.countCards("h", { name: "sha", color: "red" })) return [1, 3];
-					return [
-						1,
-						target.countCards("h") <= target.hp ||
-						(using &&
-							game.hasPlayer(function (current) {
-								return current != player && get.attitude(player, current) < 0 && player.inRange(current);
-							}))
-							? 3
-							: 2,
-					];
-				}
+			effect: {
+				target(card, player, target) {
+					if (get.tag(card, "damage")) {
+						if (player.hasSkillTag("jueqing", false, target)) return [1, 1];
+						return 1.2;
+					}
+					if (get.tag(card, "loseHp")) {
+						if (target.hp <= 1) return;
+						var using = target.isPhaseUsing();
+						if (target.hp <= 2) return [1, player.countCards("h") <= 1 && using ? 3 : 0];
+						if (using && target.countCards("h", { name: "sha", color: "red" })) return [1, 3];
+						return [
+							1,
+							target.countCards("h") <= target.hp ||
+							(using &&
+								game.hasPlayer(function (current) {
+									return current != player && get.attitude(player, current) < 0 && player.inRange(current);
+								}))
+								? 3
+								: 2,
+						];
+					}
+				},
 			},
 		},
 	},

--- a/character/refresh/skill.js
+++ b/character/refresh/skill.js
@@ -7400,7 +7400,7 @@ const skills = {
 		ai: {
 			expose: 0.2,
 			effect: {
-				target: function (card, player, target) {
+				target_use: function (card, player, target) {
 					if (card.name != "sha") return;
 					var players = game.filterPlayer();
 					if (get.attitude(player, target) <= 0) {
@@ -7648,7 +7648,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
+				target_use: function (card, player, target) {
 					if (target != _status.currentPhase && target.countCards("h") >= target.getHandcardLimit() && (get.type(card) == "delay" || get.color(card) == "none")) return "zerotarget";
 				},
 			},
@@ -13465,7 +13465,7 @@ const skills = {
 				},
 			},
 			effect: {
-				target: function (card, player, target) {
+				target_use: function (card, player, target) {
 					if (player == target && get.type(card) == "equip") {
 						if (player.countCards("e", { subtype: get.subtype(card) })) {
 							if (
@@ -13941,20 +13941,22 @@ const skills = {
 			player.addSkill("reqianxun2");
 		},
 		ai: {
-			effect: function (card, player, target) {
-				if (player == target || !target.hasFriend()) return;
-				var type = get.type(card);
-				var nh = Math.min(
-					target.countCards(),
-					game.countPlayer(i => get.attitude(target, i) > 0)
-				);
-				if (type == "trick") {
-					if (!get.tag(card, "multitarget") || get.info(card).singleCard) {
-						if (get.tag(card, "damage")) return [1.5, nh - 1];
-						return [1, nh];
-					}
-				} else if (type == "delay") return [0.5, 0.5];
-			},
+			effect: {
+				target_use(card, player, target) {
+					if (player == target || !target.hasFriend()) return;
+					var type = get.type(card);
+					var nh = Math.min(
+						target.countCards(),
+						game.countPlayer(i => get.attitude(target, i) > 0)
+					);
+					if (type == "trick") {
+						if (!get.tag(card, "multitarget") || get.info(card).singleCard) {
+							if (get.tag(card, "damage")) return [1.5, nh - 1];
+							return [1, nh];
+						}
+					} else if (type == "delay") return [0.5, 0.5];
+				},
+			}
 		},
 	},
 	reqianxun2: {

--- a/character/sb/skill.js
+++ b/character/sb/skill.js
@@ -6090,16 +6090,18 @@ const skills = {
 				},
 				ai: {
 					maihp: true,
-					effect: function (card, player, target) {
-						if (get.tag(card, "damage")) {
-							if (player.hasSkillTag("jueqing", false, target)) return [1, 1];
-							return 1.2;
-						}
-						if (get.tag(card, "loseHp")) {
-							if (target.hp <= 1 || target.hujia >= 5) return;
-							return [1, 1];
-						}
-					},
+					effect: {
+						target(card, player, target) {
+							if (get.tag(card, "damage")) {
+								if (player.hasSkillTag("jueqing", false, target)) return [1, 1];
+								return 1.2;
+							}
+							if (get.tag(card, "loseHp")) {
+								if (target.hp <= 1 || target.hujia >= 5) return;
+								return [1, 1];
+							}
+						},
+					}
 				},
 			},
 		},

--- a/character/sb/skill.js
+++ b/character/sb/skill.js
@@ -1479,7 +1479,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player: function (card, player, target) {
+						player_use(card, player, target) {
 							if (player.getStorage("sbyijue_effect").includes(target)) return "zeroplayertarget";
 						},
 					},
@@ -2736,10 +2736,10 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					if (card.name == "sha" && get.color(card) == "red") return [1, 0.6];
 				},
-				player: function (card, player, target) {
+				player_use(card, player, target) {
 					if (card.name == "sha" && get.color(card) == "red") return [1, 1];
 				},
 			},
@@ -3451,7 +3451,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player: function (card, player, target) {
+				player_use(card, player, target) {
 					if (player != target && target && target.group == "qun" && card.name != "tao") return [1, 0.1];
 				},
 			},

--- a/character/shenhua/skill.js
+++ b/character/shenhua/skill.js
@@ -971,7 +971,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target(card, player, target) {
+				target_use(card, player, target) {
 					let hs = player.getCards("h", i => i !== card && (!card.cards || !card.cards.includes(i))),
 						num = player.getCardUsable("sha");
 					if ((card.name !== "sha" && card.name !== "juedou") || hs.length < target.countCards("h")) return 1;
@@ -2382,7 +2382,7 @@ const skills = {
 					return false;
 			},
 			effect: {
-				target(card, player, target) {
+				target_use(card, player, target) {
 					if (
 						player == target &&
 						get.type(card) == "equip" &&
@@ -3901,10 +3901,10 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target(card, player, target) {
+				target_use(card, player, target) {
 					if (card.name == "sha" && get.color(card) == "red") return [1, 0.6];
 				},
-				player(card, player, target) {
+				player_use(card, player, target) {
 					if (card.name == "sha" && get.color(card) == "red") return [1, 1];
 				},
 			},

--- a/character/shiji/skill.js
+++ b/character/shiji/skill.js
@@ -1471,13 +1471,13 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player: function (card, player, target) {
+				player_use(card, player, target) {
 					var hp = player.hp,
 						evt = _status.event;
 					if (evt.name == "chooseToUse" && evt.player == player && evt.skill == "spjungong" && !ui.selected.cards.length) hp -= (player.getStat("skill").spjungong || 0) + 1;
 					if (card && card.name == "sha" && hp == target.hp) return [1, 0.3];
 				},
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					if (card && card.name == "sha" && player.hp == target.hp) return [1, 0.3];
 				},
 			},
@@ -1710,7 +1710,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player: function (card, player, target) {
+						player_use(card, player, target) {
 							if (get.name(card) == "shan") {
 								let num = get.number(card);
 								if (!num || num <= player.storage.shanxie_banned.num) return "zeroplayertarget";
@@ -2119,7 +2119,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (card.name == "sha" && player.hp > target.hp && get.attitude(player, target) < 0) {
 						var num = get.number(card);
 						if (typeof num != "number") return false;

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -2420,7 +2420,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player: function (card, player, target) {
+						player_use(card, player, target) {
 							if (card.name == "tiesuo" && (!player.storage.counttrigger || !player.storage.counttrigger.hezhong_0)) return "zerotarget";
 						},
 					},
@@ -2457,7 +2457,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player: function (card, player, target) {
+						player_use(card, player, target) {
 							if (card.name == "tiesuo" && (!player.storage.counttrigger || !player.storage.counttrigger.hezhong_1)) return "zerotarget";
 						},
 					},
@@ -4320,7 +4320,7 @@ const skills = {
 			diamond_ai: {
 				ai: {
 					effect: {
-						player: function (card, player, target) {
+						player_use(card, player, target) {
 							if (get.name(card) == "sha" && !player.hasSkill("oltianhou_diamond") && target != player.getNext() && target != player.getPrevious()) {
 								let num = get.number(card),
 									max = _status.aiyh_MAXNUM || 13;
@@ -5067,7 +5067,7 @@ const skills = {
 		ai: {
 			threaten: 3,
 			effect: {
-				player_use: function (card, player, target) {
+				player_use(card, player, target) {
 					if (
 						typeof card == "object" &&
 						card.cards &&
@@ -6587,7 +6587,7 @@ const skills = {
 			order: 1,
 			threaten: 1.1,
 			effect: {
-				player_use: function (card, player, target) {
+				player_use(card, player, target) {
 					if (_status._olkenshang_aiChecking || ui.selected.targets.length) return;
 					if (typeof card != "object" || !card.storage || !card.storage.olkenshang) return false;
 					_status._olkenshang_aiChecking = true;
@@ -6795,7 +6795,7 @@ const skills = {
 			threaten: 0.8,
 			halfneg: true,
 			effect: {
-				player: function (card, player, target) {
+				player_use(card, player, target) {
 					if ((!card.isCard || !card.cards) && get.itemtype(card) != "card") return;
 					let cs = 0;
 					if (
@@ -10746,7 +10746,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					if (card.name != "sha") return;
 					if (
 						target.hasSkillTag("unequip2") ||
@@ -10871,7 +10871,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target, effect) {
+				target_use(card, player, target, effect) {
 					if (
 						effect > 0 ||
 						player.hasSkillTag("unequip", false, {
@@ -12042,7 +12042,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player_use: function (card, player, target) {
+				player_use(card, player, target) {
 					if (!target || player._saodi_judging || ui.selected.targets.length || player == target || target.hasSkill("nodis")) return;
 					if (typeof card != "object" || (card.name != "sha" && get.type(card) != "trick")) return false;
 					player._saodi_judging = true;
@@ -16192,17 +16192,6 @@ const skills = {
 			}
 		},
 		group: "neifa_use",
-		ai: {
-			reverseOrder: true,
-			skillTagFilter: function (player) {
-				if (player.storage.counttrigger && player.storage.counttrigger.neifa_use >= 2) return false;
-			},
-			effect: {
-				target: function (card, player, target) {
-					if ((!player.storage.counttrigger || !player.storage.counttrigger.neifa_use || player.storage.counttrigger.neifa_use < 2) && player == target && get.type(card) == "equip") return [1, 3];
-				},
-			},
-		},
 	},
 	neifa_use: {
 		audio: "neifa",
@@ -16214,6 +16203,17 @@ const skills = {
 		},
 		content: function () {
 			player.draw(player.countMark("neifa_nobasic"));
+		},
+		ai: {
+			reverseOrder: true,
+			skillTagFilter(player) {
+				if (player.storage.counttrigger && player.storage.counttrigger.neifa_use >= 2) return false;
+			},
+			effect: {
+				player_use(card, player, target) {
+					if (player.countSkill("neifa_use") < 2 && get.type(card) == "equip") return [1, player.countMark("neifa_nobasic")];
+				},
+			},
 		},
 	},
 	//许靖
@@ -16686,7 +16686,7 @@ const skills = {
 		ai: {
 			threaten: 1.8,
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					let used = target.getHistory("useCard").length + target.getHistory("respond").length;
 					if (get.subtype(card) == "equip1" && !get.cardtag(card, "gifts")) {
 						if (player != target || !player.isPhaseUsing()) return;
@@ -23894,7 +23894,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card) {
+				target_use(card) {
 					if (get.type(card) != "trick") return;
 					if (card.name == "tiesuo") return [0, 0];
 					if (card.name == "yihuajiemu") return [0, 1];
@@ -24055,7 +24055,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					if (get.color(card) == "black" && target.countCards("h") > 0) {
 						return [1, 0.5];
 					}
@@ -26673,7 +26673,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (card.name == "sha") return [1, 0.5];
 				},
 			},

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -20368,6 +20368,9 @@ const skills = {
 		charlotte: true,
 	},
 	weidi: {
+		available(mode) {
+			return mode == "identity" || mode == "versus" && _status.mode == "four";
+		},
 		init(player) {
 			const list = [];
 			const zhu = get.zhu(player);

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -6242,6 +6242,9 @@ const skills = {
 			"step 1";
 			trigger.phaseList.splice(trigger.num, 0, "phaseUse|oldianjun");
 		},
+		ai: {
+			halfneg: true
+		},
 	},
 	olkangrui: {
 		audio: 2,

--- a/character/sp2/skill.js
+++ b/character/sp2/skill.js
@@ -889,7 +889,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player_use: function (card, player, target) {
+						player_use(card, player, target) {
 							var targets = game.filterPlayer(targetx => targetx != player && targetx.getStorage("starcanxi_xiangsi").includes(player.group));
 							if (!targets.length) return;
 							if (get.tag(card, "recover") && target == player && target.hp > 2) return 0;
@@ -2249,7 +2249,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player: function (card, player, target) {
+				player_use(card, player, target) {
 					if (_status.event.name == "chooseToUse" && get.name(card) == "sha" && (!player.storage.counttrigger || !player.storage.counttrigger.dctingxian) && !_status._dctingxian_aiChecking) {
 						_status._dctingxian_aiChecking = true;
 						var eff = get.effect(target, { name: "sha" }, player, player);
@@ -11789,7 +11789,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player: function (card, player, target) {
+				player_use(card, player, target) {
 					var evt = player.getLastUsed();
 					if (evt && evt.targets.includes(target) && (!player.storage.counttrigger || !player.storage.counttrigger.xinfu_lianpian || !player.storage.counttrigger.xinfu_lianpian < 3) && player.isPhaseUsing(player)) return [1.5, 0];
 				},

--- a/character/standard/skill.js
+++ b/character/standard/skill.js
@@ -1651,7 +1651,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target(card, player, target) {
+				target_use(card, player, target) {
 					if (target.countCards("he") == 0) return;
 					if (card.name != "sha") return;
 					let min = 1;

--- a/character/swd.js
+++ b/character/swd.js
@@ -3834,22 +3834,24 @@ game.import("character", function () {
 				ai: {
 					maixie: true,
 					maixie_hp: true,
-					effect: function (card, player, target) {
-						if (get.tag(card, "damage")) {
-							if (player.hasSkillTag("jueqing", false, target)) return [1, -0.5];
-							if (!target.hasFriend()) {
-								if (get.mode() == "guozhan") {
-									if (!player.hasFriend()) return;
-								} else {
-									return;
+					effect: {
+						target(card, player, target) {
+							if (get.tag(card, "damage")) {
+								if (player.hasSkillTag("jueqing", false, target)) return [1, -0.5];
+								if (!target.hasFriend()) {
+									if (get.mode() == "guozhan") {
+										if (!player.hasFriend()) return;
+									} else {
+										return;
+									}
 								}
+								if (target.countCards("h") > 2 || target.countCards("e", { color: "black" })) {
+									return [1, 0, 0, -1];
+								}
+								return [1, -0.5];
 							}
-							if (target.countCards("h") > 2 || target.countCards("e", { color: "black" })) {
-								return [1, 0, 0, -1];
-							}
-							return [1, -0.5];
-						}
-					},
+						},
+					}
 				},
 			},
 			xuanyuan: {

--- a/character/swd.js
+++ b/character/swd.js
@@ -1259,7 +1259,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target_use(card, player, target, current) {
 							if (
 								target == player &&
 								lib.skill.gaizao.filterx(card, target) &&
@@ -1869,7 +1869,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target_use(card, player, target) {
 							if (get.tag(card, "respondShan")) {
 								var shans = target.countCards("h", "shan");
 								var hs = target.countCards("h");
@@ -1920,7 +1920,7 @@ game.import("character", function () {
 					mingzhi: false,
 					useShan: true,
 					effect: {
-						target: function (card, player, target) {
+						target_use(card, player, target) {
 							if (get.tag(card, "respondShan")) {
 								var shans = target.countCards("h", "shan");
 								var hs = target.countCards("h");
@@ -2970,7 +2970,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card) {
+						target_use(card) {
 							if (card.name == "sha") return 1.3;
 						},
 					},
@@ -3307,7 +3307,7 @@ game.import("character", function () {
 				ai: {
 					mingzhi: false,
 					effect: {
-						target: function (card, player, target) {
+						target_use(card, player, target) {
 							if (player == _status.currentPhase) return;
 							if (
 								!game.hasPlayer(function (current) {
@@ -4484,7 +4484,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						player: function (card, player, target) {
+						player_use(card, player, target) {
 							if (player != target) return;
 							if (get.type(card) == "equip" && !player.needsToDiscard()) {
 								return [0, 0, 0, 0];
@@ -8406,7 +8406,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target_use(card, player, target) {
 							if (
 								get.color(card) == "black" &&
 								get.attitude(target, player) < 0 &&
@@ -8676,7 +8676,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target_use(card, player, target) {
 							return 0.7;
 						},
 					},

--- a/character/tw/skill.js
+++ b/character/tw/skill.js
@@ -8888,7 +8888,7 @@ const skills = {
 				charlotte: true,
 				ai: {
 					effect: {
-						player_use: function (card, player, target) {
+						player_use(card, player, target) {
 							if (
 								card.cards &&
 								card.cards.some(i => i.hasGaintag("twkujianx")) &&
@@ -9519,7 +9519,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (card.name == "sha" && player.hp > target.hp && get.attitude(player, target) < 0) {
 						var num = get.number(card);
 						var bs = player.getCards("h", function (cardx) {
@@ -13976,7 +13976,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target, current, isLink) {
+				target_use(card, player, target, current, isLink) {
 					if (card.name == "sha" && !isLink) return 0.8;
 				},
 			},
@@ -14317,7 +14317,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player: function (card, player, target) {
+						player_use(card, player, target) {
 							if (get.type(card) !== "delay" && get.type(card) !== "equip") return 1;
 							let za = game.findPlayer(cur => cur.hasSkill("twzhian") && (!cur.storage.counttrigger || !cur.storage.counttrigger.twzhian) && get.attitude(player, cur) <= 0);
 							if (za) return [0.5, -0.8];

--- a/character/xianding/skill.js
+++ b/character/xianding/skill.js
@@ -1146,7 +1146,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player(card, player, target, current) {
+						player_use(card, player, target, current) {
 							if (get.type(card) == "trick" && player.getStorage("dcjujian_forbid").includes(target)) return "zeroplayertarget";
 						},
 					},
@@ -5670,7 +5670,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player: (card, player, target) => {
+						player_use(card, player, target) {
 							if (get.itemtype(card) === "card" && cardx.hasGaintag("dczhaowen_tag") && get.color(card, player) === "red") return [1, 1];
 						},
 					},
@@ -5737,7 +5737,7 @@ const skills = {
 				if (name != "phase") return false;
 			},
 			effect: {
-				target_use: (card, player, target) => {
+				target_use(card, player, target) {
 					if (player === target || typeof card !== "object" || get.color(card) !== "black") return;
 					if (target.hasSkill("jiu")) {
 						if (
@@ -7056,7 +7056,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player: function (card, player, target) {
+				player_use(card, player, target) {
 					var evt = player.getLastUsed();
 					if (evt && evt.targets.includes(target)) return [1.5, 0];
 				},
@@ -8630,7 +8630,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player_use: function (card, player, target) {
+						player_use(card, player, target) {
 							if (get.tag(card, "recover") && target.hp > 0) return 0;
 							if (get.tag(card, "damage")) return 0.5;
 						},
@@ -8906,7 +8906,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use: (card, player, target) => {
+				target_use(card, player, target) {
 					if (player === target) return;
 					if (
 						game.hasPlayer2(current => {
@@ -9451,7 +9451,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player_use: function (card, player, target) {
+						player_use(card, player, target) {
 							if (typeof card != "object") return;
 							var storage = player.getStorage("olddcxiangmian_countdown");
 							for (var i = 0; i < storage.length / 3; i++) {
@@ -9553,7 +9553,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player_use: function (card, player, target) {
+						player_use(card, player, target) {
 							if (typeof card != "object") return;
 							var storage = player.getStorage("dcxiangmian_countdown");
 							for (var i = 0; i < storage.length / 3; i++) {
@@ -13133,7 +13133,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player: function (card, player, target) {
+				player_use(card, player, target) {
 					if (
 						target &&
 						target.getExpansions("xinzhoufu2").length > 0 &&
@@ -13988,7 +13988,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player_use: function (card, player, target) {
+				player_use(card, player, target) {
 					if (
 						typeof card == "object" &&
 						player == _status.currentPhase &&
@@ -14985,7 +14985,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use: function (card, player, target) {
+				target_use(card, player, target) {
 					if (get.itemtype(player) !== "player" || player === target) return 1;
 					let num = 1,
 						ds = 2 + get.sgn(player.hp - target.hp);

--- a/character/xianding/skill.js
+++ b/character/xianding/skill.js
@@ -5737,7 +5737,7 @@ const skills = {
 				if (name != "phase") return false;
 			},
 			effect: {
-				target: (card, player, target) => {
+				target_use: (card, player, target) => {
 					if (player === target || typeof card !== "object" || get.color(card) !== "black") return;
 					if (target.hasSkill("jiu")) {
 						if (
@@ -8906,7 +8906,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: (card, player, target) => {
+				target_use: (card, player, target) => {
 					if (player === target) return;
 					if (
 						game.hasPlayer2(current => {
@@ -14985,7 +14985,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
+				target_use: function (card, player, target) {
 					if (get.itemtype(player) !== "player" || player === target) return 1;
 					let num = 1,
 						ds = 2 + get.sgn(player.hp - target.hp);

--- a/character/xianjian.js
+++ b/character/xianjian.js
@@ -287,7 +287,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						player: function (card, player) {
+						player_use(card, player) {
 							if (_status.currentPhase != player) return;
 							if (get.type(card) == "basic") return;
 							if (get.tag(card, "gain")) return;
@@ -1029,7 +1029,7 @@ game.import("character", function () {
 					reverseEquip: true,
 					threaten: 1.5,
 					effect: {
-						target: function (card, player, target, current) {
+						target_use(card, player, target, current) {
 							if (get.type(card) == "equip") return [1, 3];
 						},
 					},
@@ -4157,7 +4157,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target_use(card, player, target) {
 							if (
 								target.storage.xjzhimeng2 &&
 								get.type(card, "trick") == get.type(target.storage.xjzhimeng2, "trick")
@@ -4268,7 +4268,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target_use(card, player, target, current) {
 							if (target == player.next || target == player.previous) return 0.1;
 						},
 					},

--- a/character/xinghuoliaoyuan/skill.js
+++ b/character/xinghuoliaoyuan/skill.js
@@ -930,7 +930,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player_use: function (card, player, target) {
+						player_use(card, player, target) {
 							if (typeof card != "object" || !player.isPhaseUsing()) return;
 							var hasPanjun = game.hasPlayer(function (current) {
 								return (
@@ -1581,7 +1581,7 @@ const skills = {
 			pretao: true,
 			threaten: 1.8,
 			effect: {
-				player(card, player, target) {
+				player_use(card, player, target) {
 					if (
 						typeof card === "object" &&
 						card.name !== "shan" &&

--- a/character/yijiang/skill.js
+++ b/character/yijiang/skill.js
@@ -1609,7 +1609,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (target.isHealthy() || (card.name != "sha" && card.name != "juedou")) return;
 					if (target.storage.counttrigger && target.storage.counttrigger.yizu && current < 0) return 5;
 					if (player.hp < target.hp) return;
@@ -2495,7 +2495,7 @@ const skills = {
 		ai: {
 			threaten: 0.6,
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (typeof card != "object" || target.hasSkill("xindanshou_as") || !["basic", "trick"].includes(get.type(card, "trick"))) return;
 					var num = 0;
 					game.countPlayer2(function (current) {
@@ -4153,7 +4153,7 @@ const skills = {
 				return bool;
 			},
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (card.name == "sha" && current < 0) return 0.7;
 				},
 			},
@@ -4857,7 +4857,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (card.name == "sha" && get.attitude(player, target) < 0) {
 						return 0.3;
 					}
@@ -7307,7 +7307,7 @@ const skills = {
 				if (arg.target != player.storage.xinxianzhen) return false;
 			},
 			effect: {
-				player: function (card, player, target, current, isLink) {
+				player_use(card, player, target, current, isLink) {
 					if (isLink || !player.storage.xinxianzhen) return;
 					if (target != player.storage.xinxianzhen && ["sha", "guohe", "shunshou", "huogong", "juedou"].includes(card.name)) {
 						if (get.effect(player.storage.xinxianzhen, card, player, player) > 0) {
@@ -8350,7 +8350,7 @@ const skills = {
 		ai: {
 			respondShan: true,
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (get.tag(card, "respondShan") && current < 0) {
 						var nh = player.countCards("h");
 						var players = game.filterPlayer();
@@ -9547,7 +9547,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player_use: function (card, player, target) {
+						player_use(card, player, target) {
 							var list = player.storage.taoxi_list;
 							if (!list || !list[1]) return;
 							if (list[1].includes(card)) return [1, 1];
@@ -12069,7 +12069,7 @@ const skills = {
 		ai: {
 			expose: 0.2,
 			effect: {
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					if (card.name != "sha") return;
 					var players = game.filterPlayer();
 					if (get.attitude(player, target) <= 0) {
@@ -12787,7 +12787,7 @@ const skills = {
 				return arg && arg.jiu == true;
 			},
 			effect: {
-				target: (card, player, target) => {
+				target_use(card, player, target) {
 					if (target.hp <= 0 && target.hasSkill("zhenlie_lose") && get.tag(card, "recover")) return [1, 1.2];
 				},
 			},
@@ -12812,10 +12812,10 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target, current) {
+				target_use(card, player, target, current) {
 					if (get.type(card) == "trick" && player != target) return "zeroplayertarget";
 				},
-				player: function (card, player, target, current) {
+				player_use(card, player, target, current) {
 					if (get.type(card) == "trick" && player != target) return "zeroplayertarget";
 				},
 			},
@@ -12989,7 +12989,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
+				target_use(card, player, target) {
 					if (player == target && get.subtypes(card).includes("equip2")) {
 						if (get.equipValue(card) <= 8) return 0;
 					}

--- a/character/yijiang/skill.js
+++ b/character/yijiang/skill.js
@@ -11102,9 +11102,11 @@ const skills = {
 			player.draw();
 		},
 		ai: {
-			effect: function (card, player, target) {
-				if (get.type(card) == "trick") return [1, 1];
-			},
+			effect: {
+				target_use(card, player, target) {
+					if (get.type(card) == "trick" && player !== target) return [1, 1];
+				},
+			}
 		},
 	},
 	shenxing: {

--- a/character/yingbian/skill.js
+++ b/character/yingbian/skill.js
@@ -101,10 +101,16 @@ const skills = {
 			effect: {
 				player: function (card, player, target) {
 					if (!get.tag(card, "damage")) return;
-					if (!lib.card[card.name] || !card.cards || !card.cards.length) return [1, 0, 1, -1];
+					if (!lib.card[card.name] || !card.cards || !card.cards.length) return [1, 0, 2, 0];
+					return [1, -1];
+				},
+				target: function (card, player, target) {
+					if (!get.tag(card, "damage")) return;
+					if (!lib.card[card.name] || !card.cards || !card.cards.length) return 2;
 					return [1, -1];
 				},
 			},
+			halfneg: true
 		},
 		subSkill: {
 			effect: {

--- a/character/yingbian/skill.js
+++ b/character/yingbian/skill.js
@@ -597,7 +597,7 @@ const skills = {
 				onremove: true,
 				ai: {
 					effect: {
-						player: function (card, player, target) {
+						player_use(card, player, target) {
 							if (card.name == player.storage.xiongshu_ai) return "zeroplayertarget";
 						},
 					},

--- a/character/yxs.js
+++ b/character/yxs.js
@@ -1460,7 +1460,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target_use(card, player, target, current) {
 							if (get.type(card) == "trick" || card.name == "sha") return "zeroplayertarget";
 						},
 					},
@@ -1781,7 +1781,7 @@ game.import("character", function () {
 				ai: {
 					mingzhi: false,
 					effect: {
-						target: function (card, player, target) {
+						player_use(card, player, target) {
 							if (get.tag(card, "respondShan")) {
 								return 0.8;
 							}

--- a/character/zhuogui.js
+++ b/character/zhuogui.js
@@ -123,7 +123,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target_use(card, player, target, current) {
 							if (target.getEquip(2)) return;
 							return lib.skill.tengjia1.ai.effect.target.apply(this, arguments);
 						},

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -4587,20 +4587,10 @@ export class Get {
 			game.expandSkills(skills2);
 			for (var i = 0; i < skills2.length; i++) {
 				temp2 = get.info(skills2[i]).ai;
-				if (temp2 && temp2.threaten) temp3 = cache.delegate(temp2).threaten;
+				if (!temp2) continue;
+				if (temp2.threaten) temp3 = cache.delegate(temp2).threaten;
 				else temp3 = undefined;
-				if (temp2 && typeof temp2.effect == "function") {
-					if (
-						!player.hasSkillTag("ignoreSkill", true, {
-							card: card,
-							target: target,
-							skill: skills2[i],
-							isLink: isLink,
-						})
-					)
-						temp2 = cache.delegate(temp2).effect(card, player, target, result2, isLink);
-					else temp2 = undefined;
-				} else if (temp2 && typeof temp2.effect == "object" && typeof temp2.effect.target == "function") {
+				if (typeof temp2.effect == "object" && typeof temp2.effect.target == "function") {
 					if (
 						!player.hasSkillTag("ignoreSkill", true, {
 							card: card,
@@ -4610,6 +4600,18 @@ export class Get {
 						})
 					)
 						temp2 = cache.delegate(temp2.effect).target(card, player, target, result2, isLink);
+					else temp2 = undefined;
+				} else if (typeof temp2.effect == "function") { //考虑废弃
+					console.log("此写法使用频率极低且影响代码可读性，不建议使用");
+					if (
+						!player.hasSkillTag("ignoreSkill", true, {
+							card: card,
+							target: target,
+							skill: skills2[i],
+							isLink: isLink,
+						})
+					)
+						temp2 = cache.delegate(temp2).effect(card, player, target, result2, isLink);
 					else temp2 = undefined;
 				} else temp2 = undefined;
 				if (typeof temp2 == "object") {


### PR DESCRIPTION
### PR受影响的平台
所有平台


### 诱因和背景
刘辩【诗怨】effect范围过大



### PR描述
尝试将“使用牌指定为目标”“使用牌”“成为使用牌的目标”此类时机触发的技能ai.effect改为effect_use；
修复部分AI和描述bug；
部分技能标签补充；
为需要主公才能发动的技能增加available；
将函数类型的ai.effect改为ai.effect: {target(){}}，并将get.effect中此低频用法调后；
拆顺ai不再无懈没有牌的目标



### 扩展适配
建议将技能中函数类型的ai.effect展开为ai.effect: {target(){...}}



### 检查清单
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
