### PR TITLE
game.resume/resume2函数对async event的兼容判断,修复通过server.exe启动的网页端创建扩展不保存为文件和编辑武将图片不显示的bug

### DIFF
--- a/character/shenhua/skill.js
+++ b/character/shenhua/skill.js
@@ -4414,7 +4414,8 @@ const skills = {
 				next = switchToAuto();
 			}
 			const result = await next;
-			_status.paused = false; // 恢复 game.loop 但不立刻执行
+			// _status.paused = false; // 恢复 game.loop 但不立刻执行
+			game.resume();
 			result.logged = event.logged;
 			event.result = {
 				bool: result.bool,

--- a/node_modules/@types/noname-typings/nonameModules/noname/get/index.d.ts
+++ b/node_modules/@types/noname-typings/nonameModules/noname/get/index.d.ts
@@ -252,9 +252,10 @@ export class Get {
      * ```
      *
      * @param {string} str
+     * @param {boolean} log
      * @returns {string}
      */
-    pureFunctionStr(str: string): string;
+    pureFunctionStr(str: string, log?: boolean): string;
     funcInfoOL(func: any): any;
     infoFuncOL(info: any): any;
     eventInfoOL(item: any, level: any, noMore: any): string;

--- a/node_modules/@types/noname-typings/nonameModules/noname/library/element/player.d.ts
+++ b/node_modules/@types/noname-typings/nonameModules/noname/library/element/player.d.ts
@@ -843,7 +843,7 @@ export class Player extends HTMLDivElement {
      * @param {Parameters<this['iterableGetCards']>[0]} arg1
      * @param {Parameters<this['iterableGetCards']>[1]} arg2
      */
-    iterableGetGainableCards(player: Parameters<import("../index.js").Library['filter']['canBeGained']>[1], arg1: Parameters<this['iterableGetCards']>[0], arg2: Parameters<this['iterableGetCards']>[1]): Generator<any, void, unknown>;
+    iterableGetGainableCards(player: any, arg1: Parameters<this['iterableGetCards']>[0], arg2: Parameters<this['iterableGetCards']>[1]): Generator<any, void, unknown>;
     /**
      *
      * @param {Parameters<this['iterableGetGainableCards']>[0]} player

--- a/node_modules/@types/noname-typings/nonameModules/noname/status/index.d.ts
+++ b/node_modules/@types/noname-typings/nonameModules/noname/status/index.d.ts
@@ -1,7 +1,10 @@
 export class status {
     paused: boolean;
     paused2: boolean;
-    paused3: boolean;
+    /**
+     * @type { boolean | "paused" }
+     */
+    paused3: boolean | "paused";
     over: boolean;
     clicked: boolean;
     auto: boolean;

--- a/node_modules/@types/noname-typings/nonameModules/noname/util/error.d.ts
+++ b/node_modules/@types/noname-typings/nonameModules/noname/util/error.d.ts
@@ -88,8 +88,56 @@ export class ErrorReporter {
     #private;
 }
 export class ErrorManager {
+    /** @type {WeakMap<Function, CodeSnippet>} */
+    static "__#4@#codeSnippets": WeakMap<Function, CodeSnippet>;
     /** @type {WeakMap<Object, ErrorReporter>} */
     static "__#4@#errorReporters": WeakMap<any, ErrorReporter>;
+    /**
+     * ```plain
+     * 获取函数对应的代码片段
+     * ```
+     *
+     * @param {Function} func
+     * @returns {CodeSnippet?}
+     */
+    static getCodeSnippet(func: Function): CodeSnippet | null;
+    /**
+     * ```plain
+     * 设置函数对应的代码片段
+     * ```
+     *
+     * @param {Function} func
+     * @param {CodeSnippet} snippet
+     */
+    static setCodeSnippet(func: Function, snippet: CodeSnippet): WeakMap<Function, CodeSnippet>;
+    /**
+     * ```plain
+     * 获取一个错误的堆栈层数
+     * ```
+     *
+     * @param {Error} error
+     * @returns {number?}
+     */
+    static "__#4@#getStackLevel": (error: Error) => number | null;
+    /**
+     * ```plain
+     * 封装被设定了代码片段函数的错误捕获调用
+     *
+     * 当 `body` 函数在它这一层调用栈中出现错误时
+     * 此函数将自动记录此次错误信息并整理相关代码片段
+     * ```
+     * @example
+     * ```javascript
+     * ErrorManager.errorHandle(() => {
+     *     event.content(...);
+     * }, event.content);
+     * ```
+     *
+     * @param {Function} action 调用函数的闭包
+     * @param {Function} body 实际被调用的函数，同时也是持有代码片段的函数
+     * @param {number} extraLevel action调用到body的间隔调用栈层数
+     */
+    static errorHandle(action: Function, body: Function, extraLevel?: number): void;
     /**
      * ```plain
      * 设置错误报告器
@@ -98,9 +146,64 @@ export class ErrorManager {
      * ```
      *
      * @param {Object} obj
+     * @param {ErrorReporter|CodeSnippet|null} reporter
+     *
+     * @overload
+     * @param {Object} obj
+     *
+     * @overload
+     * @param {Object} obj
      * @param {ErrorReporter?} reporter
+     *
+     * @overload
+     * @param {Object} obj
+     * @param {CodeSnippet?} codeSnippet
      */
-    static setErrorReporter(obj: any, reporter?: ErrorReporter | null): void;
+    static setErrorReporter(obj: any): any;
+    /**
+     * ```plain
+     * 设置错误报告器
+     *
+     * 在报告错误时可以从此处获取错误报告器来直接报告错误
+     * ```
+     *
+     * @param {Object} obj
+     * @param {ErrorReporter|CodeSnippet|null} reporter
+     *
+     * @overload
+     * @param {Object} obj
+     *
+     * @overload
+     * @param {Object} obj
+     * @param {ErrorReporter?} reporter
+     *
+     * @overload
+     * @param {Object} obj
+     * @param {CodeSnippet?} codeSnippet
+     */
+    static setErrorReporter(obj: any, reporter: ErrorReporter | null): any;
+    /**
+     * ```plain
+     * 设置错误报告器
+     *
+     * 在报告错误时可以从此处获取错误报告器来直接报告错误
+     * ```
+     *
+     * @param {Object} obj
+     * @param {ErrorReporter|CodeSnippet|null} reporter
+     *
+     * @overload
+     * @param {Object} obj
+     *
+     * @overload
+     * @param {Object} obj
+     * @param {ErrorReporter?} reporter
+     *
+     * @overload
+     * @param {Object} obj
+     * @param {CodeSnippet?} codeSnippet
+     */
+    static setErrorReporter(obj: any, codeSnippet: CodeSnippet | null): any;
     /**
      * ```plain
      * 获取设置的错误报告器

--- a/node_modules/@types/noname-typings/nonameModules/noname/util/sandbox.d.ts
+++ b/node_modules/@types/noname-typings/nonameModules/noname/util/sandbox.d.ts
@@ -51,7 +51,7 @@ export class AccessAction {
 export class Rule {
     /**
      * ```plain
-     * 检查当前是否是 Monitor 所属的运行域
+     * 检查当前是否是 Rule 所属的运行域
      * ```
      *
      * @param {Rule} thiz
@@ -614,15 +614,13 @@ export class Domain {
     static "__#11@#domainLinks": Array<any>;
     /**
      * ```plain
-     * 替代 Array.isArray 并暴露给外部
-     * 确保 Array.isArray 对代理数组放宽
+     * 检查对象是否是Promise对象
      * ```
      *
-     * @param {Domain} domain
-     * @param {any} array
+     * @param {Error?} error
      * @returns {boolean}
      */
-    static "__#11@#isArray": (domain: Domain, array: any) => boolean;
+    static isError(error: Error | null): boolean;
     /**
      * @param {Domain} domain
      */

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -5908,6 +5908,8 @@ export class Game {
 			}
 			_status.paused = false;
 			delete _status.waitingForTransition;
+			if (_status.event && _status.event.content instanceof AsyncFunction ||
+				Array.isArray(_status.event.contents)) return;
 			game.loop();
 		}
 	}
@@ -5915,6 +5917,8 @@ export class Game {
 		if (_status.connectMode) return;
 		if (_status.paused2) {
 			_status.paused2 = false;
+			if (_status.event && _status.event.content instanceof AsyncFunction ||
+				Array.isArray(_status.event.contents)) return;
 			game.loop();
 		}
 	}

--- a/noname/init/index.js
+++ b/noname/init/index.js
@@ -1167,7 +1167,9 @@ async function setOnError() {
 		Reflect.set(window, "eo", err);
 		if (promiseErrorHandler.onErrorFinish) promiseErrorHandler.onErrorFinish();
 		// @ts-ignore
-		if (!lib.config.errstop && (_status && _status.event && !(_status.event.content instanceof AsyncFunction))) {
+		if (!lib.config.errstop && _status && _status.event) {
+			if (_status.event.content instanceof AsyncFunction ||
+				Array.isArray(_status.event.contents)) return;
 			_status.withError = true;
 			game.loop();
 		}

--- a/noname/status/index.js
+++ b/noname/status/index.js
@@ -3,6 +3,9 @@ import { lib } from "../library/index.js";
 export class status {
 	paused = false;
 	paused2 = false;
+	/**
+	 * @type { boolean | "paused" }
+	 */
 	paused3 = false;
 	over = false;
 	clicked = false;

--- a/noname/ui/create/menu/pages/exetensionMenu.js
+++ b/noname/ui/create/menu/pages/exetensionMenu.js
@@ -832,7 +832,7 @@ export const extensionMenu = function (connectMenu) {
 								};
 								img.src = data;
 							};
-							if (game.download) {
+							if (game.readFile) {
 								var url = lib.assetURL + "extension/" + name + "/" + file;
 								createButton(i, url);
 								if (lib.device == "ios" || lib.device == "android") {
@@ -1418,7 +1418,7 @@ export const extensionMenu = function (connectMenu) {
 								};
 								img.src = data;
 							};
-							if (game.download) {
+							if (game.readFile) {
 								var url = lib.assetURL + "extension/" + name + "/" + file;
 								createButton(i, url, fullskin);
 								if (lib.device == "ios" || lib.device == "android") {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,3 +1,4 @@
+/// <reference lib="WebWorker" />
 /**
  * @type { ServiceWorkerGlobalScope } 提供ServiceWorker的代码提示
  */


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
game.resume/resume2函数对async event的兼容判断
修复通过server.exe启动的网页端创建扩展不保存为文件和编辑武将图片不显示的bug

### PR描述
<!-- 详细描述您的更改 -->
game.resume/resume2函数对async event的兼容判断

修复ServiceWorkerGlobalScope类型提示失效的问题

跟进typings

修复通过server.exe启动的网页端创建扩展不保存为文件和编辑武将图片不显示的bug
[解决了这个issue](https://github.com/libccy/noname/issues/1346)

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
无


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [ ] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [ ] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
