### PR TITLE
bugfix: 修正pureFunctionStr，可以接受解构参数

### DIFF
--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -1508,10 +1508,34 @@ export class Get {
 	infoPlayersOL(infos) {
 		return Array.from(infos || []).map(get.infoPlayerOL);
 	}
-	/** 箭头函数头 */
-	#arrowPattern = /^(?:async\b\s*)?(?:([\w$]+)|\((\s*[\w$]+(?:\s*=\s*.+?)?(?:\s*,\s*[\w$]+(?:\s*=\s*.+?)?)*\s*)?\))\s*=>/;
-	/** 标准函数头 */
-	#fullPattern = /^([\w\s*]+)\((\s*[\w$]+(?:\s*=\s*.+?)?(?:\s*,\s*[\w$]+(?:\s*=\s*.+?)?)*\s*)?\)\s*\{/;
+	/** @type {RegExp} */
+	#specialHeadPattern = /^(?:async)?\s+[\w$]+\s*=>/;
+	/** @type {RegExp} */
+	#functionHeadPattern = /^(?:async\b\s*)?(?:function\b\s*)?(?:\*\s*)?(?:[\w$]+\b\s*)?\(/;
+	/** @type {RegExp} */
+	#illegalFunctionHeadPattern = /^(?:async\b\s*)?\*\s*\(/;
+	/** @type {RegExp} */
+	#functionNeckPattern = /^\)\s*(?:=>\s*\{|=>|\{)/;
+	/** @type {RegExp} */
+	#identifierPattern = /\b[\w$]+\b/;
+	/** @type {RegExp} */
+	#asyncHeadPattern = /^async[\s\*\(]/;
+	/**
+	 * ```plain
+	 * 测试一段代码是否为函数参数列表
+	 * ```
+	 * 
+	 * @param {string} paramstr
+	 */
+	isFunctionParam(paramstr) {
+		if (paramstr.length == 0) return true;
+		try {
+			new Function(paramstr, "");
+			return true;
+		} catch (e) {
+			return false;
+		}
+	}
 	/**
 	 * ```plain
 	 * 测试一段代码是否为函数体
@@ -1523,7 +1547,7 @@ export class Get {
 	 * @param {FunctionType} type 
 	 * @returns {boolean} 
 	 */
-	isFunctionBody(code, type = null) {
+	isFunctionBody(code, type = /* (function(){return null})() */ null) {
 		if (type == "any") {
 			return ["async", "generator", "agenerator", null]
 				// @ts-ignore // 突然发现ts-ignore也挺方便的喵
@@ -1559,39 +1583,109 @@ export class Get {
 	 * @returns {string} 
 	 */
 	pureFunctionStr(str, log = false) {
+		const emptyFunction = "function () {}";
 		str = str.trim();
-		const arrowMatch = get.#arrowPattern.exec(str);
-		if (arrowMatch) {
-			let body = str.slice(arrowMatch[0].length).trim();
+		// 对于特殊的箭头函数特殊处理: identifier => ...
+		const specialMatch = get.#specialHeadPattern.exec(str);
+		if (specialMatch) {
+			let body = str.slice(specialMatch[0].length).trim();
 			if (body.startsWith("{") && body.endsWith("}")) body = body.slice(1, -1);
 			else body = `return ${body}`;
 			if (!get.isFunctionBody(body, "any")) {
-				if (log) console.error("发现疑似恶意的远程代码:", str);
-				return `()=>{}`;
+				if (log) console.warn("发现无法识别的远程代码:", str);
+				return emptyFunction;
 			}
-			return `${arrowMatch[0]}{${body}}`;
+			return `${specialMatch[0]}{${body}}`;
 		}
-		if (!str.endsWith("}")) {
+		// 匹配函数头
+		const functionHead = get.#functionHeadPattern.exec(str);
+		if (!functionHead) {
 			if (log) console.warn("发现无法识别的远程代码:", str);
-			return '()=>{}';
+			return emptyFunction;
 		}
-		const fullMatch = get.#fullPattern.exec(str);
-		if (!fullMatch) {
+		// 检查非法函数头
+		if (get.#illegalFunctionHeadPattern.test(functionHead[0])) {
 			if (log) console.warn("发现无法识别的远程代码:", str);
-			return '()=>{}';
+			return emptyFunction;
 		}
-		const head = fullMatch[1];
-		const args = fullMatch[2] || '';
-		const body = str.slice(fullMatch[0].length).slice(0, -1);
-		if (!get.isFunctionBody(body, "any")) {
-			if (log) console.error("发现疑似恶意的远程代码:", str);
-			return '()=>{}';
+		// 遍历字符串来寻找参数列表的关闭括号
+		const headLen = functionHead[0].length;
+		let start = headLen;
+		let foundClose;
+		let verifiedParams = null;
+		while ((foundClose = str.indexOf(")", start)) >= 0) {
+			const tempParams = str.slice(headLen, foundClose);
+			// 检查收集到的参数列表是否是有效的
+			if (get.isFunctionParam(tempParams)) {
+				verifiedParams = tempParams;
+				break;
+			}
+			start = foundClose + 1;
 		}
-		str = `(${args}){${body}}`;
-		if (head.includes("*")) str = "*" + str;
-		str = "function" + str;
-		if (/\basync\b/.test(head)) str = "async " + str;
-		return str;
+		if (verifiedParams == null) {
+			if (log) console.warn("发现无法识别的远程代码:", str);
+			return emptyFunction;
+		}
+		// 检查函数连接
+		const neckStart = str.slice(foundClose);
+		const neckMatch = get.#functionNeckPattern.exec(neckStart);
+		if (!neckMatch) {
+			if (log) console.warn("发现无法识别的远程代码:", str);
+			return emptyFunction;
+		}
+		// 箭头函数分流检查
+		if (neckMatch[0].includes("=>")) {
+			let funcHead = functionHead[0];
+			let idMatch;
+			while (idMatch = get.#identifierPattern.exec(funcHead)) {
+				if (idMatch[0] != "async") {
+					if (log) console.warn("发现无法识别的远程代码:", str);
+					return emptyFunction;
+				}
+				funcHead = funcHead.slice(idMatch.index + idMatch[0].length);
+			}
+		} else {
+			let funcHead = functionHead[0];
+			let idMatch;
+			while (idMatch = get.#identifierPattern.exec(funcHead)) {
+				if (idMatch[0] != "async") break;
+				funcHead = funcHead.slice(idMatch.index + idMatch[0].length);
+			}
+			if (!idMatch) {
+				if (log) console.warn("发现无法识别的远程代码:", str);
+				return emptyFunction;
+			}
+		}
+		// 块类型分流
+		const isBlock = neckMatch[0].endsWith("{");
+		let funcBody;
+		if (isBlock) {
+			if (!str.endsWith("}")) {
+				if (log) console.warn("发现无法识别的远程代码:", str);
+				return emptyFunction;
+			}
+			funcBody = "{" + str.slice(foundClose + neckMatch[0].length);
+		} else {
+			// 将表达式函数体转换成块函数体
+			funcBody = `{ return ${str.slice(foundClose + neckMatch[0].length)}; }`;
+		}
+		// 收集函数类型
+		let funcType = 0;
+		if (functionHead[0].includes("*")) funcType |= 1;
+		if (get.#asyncHeadPattern.test(functionHead[0])) funcType |= 2;
+		// 检查函数体
+		const checkType = [null, "generator", "async", "agenerator"][funcType];
+		// @ts-ignore
+		if (!get.isFunctionBody(funcBody, checkType)) {
+			if (log) console.warn("发现无法识别的远程代码:", str);
+			return emptyFunction;
+		}
+		// 开始构造最终的函数
+		let finalStr = ` (${verifiedParams}) ${funcBody}`;
+		if (funcType & 1) finalStr = "*" + finalStr;
+		finalStr = "function" + finalStr;
+		if (funcType & 2) finalStr = "async " + finalStr;
+		return finalStr;
 	}
 	funcInfoOL(func) {
 		if (typeof func == "function") {


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有


### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
旧的函数不支持解构参数


### PR描述
<!-- 详细描述您的更改 -->
重构了清洗函数，让它可以支持解构参数喵
* 多种函数头与函数体
![image](https://github.com/libccy/noname/assets/17672951/42d19c4b-5088-480d-b6c9-650391428973)
* 解构参数与上下文关键字
![image](https://github.com/libccy/noname/assets/17672951/c90c6841-cc23-4f82-88a8-cb7ab922b085)
* 抽象的参数默认值
![image](https://github.com/libccy/noname/assets/17672951/e1b99491-f8d5-4127-bebc-954412a7c790)


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
已通过函数格式测试


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
