### PR TITLE
修复安卓客户端读不到`noname-compatible`的问题

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -18,21 +18,11 @@
 	} = await new Promise((resolve, reject) => {
 		import("../noname-compatible.js")
 			.then(resolve, async () => {
-				let util = await import("../noname/util/index.js");
-				let { device, assetURL } = util;
-
-				let rootURL = new URL(device ? assetURL : typeof window.__dirname == "string" ? window.__dirname : "/");
-				let { GetCompatible, get, setGetCompatible } = await import("../noname/get/compatible.js");
-				let { GameCompatible, game, setGameCompatible, UpdateReason } = await import("../noname/game/compatible.js");
+				let [util, { get }, { game, UpdateReason }] = await Promise.all([import("../noname/util/index.js"), import("../noname/get/compatible.js"), import("../noname/game/compatible.js")]);
 
 				return {
-					rootURL,
-					GetCompatible,
 					get,
-					setGetCompatible,
-					GameCompatible,
 					game,
-					setGameCompatible,
 					UpdateReason,
 					util,
 				};

--- a/game/game.js
+++ b/game/game.js
@@ -10,6 +10,9 @@
 	const minSafariVersion = [14, 5, 0];
 
 	// 获取基础变量
+	/**
+	 * @type {import("../noname-compatible.js")}
+	 */
 	const {
 		game,
 		get,

--- a/game/game.js
+++ b/game/game.js
@@ -15,7 +15,30 @@
 		get,
 		util: { nonameInitialized, assetURL, userAgent },
 		UpdateReason,
-	} = await import("../noname-compatible.js");
+	} = await new Promise((resolve, reject) => {
+		import("../noname-compatible.js")
+			.then(resolve, async () => {
+				let util = await import("../noname/util/index.js");
+				let { device, assetURL } = util;
+
+				let rootURL = new URL(device ? assetURL : typeof window.__dirname == "string" ? window.__dirname : "/");
+				let { GetCompatible, get, setGetCompatible } = await import("../noname/get/compatible.js");
+				let { GameCompatible, game, setGameCompatible, UpdateReason } = await import("../noname/game/compatible.js");
+
+				return {
+					rootURL,
+					GetCompatible,
+					get,
+					setGetCompatible,
+					GameCompatible,
+					game,
+					setGameCompatible,
+					UpdateReason,
+					util,
+				};
+			})
+			.catch(reject);
+	});
 
 	// 使用到的文本
 	const globalText = {


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
android

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
似乎部分客户端读取不到`noname-compatible.js`，故在此做个`fallback`


### PR描述
<!-- 详细描述您的更改 -->
在`import("../noname-compatible.js")`失败后自行尝试读取需要的东西


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
没安卓端，但电脑端和网页端能跑，按理说没问题


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->



### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
