### PR TITLE
优化【护关】ai，修复部分姓名

### DIFF
--- a/character/collab/character.js
+++ b/character/collab/character.js
@@ -23,7 +23,7 @@ const characters = {
 	quyuan: ["male", "qun", 3, ["dcqiusuo", "dclisao"], ["name:芈|原"]],
 	xin_sunquan: ["male", "wu", 3, ["dchuiwan", "dchuanli"]],
 	wuhujiang: ["male", "shu", 4, ["olhuyi"], ["name:关|羽-张|飞-赵|云-马|超-黄|忠"]],
-	dc_noname: ["male", "qun", 3, ["dcchushan"], ["name:null:null"]],
+	dc_noname: ["male", "qun", 3, ["dcchushan"], ["name:null|null"]],
 };
 
 export default characters;

--- a/character/gujian.js
+++ b/character/gujian.js
@@ -3,7 +3,7 @@ game.import("character", function () {
 	return {
 		name: "gujian",
 		character: {
-			gjqt_bailitusu: ["male", "shu", 4, ["xuelu", "fanshi", "shahun"]],
+			gjqt_bailitusu: ["male", "shu", 4, ["xuelu", "fanshi", "shahun"], ["name:百里|屠苏"]],
 			gjqt_fengqingxue: ["female", "wu", 3, ["qinglan", "yuehua", "swd_wuxie"]],
 			gjqt_xiangling: ["female", "wu", 3, ["xlqianhuan", "meihu", "xidie"]],
 			gjqt_fanglansheng: ["male", "wu", 3, ["fanyin", "mingkong", "fumo"]],
@@ -11,24 +11,20 @@ game.import("character", function () {
 			gjqt_hongyu: ["female", "shu", 4, ["jianwu", "meiying"]],
 
 			gjqt_yuewuyi: ["male", "wei", 4, ["yanjia", "xiuhua", "liuying"]],
-			gjqt_wenrenyu: ["female", "shu", 4, ["chizhen", "dangping"]],
+			gjqt_wenrenyu: ["female", "shu", 4, ["chizhen", "dangping"], ["name:闻人|羽"]],
 			gjqt_xiayize: ["male", "qun", 3, ["xuanning", "liuguang", "yangming"]],
 			gjqt_aruan: ["female", "wu", 3, ["zhaolu", "jiehuo", "yuling"]],
 
 			gjqt_xunfang: ["female", "shu", 3, ["manwu", "xfanghua"]],
-			gjqt_ouyangshaogong: ["male", "shu", 3, ["yunyin", "shishui", "duhun"]],
+			gjqt_ouyangshaogong: ["male", "shu", 3, ["yunyin", "shishui", "duhun"], ["name:欧阳|少恭"]],
 
 			gjqt_xieyi: ["male", "qun", 3, ["lingyan", "xunjian", "humeng"]],
 			gjqt_yanjiaxieyi: ["male", "qun", 2, ["xianju"], ["unseen"]],
 			gjqt_chuqi: ["male", "qun", 2, ["xuanci"], ["unseen"]],
 
-			// gjqt_xuange:['male','qun',4,['zhenlu','zhuixing']],
 			gjqt_beiluo: ["male", "qun", 4, ["lingnu", "zhenying", "cihong"]],
 			gjqt_yunwuyue: ["female", "wei", 3, ["yange", "woxue", "lianjing"]],
 			gjqt_cenying: ["female", "shu", 3, ["yunyou", "xuanzhen", "qingshu"]],
-			// gjqt_changliu:['male','qun',4,['xiange']],
-			// gjqt_fenglishuang:['female','wei',3,[]],
-			// gjqt_nishang:[],
 		},
 		characterIntro: {
 			gjqt_bailitusu:

--- a/character/huicui/skill.js
+++ b/character/huicui/skill.js
@@ -11277,9 +11277,7 @@ const skills = {
 					if (att <= 0) {
 						if (
 							!player.hasSkill("yaopei") ||
-							player.hasHistory("useSkill", function (evt) {
-								return evt.skill == "huguan" && evt.targets.includes(target);
-							}) ||
+							!player.countCards("he") ||
 							target.needsToDiscard() - target.needsToDiscard(-target.countCards("h") / 4) > (att > -2 ? 1.6 : 1)
 						)
 							return "cancel2";

--- a/character/key/character.js
+++ b/character/key/character.js
@@ -5,7 +5,7 @@ const characters = {
 		hp: 4,
 		skills: ["mubing", "ziqu", "diaoling"],
 		groupBorder: "key",
-		names: "仲村-由理",
+		names: "仲村|由理",
 	},
 	key_lucia: {
 		sex: "female",

--- a/character/mobile/character.js
+++ b/character/mobile/character.js
@@ -109,7 +109,7 @@ const characters = {
 	chendeng: ["male", "qun", 3, ["zhouxuan", "fengji"]],
 	re_heqi: ["male", "wu", 4, ["reqizhou", "reshanxi"]],
 	yangbiao: ["male", "qun", 3, ["zhaohan", "rangjie", "yizheng"]],
-	re_sp_zhugeliang: ["male", "shu", 3, ["bazhen", "rehuoji", "rekanpo"]],
+	re_sp_zhugeliang: ["male", "shu", 3, ["bazhen", "rehuoji", "rekanpo"], ["name:诸葛|亮"]],
 	xin_xiahoudun: ["male", "wei", 4, ["reganglie", "xinqingjian"], ["name:夏侯|惇"]],
 	zhangyì: ["male", "shu", 4, ["rezhiyi"]],
 	jiakui: ["male", "wei", 3, ["zhongzuo", "wanlan"]],

--- a/character/sb/character.js
+++ b/character/sb/character.js
@@ -7,7 +7,7 @@ const characters = {
 	sb_caopi: ["male", "wei", 3, ["sbxingshang", "sbfangzhu", "sbsongwei"], ["zhu"]],
 	sb_guanyu: ["male", "shu", 4, ["sbwusheng", "sbyijue"]],
 	sb_huangyueying: ["female", "shu", 3, ["sbjizhi", "sbqicai"]],
-	sb_sp_zhugeliang: ["male", "shu", 3, ["sbhuoji", "sbkanpo"]],
+	sb_sp_zhugeliang: ["male", "shu", 3, ["sbhuoji", "sbkanpo"], ["name:诸葛|亮"]],
 	sb_zhanghe: ["male", "wei", 4, ["sbqiaobian"]],
 	sb_yujin: ["male", "wei", 4, ["sbxiayuan", "sbjieyue"]],
 	sb_huaxiong: ["male", "qun", "3/4/1", ["new_reyaowu", "sbyangwei"]],

--- a/character/sp/character.js
+++ b/character/sp/character.js
@@ -131,7 +131,7 @@ const characters = {
 	sp_caiwenji: ["female", "wei", 3, ["chenqing", "mozhi"]],
 	zhugeguo: ["female", "shu", 3, ["qirang", "yuhua"], ["name:诸葛|果"]],
 
-	lingju: ["female", "qun", 3, ["jieyuan", "fenxin"]],
+	lingju: ["female", "qun", 3, ["jieyuan", "fenxin"], ["name:吕|null"]],
 
 	cuiyan: ["male", "wei", 3, ["yawang", "xunzhi"]],
 	jsp_guanyu: ["male", "wei", 4, ["new_rewusheng", "danji"]],

--- a/character/swd.js
+++ b/character/swd.js
@@ -12,13 +12,13 @@ game.import("character", function () {
 			swd_nicole: ["female", "qun", 3, ["huanjian", "lingwu", "minjing"]],
 			swd_wangsiyue: ["female", "wei", 3, ["duishi", "biyue"]],
 			swd_weida: ["female", "qun", 3, ["yueren", "zhenlie", "duijue"]],
-			swd_xuanyuanjianxian: ["male", "qun", 4, ["pozhou", "huajian", "xuanyuan"]],
+			swd_xuanyuanjianxian: ["male", "qun", 4, ["pozhou", "huajian", "xuanyuan"], ["name:轩辕|null"]],
 
 			swd_chenjingchou: ["male", "wu", 3, ["youyin", "yihua"]],
-			swd_duguningke: ["female", "qun", 3, ["nlianji", "touxi"]],
+			swd_duguningke: ["female", "qun", 3, ["nlianji", "touxi"], ["name:独孤|宁珂"]],
 			swd_guyue: ["male", "wei", 3, ["gtiandao", "gxianyin", "wangchen"]],
-			swd_tuobayuer: ["female", "shu", 4, ["swdliuhong", "poyue", "niepan"]],
-			swd_yuwentuo: ["male", "shu", 4, ["wushuang", "xielei", "kunlunjing"]],
+			swd_tuobayuer: ["female", "shu", 4, ["swdliuhong", "poyue", "niepan"], ["name:拓跋|玉儿"]],
+			swd_yuwentuo: ["male", "shu", 4, ["wushuang", "xielei", "kunlunjing"], ["name:宇文|拓"]],
 			swd_yuxiaoxue: ["female", "wei", 3, ["huanhun", "daixing", "yinyue"]],
 
 			swd_jiliang: ["male", "wu", 3, ["yunchou", "gongxin", "jqimou"]],
@@ -27,7 +27,7 @@ game.import("character", function () {
 			swd_xiyan: ["male", "qun", 3, ["jiefen", "datong"]],
 			swd_cheyun: ["female", "wu", 3, ["cyxianjiang", "cyqiaoxie", "shengong"]],
 			swd_huanyuanzhi: ["male", "qun", 3, ["swdtianshu", "lanzhi", "mufeng"]],
-			swd_murongshi: ["female", "shu", 4, ["duanyi", "guxing"]],
+			swd_murongshi: ["female", "shu", 4, ["duanyi", "guxing"], ["name:慕容|诗"]],
 			swd_jipeng: ["male", "wu", 3, ["reyingzi", "guozao"]],
 			swd_qi: ["male", "qun", 3, ["yaotong", "heihuo", "pojian"]],
 
@@ -56,7 +56,7 @@ game.import("character", function () {
 			swd_zhuoshanzhu: ["male", "wu", 4, ["suiyan", "wanjun"]],
 			swd_jiting: ["female", "wei", 4, ["guanhu", "lingshi"]],
 
-			swd_sikongyu: ["male", "wu", 4, ["sliufeng", "linyun", "hutian"]],
+			swd_sikongyu: ["male", "wu", 4, ["sliufeng", "linyun", "hutian"], ["name:司空|宇"]],
 			swd_muyue: ["female", "wei", 3, ["xingzhui", "lingxian", "shouyin"]],
 			swd_ziqiao: ["female", "shu", 3, ["guaili", "fuyan"]],
 			swd_fengyu: ["male", "shu", 4, ["fzhenwei", "shangxi"]],
@@ -72,18 +72,17 @@ game.import("character", function () {
 			// swd_philis:['male','qun',4,['yicong','wangxi']],
 			// swd_pepin:['male','qun',4,['rejianxiong','quhu']],
 			swd_kangnalishi: ["male", "qun", 1, ["busi", "xuying", "yinguo"]],
-			swd_xuanyuanjiantong: ["male", "qun", 3, ["chengjian", "huanling"]],
+			swd_xuanyuanjiantong: ["male", "qun", 3, ["chengjian", "huanling"], ["name:轩辕|null"]],
 			swd_huiyan: ["male", "qun", 4, ["hwendao", "lingfeng", "hxunzhi"]],
 
 			// swd_chenfu:['male','qun',4,['xuanzhou','bingfeng']],
 			// swd_chengyaojin:['male','qun',4,['jiuchi','jufu']],
 			swd_shanxiaoxiao: ["female", "wu", 3, ["shehun", "xiaomoyu"]],
-			swd_yuchiyanhong: ["female", "shu", 3, ["huanxing", "meihuo"]],
+			swd_yuchiyanhong: ["female", "shu", 3, ["huanxing", "meihuo"], ["name:尉迟|嫣红"]],
 			// swd_hanteng:['male','qun',4,['kuangfu']],
 			// swd_heran:['male','qun',3,['yujian','guiyin','shejie']],
 			// swd_xingtian:['male','qun',8,[]],
 			// swd_qinshubao:['male','qun',3,['huajing','pingxu']],
-			// swd_tuobayueer:['female','shu',3,['shushen','biyue']],
 			// swd_yangshuo:['male','qun',4,['longdan','luomu']],
 			// swd_zhanglie:['male','qun',4,['huajin','poxiao']],
 
@@ -98,7 +97,7 @@ game.import("character", function () {
 
 			swd_youzhao: ["male", "shu", 4, ["longdan", "yuchen"]],
 			swd_shangzhang: ["male", "shu", 4, ["lianwu"]],
-			swd_situqiang: ["female", "shu", 3, ["fengze", "lingyue", "jinlin"]],
+			swd_situqiang: ["female", "shu", 3, ["fengze", "lingyue", "jinlin"], ["name:司徒|蔷"]],
 
 			swd_chunyuheng: ["male", "wei", 2, ["jueqing", "shengshou", "xuying"]],
 			swd_hanlong: ["male", "wei", 4, ["ciqiu", "siji"]],
@@ -10318,7 +10317,6 @@ game.import("character", function () {
 			swd_wangsiyue: "王思月",
 			swd_huanglei: "黄雷",
 			swd_tuobayuer: "拓跋玉儿",
-			swd_tuobayueer: "拓跋月儿",
 			swd_chengyaojin: "程咬金",
 			swd_qinshubao: "秦叔宝",
 			swd_lishimin: "李世民",

--- a/character/swd.js
+++ b/character/swd.js
@@ -37,8 +37,8 @@ game.import("character", function () {
 
 			swd_zhaoyun: ["male", "shu", 4, ["longdan", "pozhen", "tanlin"]],
 			swd_hengai: ["female", "shu", 3, ["funiao", "ningxian", "hlingbo"]],
-			swd_duanmeng: ["female", "shu", 4, ["xuanying", "lieren"]],
-			swd_jiangwu: ["male", "shu", 4, ["yijue", "dangping"]],
+			swd_duanmeng: ["female", "shu", 4, ["xuanying", "lieren"], ["name:马|蕴"]],
+			swd_jiangwu: ["male", "shu", 4, ["yijue", "dangping"], ["name:严|鹏"]],
 			swd_tuwei: ["male", "shu", 3, ["zhanlu", "susheng"]],
 			swd_yeyaxi: ["female", "shu", 3, ["rexue", "huopu", "shenyan"]],
 
@@ -95,8 +95,8 @@ game.import("character", function () {
 			swd_haidapang: ["female", "wu", 3, ["bingjian", "rumeng"]],
 			swd_shaowei: ["female", "shu", 3, ["jianji", "huangyu"]],
 
-			swd_youzhao: ["male", "shu", 4, ["longdan", "yuchen"]],
-			swd_shangzhang: ["male", "shu", 4, ["lianwu"]],
+			swd_youzhao: ["male", "shu", 4, ["longdan", "yuchen"], ["name:赵|昂"]],
+			swd_shangzhang: ["male", "shu", 4, ["lianwu"], ["name:马|null"]],
 			swd_situqiang: ["female", "shu", 3, ["fengze", "lingyue", "jinlin"], ["name:司徒|蔷"]],
 
 			swd_chunyuheng: ["male", "wei", 2, ["jueqing", "shengshou", "xuying"]],

--- a/character/xiake.js
+++ b/character/xiake.js
@@ -3,7 +3,6 @@ game.import("character", function () {
 	return {
 		name: "xiake",
 		character: {
-			// xk_dongfangweiming:['male','shu',4,[]],
 			xk_guyuexuan: ["male", "qun", 4, ["rouquan", "gzhenji"]],
 			xk_jinji: ["male", "shu", 4, ["zhongzhan", "lianpo"]],
 			// xk_shenxiangyun:['female','wei',3,['zhenjiu']],
@@ -105,7 +104,6 @@ game.import("character", function () {
 			},
 		},
 		translate: {
-			xk_dongfangweiming: "东方未明",
 			xk_guyuexuan: "谷月轩",
 			xk_jinji: "荆棘",
 			xk_shenxiangyun: "沈湘芸",

--- a/character/xiake.js
+++ b/character/xiake.js
@@ -6,7 +6,7 @@ game.import("character", function () {
 			xk_guyuexuan: ["male", "qun", 4, ["rouquan", "gzhenji"]],
 			xk_jinji: ["male", "shu", 4, ["zhongzhan", "lianpo"]],
 			// xk_shenxiangyun:['female','wei',3,['zhenjiu']],
-			xk_fujianhan: ["male", "qun", 4, ["zuijian", "zitong"]],
+			// xk_fujianhan: ["male", "qun", 4, ["zuijian", "zitong"]],
 		},
 		skill: {
 			zhongzhan: {

--- a/character/xianjian.js
+++ b/character/xianjian.js
@@ -18,7 +18,7 @@ game.import("character", function () {
 			pal_zixuan: ["female", "wei", 3, ["shuiyun", "wangyou", "changnian"]],
 			pal_changqing: ["male", "wei", 4, ["luanjian", "ctianfu"]],
 
-			pal_nangonghuang: ["male", "wei", 3, ["zhaoyao", "sheling", "zhangmu"]],
+			pal_nangonghuang: ["male", "wei", 3, ["zhaoyao", "sheling", "zhangmu"], ["name:南宫|煌"]],
 			pal_wenhui: ["female", "shu", 4, ["huxi", "longxiang"]],
 			pal_wangpengxu: ["female", "shu", 3, ["duxinshu", "feixu"]],
 			pal_xingxuan: ["male", "wei", 3, ["feizhua", "leiyu", "lingxue"]],
@@ -27,7 +27,7 @@ game.import("character", function () {
 			pal_yuntianhe: ["male", "wu", 4, ["longxi", "zhuyue", "guanri"]],
 			pal_hanlingsha: ["female", "shu", 3, ["tannang", "tuoqiao"]],
 			pal_liumengli: ["female", "wei", 3, ["tianxian", "runxin", "xjzhimeng"]],
-			pal_murongziying: ["male", "wei", 4, ["xuanning", "poyun", "qianfang"]],
+			pal_murongziying: ["male", "wei", 4, ["xuanning", "poyun", "qianfang"], ["name:慕容|紫英"]],
 			pal_xuanxiao: ["male", "wei", 4, ["xuanyan", "ningbin", "xfenxin"]],
 
 			pal_jiangyunfan: ["male", "wei", 4, ["xunying", "liefeng"]],

--- a/character/yijiang/character.js
+++ b/character/yijiang/character.js
@@ -93,7 +93,7 @@ const characters = {
 
 	yujin: ["male", "wei", 4, ["rezhenjun"], ["die:ol_yujin.mp3"]],
 
-	linghuyu: ["male", "wei", 4, ["xvzhi"]],
+	linghuyu: ["male", "wei", 4, ["xvzhi"], ["name:令狐|愚"]],
 	yj_simafu: ["male", "wei", 3, ["beiyu", "duchi"], ["name:司马|孚"]],
 	yj_xuangongzhu: ["female", "wei", 3, ["yjqimei", "yjzhuiji"], ["name:司马|null"]],
 	xukun: ["male", "wu", 4, ["fazhu"]],

--- a/character/yxs.js
+++ b/character/yxs.js
@@ -9,7 +9,7 @@ game.import("character", function () {
 			yxs_mozi: ["male", "qun", 3, ["jieyong", "feigong", "jianai"], ["name:墨|翟"]],
 			yxs_bole: ["male", "wu", 3, ["bolehuiyan", "xiangma"], ["name:孙|阳"]],
 			yxs_aijiyanhou: ["female", "qun", 3, ["seyou", "sheshi"], ["name:null|null"]],
-			yxs_diaochan: ["female", "qun", 3, ["fengyi", "wange"]],
+			yxs_diaochan: ["female", "qun", 3, ["fengyi", "wange"], ["name:null|null"]],
 			yxs_yangyuhuan: ["female", "wu", 3, ["fengyan", "nichang"]],
 			yxs_baosi: ["female", "wu", 3, ["jieyin", "fenghuo"], ["name:姒|null"]],
 			yxs_napolun: ["male", "wei", 4, ["tongling", "fanpu"], ["name:波拿巴|拿破仑"]],

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -352,7 +352,7 @@ export class Get extends GetCompatible {
 	 * @param { string } str
 	 * @param { string|undefined } defaultSurname
 	 * @param { string|undefined } defaultName
-	 * @returns { Array | undefined }
+	 * @returns { Array }
 	 */
 	characterSurname(str, defaultSurname, defaultName){
 		const info = get.character(str).names;


### PR DESCRIPTION
### PR受影响的平台
所有平台



### PR描述
优化【护关】ai；
修复部分姓名；
适配部分轩辕剑、古剑奇谭、仙剑奇侠传武将姓名；
注释xiake.js中一个不存在对应技能的武将；
删除非联机武将包中一个没有对应技能、info和简介的武将



### 扩展适配
无需适配



### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
