### PR TITLE
fix：将2024标准包修正为四象封印·少阴、醮影修复

### DIFF
--- a/character/standard/skill.js
+++ b/character/standard/skill.js
@@ -2,7 +2,7 @@ import { lib, game, ui, get, ai, _status } from "../../noname.js";
 
 /** @type { importCharacterConfig['skill'] } */
 const skills = {
-	//2024标包武将
+	//四象封印·少阴
 	//孙皓
 	stdcanshi: {
 		audio: "canshi",
@@ -836,7 +836,7 @@ const skills = {
 		},
 	},
 	stdzhanying: {
-		audio: "zhanying",
+		audio: "jiaoying",
 		trigger: { global: "damageBegin2" },
 		filter(event, player) {
 			if (_status.currentPhase !== player) return false;

--- a/character/standard/sort.js
+++ b/character/standard/sort.js
@@ -3,7 +3,7 @@ const characterSort = {
 	standard_2013: ["old_re_lidian", "huaxiong", "re_yuanshu"],
 	standard_2019: ["gongsunzan", "xf_yiji"],
 	standard_2023: ["std_panfeng", "ganfuren"],
-	standard_2024: ["std_sunhao", "std_mateng", "std_mayunlu", "std_jianggan", "std_zhouchu", "std_lvlingqi", "std_dc_yanghu", "std_dc_luotong", "std_lijue", "std_chengpu", "std_db_wenyang", "std_re_dengzhi", "std_zhangyì", "std_chengyu", "std_fanyufeng", "std_feiyi"],
+	standard_shaoyin: ["std_sunhao", "std_mateng", "std_mayunlu", "std_jianggan", "std_zhouchu", "std_lvlingqi", "std_dc_yanghu", "std_dc_luotong", "std_lijue", "std_chengpu", "std_db_wenyang", "std_re_dengzhi", "std_zhangyì", "std_chengyu", "std_fanyufeng", "std_feiyi"],
 };
 
 const characterSortTranslate = {
@@ -11,7 +11,7 @@ const characterSortTranslate = {
 	standard_2013: "2013版标准包",
 	standard_2019: "2019版标准包",
 	standard_2023: "2023版标准包",
-	standard_2024: "2024版标准包",
+	standard_shaoyin: "四象封印·少阴",
 };
 
 export { characterSort, characterSortTranslate };

--- a/character/standard/translate.js
+++ b/character/standard/translate.js
@@ -235,7 +235,7 @@ const translates = {
 	stdyibing_info: "一名角色进入濒死状态时，你可以获得其一张牌。",
 	stdbazhan: "把盏",
 	stdbazhan_info: "出牌阶段限一次，你可以交给一名男性角色一张手牌，然后其可以交给你一张与此牌类别不同的牌。",
-	stdzhanying: "蘸影",
+	stdzhanying: "醮影",
 	stdzhanying_info: "锁定技，你的回合内，手牌数比回合开始时多的角色不能使用红色牌且受到的伤害+1。",
 	stdtiaohe: "调和",
 	stdtiaohe_info: "出牌阶段限一次，你可以弃置场上的一张装备牌和一张防具牌（不能为同一名角色装备区的牌）。",


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有平台

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
无


### PR描述
<!-- 详细描述您的更改 -->
fix：将2024标准包修正为四象封印·少阴、醮影修复
（虽然个人觉得拆出来比较好，但标准版强度武将放标准包里也说得过去）

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
通过


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需适配


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [ ] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
