### PR TITLE
step转async：新袁术、张绣、旧陈到、严颜、王平、陆绩；修复自由选将搜索输入框的Bug

### DIFF
--- a/noname/ui/create/index.js
+++ b/noname/ui/create/index.js
@@ -2034,8 +2034,9 @@ export class Create {
 				}
 			}
 		};
-		input.addEventListener("keyup", (e) => {
+		input.addEventListener("keydown", (e) => {
 			if (e.key == "Enter") clickfind(e);
+			e.stopPropagation();
 		});
 		find.listen(clickfind);
 		Searcher.appendChild(input);

--- a/noname/ui/create/index.js
+++ b/noname/ui/create/index.js
@@ -2015,6 +2015,7 @@ export class Create {
 		input.style.borderRadius = "6px";
 		input.style.fontWeight = "bold";
 		input.style.fontSize = "21px";
+		input.placeholder = "支持正则搜索";
 		let find = ui.create.button(["find", "搜索"], "tdnodes");
 		find.style.display = "inline";
 		let clickfind = function (e) {


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有


### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
**诗笺喵的任务喵**
shenhua step转async
**Curpond的任务喵**
修复自由选将搜索输入框的bug，以及追加placeholder喵
详情 issue [#1350](https://github.com/libccy/noname/issues/1350)


### PR描述
<!-- 详细描述您的更改 -->
更改了 新袁术、张绣、旧陈到、严颜、王平、陆绩 这六个角色的技能喵
（其实还有两个技能，但是那两个技能没人用白改了（悲））
**追加**
修复自由选将搜索输入框的bug，以及追加placeholder喵


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
全部都使用了一遍技能喵
（那两个没有人用的技能没有测试哦，不过看了一下没有问题喵）
**追加**
测试了按键a和placeholder的显示没有问题
原本的enter响应也没有问题喵


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
