### PR TITLE
适当左移“显示剩余牌数"以支持全面屏手机完整显示

### DIFF
--- a/layout/default/layout.css
+++ b/layout/default/layout.css
@@ -714,7 +714,7 @@ table {
 }
 .touchinfo.right {
 	left: auto;
-	right: 0;
+	right: 14px;
 	text-align: right;
 }
 #window.touchinfohidden > .touchinfo {


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
手机端


### 诱因和背景
全面屏右上角剩余牌数显示不全



### PR描述
调整只影响手机端的.touchinfo.right样式



### PR测试
打开游戏肉眼观察



### 扩展适配
无需适配



### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
