### PR TITLE
补充一个sandbox的问题；同时为调试模式和苹果设备放宽；适配eruda

### DIFF
--- a/noname/init/index.js
+++ b/noname/init/index.js
@@ -125,9 +125,6 @@ export async function boot() {
 	// 加载polyfill内容
 	await import("./polyfill.js");
 
-	// 初始化沙盒的Realms
-	await initializeSandboxRealms();
-
 	// 设定游戏加载时间，超过时间未加载就提醒
 	const configLoadTime = localStorage.getItem(lib.configprefix + "loadtime");
 	// 现在不暴露到全局变量里了，直接传给onload
@@ -248,13 +245,6 @@ export async function boot() {
 		}
 	}
 
-	// 初始化security
-	const securityModule = await import("../util/security.js");
-	const security = securityModule.default;
-	security.initSecurity({
-		lib, game, ui, get, ai, _status, gnc,
-	});
-
 	const loadCssPromise = loadCss();
 	const loadConfigPromise = loadConfig();
 	await loadCssPromise;
@@ -302,6 +292,18 @@ export async function boot() {
 			delete window.noname_asset_list;
 		}
 	}
+
+	const sandboxEnabled = !config.get("debug") && !get.is.safari();
+
+	// 初始化沙盒的Realms
+	await initializeSandboxRealms(sandboxEnabled);
+
+	// 初始化security
+	const securityModule = await import("../util/security.js");
+	const security = securityModule.default;
+	security.initSecurity({
+		lib, game, ui, get, ai, _status, gnc,
+	});
 
 	if (Reflect.get(window, "isNonameServer")) config.set("mode", "connect");
 

--- a/noname/util/initRealms.js
+++ b/noname/util/initRealms.js
@@ -1,5 +1,6 @@
-// 为了兼容无法使用顶级await的版本
-const iframe = document.createElement("iframe");
+// 方便开关确定沙盒的问题喵
+// 当此处为true、debug模式为启用、设备非苹果时，沙盒生效
+let SANDBOX_ENABLED = true;
 
 // 执行上下文传递函数，请勿动喵
 // 用于传递顶级execute context
@@ -38,7 +39,12 @@ function replaceName(path, name) {
 const TARGET_URL = replaceName(import.meta.url, "sandbox.js");
 const SANDBOX_EXPORT = {};
 
-async function initializeSandboxRealms() {
+async function initializeSandboxRealms(enabled) {
+    if (!enabled) {
+        SANDBOX_ENABLED = false;
+        return;
+    }
+
     const document = window.document;
     const createElement = document.createElement.bind(document);
     const appendChild = document.body.appendChild.bind(document.body);
@@ -86,10 +92,6 @@ async function initializeSandboxRealms() {
     script.src = TARGET_URL;
     script.type = "module";
 
-    // 无法同步载入
-    // script.async = false;
-    // script.defer = false;
-
     const promise = new Promise((resolve, reject) => {
         script.onload = resolve;
         script.onerror = reject;
@@ -111,7 +113,12 @@ async function initializeSandboxRealms() {
     iframe.remove();
 }
 
+function isSandboxEnabled() {
+    return SANDBOX_ENABLED;
+}
+
 export {
     initializeSandboxRealms,
+    isSandboxEnabled,
     SANDBOX_EXPORT,
 };

--- a/noname/util/sandbox.js
+++ b/noname/util/sandbox.js
@@ -7,7 +7,7 @@
 
 // 最后为安全考虑，请遵守规范，尽量不要使用 `eval` 函数而是使用 `security.exec2` 来替代
 
-import { SANDBOX_EXPORT } from "./initRealms.js";
+import { SANDBOX_EXPORT, isSandboxEnabled } from "./initRealms.js";
 
 // 很重要的事情！
 // 请不要在在其他文件中import sandbox.js！
@@ -16,8 +16,8 @@ import { SANDBOX_EXPORT } from "./initRealms.js";
 
 /** @typedef {any} Window */
 
-// 方便开关确定沙盒的问题喵
-const SANDBOX_ENABLED = true;
+// 新的开关放到了 "./initRealms.js" 里面，请不要改动此处！
+const SANDBOX_ENABLED = isSandboxEnabled();
 
 // 暴露方法Symbol，用于类之间通信
 const SandboxExposer = Symbol("Sandbox.Exposer"); // 实例暴露

--- a/noname/util/security.js
+++ b/noname/util/security.js
@@ -2,7 +2,7 @@
 // 但沙盒不会也没有办法维护恶意服务器/房主对于游戏规则的破坏，请玩家尽量选择官方或其他安全的服务器，同时选择一个受信任的玩家作为房主
 
 // 是否强制所有模式下使用沙盒
-const SANDBOX_FORCED = false;
+const SANDBOX_FORCED = true;
 // 是否启用自动测试
 const SANDBOX_AUTOTEST = false;
 // 是否禁用自动测试延迟

--- a/noname/util/security.js
+++ b/noname/util/security.js
@@ -2,7 +2,7 @@
 // 但沙盒不会也没有办法维护恶意服务器/房主对于游戏规则的破坏，请玩家尽量选择官方或其他安全的服务器，同时选择一个受信任的玩家作为房主
 
 // 是否强制所有模式下使用沙盒
-const SANDBOX_FORCED = true;
+const SANDBOX_FORCED = false;
 // 是否启用自动测试
 const SANDBOX_AUTOTEST = false;
 // 是否禁用自动测试延迟


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有
**追加**
有针对Safari（苹果）的内容
**追加**
所有


### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
之前的情况还是可能被渗透，选择简化代码牺牲微小的兼容性来妥协安全性
**追加**
应狂神的要求，追加对于调试模式下禁用沙盒的功能
可能由于对于苹果的不兼容性，对苹果禁用沙盒功能（另外苹果的安全本身也很抗打）
（上面两种禁用沙盒依然保留防注入的功能）
**追加**
因萌喵说eruda载入有问题，特地对eruda进行优化


### PR描述
<!-- 详细描述您的更改 -->
简化一下eval，用最朴实的方法来适配大部分情况
牺牲了沙盒启用的情况下，在eval、new function、parsex等编译代码内（沙盒代码内），当再嵌套使用eval执行代码时的部分兼容性，以此来提高安全性（对于此类情况下eval最常规的使用还是做了适配，但是过于阴间的写法放弃兼容了）
（另外之前没有关闭全模式沙盒哦现在补一下_(:з」∠)_）
**追加**
调整了沙盒的载入顺序，并先确认调试模式与苹果设备再决定是否载入
**追加**
让封送代理的空白对象行为与目标对象保持一致以适应js严格的代理检查（适配eruda的用法）
添加hasInstance的封送映射，确保instanceof正常工作（适配eruda的用法）


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
新代码影响了游戏内控制台，通过控制台执行了多条代码确认工作正常
**追加**
调试模式可以影响沙盒的载入，测试通过
苹果的判断依赖于```get.is.safari()```，暂未测试，但是如果```get.is.safari()```在```boot```中正常工作那么应该与调试模式的效果相同
**追加**
对于eruda的载入和基本使用已经在电脑与安卓上测试完毕

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
暂无
**追加**
暂无


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
