### PR TITLE
为新客户端的导入离线包/完整包功能提前做适配、优化升级协议时的观感、修改处理网页参数后重启的路径

### DIFF
--- a/game/entry.js
+++ b/game/entry.js
@@ -175,7 +175,8 @@ boot().then(() => {
 					})
 					.then(() => {
 						const url = new URL(location.href);
-						location.href = url.origin + url.pathname;
+						url.searchParams.delete("sendUpdate");
+						location.href = url.toString();
 					}).catch(e => {
 						if (navigator.notification) {
 							navigator.notification.activityStop();
@@ -189,7 +190,8 @@ boot().then(() => {
 				game.saveConfig(`extension_${value}_enable`, true);
 				alert(`扩展${value}已导入成功，点击确定重启游戏`);
 				const url = new URL(location.href);
-				location.href = url.origin + url.pathname;
+				url.searchParams.delete("importExtensionName");
+				location.href = url.toString();
 			}
 		}
 	}

--- a/game/entry.js
+++ b/game/entry.js
@@ -46,8 +46,14 @@ boot().then(() => {
 			3. 保存http/s协议的状态，以后不再以file协议启动
 		*/
 		// 导出数据到根目录的noname.config.txt
+		if (navigator.notification) {
+			navigator.notification.activityStart("正在进行升级", "请稍候");
+		}
 		let data;
 		let export_data = function (data) {
+			if (navigator.notification) {
+				navigator.notification.activityStop();
+			}
 			game.promises
 				.writeFile(
 					lib.init.encode(JSON.stringify(data)),
@@ -83,6 +89,9 @@ boot().then(() => {
 		for (let [key, value] of searchParams) {
 			// 成功导入后删除noname.config.txt
 			if (key === "sendUpdate" && value === "true") {
+				if (navigator.notification) {
+					navigator.notification.activityStart("正在导入旧版数据", "请稍候");
+				}
 				game.promises
 					.readFileAsText("noname.config.txt")
 					.then((data) => {
@@ -112,7 +121,10 @@ boot().then(() => {
 									}
 									return;
 								}
-								alert("导入成功, 即将自动重启");
+								if (navigator.notification) {
+									navigator.notification.activityStop();
+								}
+								alert("升级前的配置导入成功, 即将自动重启");
 								// @ts-ignore
 								if (!lib.db) {
 									const noname_inited =
@@ -164,6 +176,10 @@ boot().then(() => {
 					.then(() => {
 						const url = new URL(location.href);
 						location.href = url.origin + url.pathname;
+					}).catch(e => {
+						if (navigator.notification) {
+							navigator.notification.activityStop();
+						}
 					});
 			}
 			// 新客户端导入扩展

--- a/node_modules/@types/noname-typings/cordova-plugin-dialogs.d.ts
+++ b/node_modules/@types/noname-typings/cordova-plugin-dialogs.d.ts
@@ -55,6 +55,32 @@ interface Notification {
 		title?: string,
 		buttonLabels?: string[],
 		defaultText?: string): void;
+	
+	/**
+     * open an activity dialog
+     */
+	activityStart(title: string, message: string): void;
+	/**
+     * Close an activity dialog
+     */
+	activityStop(): void;
+	/**
+     * Display a progress dialog with progress bar that goes from 0 to 100.
+     *
+     * @param title Title of the progress dialog.
+     * @param message Message to display in the dialog.
+     */
+	progressStart(title: string, message: string): void;
+	/**
+     * Close the progress dialog.
+     */
+	progressStop(): void;
+	/**
+     * Set the progress dialog value.
+     *
+     * @param value 0-100
+     */
+	progressValue(value: number): void;
 }
 
 /** Object, passed to promptCallback */

--- a/noname/init/cordova.js
+++ b/noname/init/cordova.js
@@ -18,6 +18,11 @@ export async function cordovaReady() {
 				game.reload();
 			}
 		}, false);
+		window.addEventListener("importPackage", () => {
+			if (confirm(`离线包/完整包已导入成功，是否重启游戏？`)) {
+				game.reload();
+			}
+		}, false);
 		document.addEventListener("pause", function () {
 			if (!_status.paused2 && typeof _status.event.isMine == "function" && !_status.event.isMine()) {
 				ui.click.pause();


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
[为新客户端的导入离线包/完整包功能提前做适配](https://github.com/libccy/noname/commit/cf6ec448a9c50943d186db0c339353223dd0fef1)

[优化升级协议时的观感](https://github.com/libccy/noname/commit/79d833e15a0069b2b21da67c6982ee50858b31cf)

[修改处理网页参数后重启的路径](https://github.com/libccy/noname/commit/71afbe7028055ee884adb8fd0f29a2eb35c96f79)

### PR描述
<!-- 详细描述您的更改 -->
导入离线包后也加了弹窗提示
安卓升级协议时提供dialog提示
修改处理网页参数后重启的路径

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->



### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
