### PR TITLE
修复诸神降临扩展祭风卧龙体力上限异常的问题

### DIFF
--- a/mode/boss.js
+++ b/mode/boss.js
@@ -1327,7 +1327,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				boss_zhugeliang: [
 					"male",
 					"shen",
-					Infinity,
+					"Infinity/Infinity",
 					["xiangxing", "yueyin", "fengqi", "gaiming"],
 					["shu", "boss", "bossallowed"],
 					"qun",


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有平台

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
诸神降临扩展中的祭风卧龙体力上限异常，为零而非无限大。


### PR描述
<!-- 详细描述您的更改 -->
把Infinity标签换成了字符串

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
测过了，没问题


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
不需要


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
