### PR TITLE
适配寻找subSkill中chooseButton+backup类技能的源头技能

### DIFF
--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -7220,6 +7220,7 @@ export class Game {
 				const iValue = `${i}_${value}`;
 				lib.skill[iValue] = info.subSkill[value];
 				lib.skill[iValue].sub = true;
+				if (!info.subSkill[value].sourceSkill) lib.skill[iValue].sourceSkill = i;
 				if (info.subSkill[value].name) lib.translate[iValue] = info.subSkill[value].name;
 				else lib.translate[iValue] = lib.translate[iValue] || lib.translate[i];
 				if (info.subSkill[value].description) lib.translate[`${iValue}_info`] = info.subSkill[value].description;

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -3682,7 +3682,7 @@ export const Content = {
 					info.chooseControl ? result : result.links,
 					player
 				);
-				lib.skill[event.buttoned + "_backup"].sourceSkill = event.buttoned;
+				lib.skill[event.buttoned + "_backup"].sourceSkill = lib.skill[event.buttoned].sourceSkill ? lib.skill[event.buttoned].sourceSkill : event.buttoned;
 				if (game.online) {
 					event._sendskill = [event.buttoned + "_backup", lib.skill[event.buttoned + "_backup"]];
 				} else {
@@ -3894,7 +3894,7 @@ export const Content = {
 					info.chooseControl ? result : result.links,
 					player
 				);
-				lib.skill[event.buttoned + "_backup"].sourceSkill = event.buttoned;
+				lib.skill[event.buttoned + "_backup"].sourceSkill = lib.skill[event.buttoned].sourceSkill ? lib.skill[event.buttoned].sourceSkill : event.buttoned;
 				if (game.online) {
 					event._sendskill = [event.buttoned + "_backup", lib.skill[event.buttoned + "_backup"]];
 				} else {


### PR DESCRIPTION
### PR受影响的平台
所有平台
### 诱因和背景
因现本体存在很多于subSkill中的chooseButton+backup类技能，这些技能的sourceSkill仅能定位至此子技能，故而对所有未写sourceSkill的子技能默认赋予此属性，并对`chooseToUse`和`chooseToRespond`函数进行修改，使得能读取至多两层sourceSkill（反正也读不到第三层）
### PR测试
已测试已通过
### 扩展适配
修改了`game.finishSkill`和`chooseToUse`、`chooseToRespond`（多为后两者）的扩展需要进行适配
### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
