### PR TITLE
优化〖博览〗、〖挈挟〗的字段筛选机制

### DIFF
--- a/character/extra/skill.js
+++ b/character/extra/skill.js
@@ -1438,7 +1438,7 @@ const skills = {
 				var info = lib.character[name];
 				if (
 					info[3].some(function (skill) {
-						var info = get.skillInfoTranslation(skill);
+						var info = get.plainText(get.skillInfoTranslation(skill));
 						if (!info.includes("【杀】")) return false;
 						var list = get.skillCategoriesOf(skill, player);
 						list.remove("锁定技");
@@ -1470,7 +1470,7 @@ const skills = {
 						var name = button.link;
 						var info = lib.character[name];
 						var skills = info[3].filter(function (skill) {
-							var info = get.skillInfoTranslation(skill);
+							var info = get.plainText(get.skillInfoTranslation(skill));
 							if (!info.includes("【杀】")) return false;
 							var list = get.skillCategoriesOf(skill, get.player());
 							list.remove("锁定技");
@@ -1509,7 +1509,7 @@ const skills = {
 			node = ui.create.buttonPresets.character(item, "character", position, noclick);
 			const info = lib.character[item];
 			const skills = info[3].filter(function (skill) {
-				var info = get.skillInfoTranslation(skill);
+				var info = get.plainText(get.skillInfoTranslation(skill));
 				if (!info.includes("【杀】")) return false;
 				var list = get.skillCategoriesOf(skill, get.player());
 				list.remove("锁定技");
@@ -1588,7 +1588,7 @@ const skills = {
 				var maxHp = get.infoMaxHp(info[2]);
 				if (maxHp != 1) card.distance = { attackFrom: 1 - maxHp };
 				var skills = info[3].filter(function (skill) {
-					var info = get.skillInfoTranslation(skill);
+					var info = get.plainText(get.skillInfoTranslation(skill));
 					if (!info.includes("【杀】")) return false;
 					var list = get.skillCategoriesOf(skill, get.player());
 					list.remove("锁定技");
@@ -1617,10 +1617,10 @@ const skills = {
 				if (skills.length) {
 					for (var skill of skills) {
 						if (lib.skill[skill].nobracket) {
-							append += '<div class="skilln">' + get.translation(skill) + '</div><div><span style="font-family: yuanli">' + get.skillInfoTranslation(skill) + "</span></div><br><br>";
+							append += '<div class="skilln">' + get.translation(skill) + '</div><div><span style="font-family: yuanli">' + get.plainText(get.skillInfoTranslation(skill)) + "</span></div><br><br>";
 						} else {
 							var translation = lib.translate[skill + "_ab"] || get.translation(skill).slice(0, 2);
-							append += '<div class="skill">【' + translation + '】</div><div><span style="font-family: yuanli">' + get.skillInfoTranslation(skill) + "</span></div><br><br>";
+							append += '<div class="skill">【' + translation + '】</div><div><span style="font-family: yuanli">' + get.plainText(get.skillInfoTranslation(skill)) + "</span></div><br><br>";
 						}
 					}
 					str = str.slice(0, str.length - 8);

--- a/character/yingbian/skill.js
+++ b/character/yingbian/skill.js
@@ -1750,7 +1750,7 @@ const skills = {
 					var skill = lib.skill[j];
 					if (!skill || skill.juexingji || skill.hiddenSkill || skill.zhuSkill || skill.dutySkill || skill.chargeSkill || lib.skill.bolan.banned.includes(j)) continue;
 					if (skill.init || (skill.ai && (skill.ai.combo || skill.ai.notemp || skill.ai.neg))) continue;
-					var info = lib.translate[j + "_info"];
+					var info = get.plainText(lib.translate[j + "_info"]);
 					if (info && info.indexOf("出牌阶段限一次") != -1) skills.add(j);
 				}
 			}

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -343,6 +343,23 @@ export class Get {
 		if (info.categories) list.addArray(info.categories(skill, player));
 		return list;
 	}
+	/**
+	 * 用于将HTML代码转换为纯文本。
+	 * @param {string} str 
+	 * @returns { string }
+	 */
+	plainText(str) {
+		if (!window.noname_plainText) {
+			window.noname_plainText = document.createElement('div');
+		}
+		var node = window.noname_plainText;
+		if(str){
+			node.innerHTML = str;
+		} else {
+			node.innerHTML = '';
+		}
+		return node.innerText;
+	}
 	numOf(obj, item) {
 		return obj.filter(element => element == item).length;
 	}

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -349,10 +349,10 @@ export class Get {
 	 * @returns { string }
 	 */
 	plainText(str) {
-		if (!window.noname_plainText) {
-			window.noname_plainText = document.createElement('div');
+		if (!window.noname_get_plainText) {
+			window.noname_get_plainText = document.createElement('div');
 		}
-		var node = window.noname_plainText;
+		var node = window.noname_get_plainText;
 		if(str){
 			node.innerHTML = str;
 		} else {

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -345,20 +345,13 @@ export class Get {
 	}
 	/**
 	 * 用于将HTML代码转换为纯文本。
-	 * @param {string} str 
+	 * @param { string } htmlContent
 	 * @returns { string }
 	 */
-	plainText(str) {
-		if (!window.noname_get_plainText) {
-			window.noname_get_plainText = document.createElement('div');
-		}
-		var node = window.noname_get_plainText;
-		if(str){
-			node.innerHTML = str;
-		} else {
-			node.innerHTML = '';
-		}
-		return node.innerText;
+	plainText(htmlContent) {
+		var parser = new DOMParser();
+		var doc = parser.parseFromString(htmlContent || '', 'text/html');
+		return doc.body.textContent || doc.body.innerText;
 	}
 	numOf(obj, item) {
 		return obj.filter(element => element == item).length;


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有平台

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
以神典韦的〖挈挟〗作为例子，某些扩展中存在类似于下面的技能描述：
`①每回合每个字数限一次，你可将一张手牌作为与其字数相同、牌名不同的基本、装备、普通锦囊牌（【<a style='color:#FF0000' href="javascript:get.sbzz_daskillTips('①不能以此法转换为赠物<br/>②以此法使用的装备牌会改变名字，进入手牌区时恢复<br/>③装备牌印装备牌会同时拥有两牌的技能，加一、减一、武器的距离效果并不算技能</i> </b><br/>④注意：失去牌的效果，因为牌名改变所以不会触发，拓展卡牌失去效果如果写的代码不检查牌名的话就会生效，顺带一提，专属卡牌【刀】的失去效果也可以触发<br/><br/><b>专属卡牌：【刀】</b><br/>①若此牌的实体牌为【杀】则视为武器；【闪】则视为防具；【桃】则视为防御马；【酒】则视为进攻马。均不是，视为宝物<br/>②失去此牌时令【摘铸】已使用的最大的字数视为未使用过，然后可以令一名其他角色随机弃置两张牌，不足则全弃并视为对其使用一张【杀】','0');">印卡规则</a>】）使用或打出。②准备阶段，你摸2+2x张牌（x为你的体力上限减手牌数，至少为0、至多为2）然后获得装备区中所有牌。`
此技能描述实际显示为：
`①每回合每个字数限一次，你可将一张手牌作为与其字数相同、牌名不同的基本、装备、普通锦囊牌（【印卡规则】）使用或打出。②准备阶段，你摸2+2x张牌（x为你的体力上限减手牌数，至少为0、至多为2）然后获得装备区中所有牌。`
按照〖挈挟〗原先的筛选方法会将此技能误认为含有“【杀】”的描述，尽管实际显示的文本中并没有。

### PR描述
<!-- 详细描述您的更改 -->
添加新函数`get.plainText`以将HTML代码转换为纯文本，并应用该函数到〖博览〗、〖挈挟〗的字段筛选机制中。


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
小测过神典韦的，神典韦那边没啥问题，但没测过钟琰的，可能会被拷打。


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
不需要


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
