### PR TITLE
bugfix: 修复因为复杂参数不能使用"use strict"导致沙盒和函数清洗的冲突问题

### DIFF
--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -1511,6 +1511,10 @@ export class Get extends GetCompatible {
 	 */
 	isFunctionParam(paramstr) {
 		if (paramstr.length == 0) return true;
+		const canCreateFunction = security.isSandboxRequired() 
+			&& security.importSandbox().Marshal.canCreateFunction;
+		if (canCreateFunction)
+			return canCreateFunction(paramstr, "");
 		try {
 			new Function(paramstr, "");
 			return true;
@@ -1530,6 +1534,10 @@ export class Get extends GetCompatible {
 	 * @returns {boolean}
 	 */
 	isFunctionBody(code, type = /* (function(){return null})() */ null) {
+		const canCreateFunction = security.isSandboxRequired() 
+			&& security.importSandbox().Marshal.canCreateFunction;
+		if (canCreateFunction)
+			return canCreateFunction("", code, type);
 		if (type == "any") {
 			return (
 				["async", "generator", "agenerator", null]


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有


### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
问题是@PZ157报告的喵，因为导致了他的扩展联机出现错误_(:з」∠)_
因为js的奇怪限制，当函数出现参数默认值时，函数内不能标注"use strict"


### PR描述
<!-- 详细描述您的更改 -->
让沙盒额外提供了接口来处理沙盒启用时的函数清洗


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
在新的版本中测试@PZ157的联机扩展不再出现问题，测试通过


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
暂无


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
