### PR TITLE
修复由理版导入扩展无法在扩展列表显示的问题

### DIFF
--- a/game/entry.js
+++ b/game/entry.js
@@ -1,4 +1,4 @@
-import { game, get, lib, boot } from "../noname.js";
+import { game, get, lib, boot, onload } from "../noname.js";
 import { canUseHttpProtocol, sendUpdate } from "../noname/init/index.js";
 
 let [core, version] = get.coreInfo();
@@ -20,155 +20,158 @@ if (core === "chrome" && !isNaN(version) && version < 85) {
 	waitUpdate = game.tryUpdateClient(/** UpdateReason.UNDERSUPPORT **/ 4);
 }
 
-waitUpdate.then(boot).then(() => {
-	// 判断是否从file协议切换到http/s协议
-	if (canUseHttpProtocol()) {
-		// 保存协议的切换状态
-		const saveProtocol = () => {
-			const url = sendUpdate();
-			if (typeof url == "string") {
-				if (typeof window.require == "function" && typeof window.process == "object") {
-					// @ts-ignore
-					const remote = require("@electron/remote");
-					const thisWindow = remote.getCurrentWindow();
-					thisWindow.loadURL(url);
-				} else {
-					location.href = url;
+waitUpdate
+	.then(boot)
+	.then(() => {
+		// 判断是否从file协议切换到http/s协议
+		if (canUseHttpProtocol()) {
+			// 保存协议的切换状态
+			const saveProtocol = () => {
+				const url = sendUpdate();
+				if (typeof url == "string") {
+					if (typeof window.require == "function" && typeof window.process == "object") {
+						// @ts-ignore
+						const remote = require("@electron/remote");
+						const thisWindow = remote.getCurrentWindow();
+						thisWindow.loadURL(url);
+					} else {
+						location.href = url;
+					}
 				}
-			}
-		};
-		/*
+			};
+			/*
 		升级方法:
 			1. 游戏启动后导出数据，然后以http/s协议重启
 			2. 以http/s协议导入数据
 			3. 保存http/s协议的状态，以后不再以file协议启动
 		*/
-		// 导出数据到根目录的noname.config.txt
-		if (navigator.notification) {
-			navigator.notification.activityStart("正在进行升级", "请稍候");
-		}
-		let data;
-		let export_data = function (data) {
+			// 导出数据到根目录的noname.config.txt
 			if (navigator.notification) {
-				navigator.notification.activityStop();
+				navigator.notification.activityStart("正在进行升级", "请稍候");
 			}
-			game.promises
-				.writeFile(lib.init.encode(JSON.stringify(data)), "./", "noname.config.txt")
-				.then(saveProtocol)
-				.catch(e => {
-					console.error("升级失败:", e);
-				});
-		};
-		// @ts-ignore
-		if (!lib.db) {
-			data = {};
-			for (let i in localStorage) {
-				if (i.startsWith(lib.configprefix)) {
-					data[i] = localStorage[i];
-				}
-			}
-			export_data(data);
-		} else {
-			game.getDB("config", null, function (data1) {
-				game.getDB("data", null, function (data2) {
-					export_data({
-						config: data1,
-						data: data2,
-					});
-				});
-			});
-		}
-	} else {
-		let searchParams = new URLSearchParams(location.search);
-		for (let [key, value] of searchParams) {
-			// 成功导入后删除noname.config.txt
-			if (key === "sendUpdate" && value === "true") {
+			let data;
+			let export_data = function (data) {
 				if (navigator.notification) {
-					navigator.notification.activityStart("正在导入旧版数据", "请稍候");
+					navigator.notification.activityStop();
 				}
 				game.promises
-					.readFileAsText("noname.config.txt")
-					.then(data => {
-						return /** @type {Promise<void>} */ (
-							// eslint-disable-next-line no-async-promise-executor
-							new Promise(async (resolve, reject) => {
-								if (!data) return reject("!data");
-								try {
-									data = JSON.parse(lib.init.decode(data));
-									if (!data || typeof data != "object") {
-										throw "err";
-									}
-									// @ts-ignore
-									if (lib.db && (!data.config || !data.data)) {
-										throw "err";
-									}
-								} catch (e) {
-									console.log(e);
-									if (e == "err") {
-										alert("导入文件格式不正确");
-										reject("导入文件格式不正确");
-									} else {
-										alert("导入失败： " + e.message);
-										reject("导入失败： " + e.message);
-									}
-									return;
-								}
-								if (navigator.notification) {
-									navigator.notification.activityStop();
-								}
-								alert("升级前的配置导入成功, 即将自动重启");
-								// @ts-ignore
-								if (!lib.db) {
-									const noname_inited = localStorage.getItem("noname_inited");
-									const onlineKey = localStorage.getItem(lib.configprefix + "key");
-									localStorage.clear();
-									if (noname_inited) {
-										localStorage.setItem("noname_inited", noname_inited);
-									}
-									if (onlineKey) {
-										localStorage.setItem(lib.configprefix + "key", onlineKey);
-									}
-									for (let i in data) {
-										localStorage.setItem(i, data[i]);
-									}
-								} else {
-									for (let i in data.config) {
-										await game.putDB("config", i, data.config[i]);
-										lib.config[i] = data.config[i];
-									}
-									for (let i in data.data) {
-										await game.putDB("data", i, data.data[i]);
-									}
-								}
-								lib.init.background();
-								resolve();
-							})
-						);
-					})
-					.then(() => {
-						return game.promises.removeFile("noname.config.txt");
-					})
-					.then(() => {
-						const url = new URL(location.href);
-						url.searchParams.delete("sendUpdate");
-						location.href = url.toString();
-					})
+					.writeFile(lib.init.encode(JSON.stringify(data)), "./", "noname.config.txt")
+					.then(saveProtocol)
 					.catch(e => {
-						if (navigator.notification) {
-							navigator.notification.activityStop();
-						}
+						console.error("升级失败:", e);
 					});
+			};
+			// @ts-ignore
+			if (!lib.db) {
+				data = {};
+				for (let i in localStorage) {
+					if (i.startsWith(lib.configprefix)) {
+						data[i] = localStorage[i];
+					}
+				}
+				export_data(data);
+			} else {
+				game.getDB("config", null, function (data1) {
+					game.getDB("data", null, function (data2) {
+						export_data({
+							config: data1,
+							data: data2,
+						});
+					});
+				});
 			}
-			// 新客户端导入扩展
-			else if (key === "importExtensionName") {
-				lib.config.extensions.add(value);
-				game.saveConfig("extensions", lib.config.extensions);
-				game.saveConfig(`extension_${value}_enable`, true);
-				alert(`扩展${value}已导入成功，点击确定重启游戏`);
-				const url = new URL(location.href);
-				url.searchParams.delete("importExtensionName");
-				location.href = url.toString();
+		} else {
+			let searchParams = new URLSearchParams(location.search);
+			for (let [key, value] of searchParams) {
+				// 成功导入后删除noname.config.txt
+				if (key === "sendUpdate" && value === "true") {
+					if (navigator.notification) {
+						navigator.notification.activityStart("正在导入旧版数据", "请稍候");
+					}
+					game.promises
+						.readFileAsText("noname.config.txt")
+						.then(data => {
+							return /** @type {Promise<void>} */ (
+								// eslint-disable-next-line no-async-promise-executor
+								new Promise(async (resolve, reject) => {
+									if (!data) return reject("!data");
+									try {
+										data = JSON.parse(lib.init.decode(data));
+										if (!data || typeof data != "object") {
+											throw "err";
+										}
+										// @ts-ignore
+										if (lib.db && (!data.config || !data.data)) {
+											throw "err";
+										}
+									} catch (e) {
+										console.log(e);
+										if (e == "err") {
+											alert("导入文件格式不正确");
+											reject("导入文件格式不正确");
+										} else {
+											alert("导入失败： " + e.message);
+											reject("导入失败： " + e.message);
+										}
+										return;
+									}
+									if (navigator.notification) {
+										navigator.notification.activityStop();
+									}
+									alert("升级前的配置导入成功, 即将自动重启");
+									// @ts-ignore
+									if (!lib.db) {
+										const noname_inited = localStorage.getItem("noname_inited");
+										const onlineKey = localStorage.getItem(lib.configprefix + "key");
+										localStorage.clear();
+										if (noname_inited) {
+											localStorage.setItem("noname_inited", noname_inited);
+										}
+										if (onlineKey) {
+											localStorage.setItem(lib.configprefix + "key", onlineKey);
+										}
+										for (let i in data) {
+											localStorage.setItem(i, data[i]);
+										}
+									} else {
+										for (let i in data.config) {
+											await game.putDB("config", i, data.config[i]);
+											lib.config[i] = data.config[i];
+										}
+										for (let i in data.data) {
+											await game.putDB("data", i, data.data[i]);
+										}
+									}
+									lib.init.background();
+									resolve();
+								})
+							);
+						})
+						.then(() => {
+							return game.promises.removeFile("noname.config.txt");
+						})
+						.then(() => {
+							const url = new URL(location.href);
+							url.searchParams.delete("sendUpdate");
+							location.href = url.toString();
+						})
+						.catch(e => {
+							if (navigator.notification) {
+								navigator.notification.activityStop();
+							}
+						});
+				}
+				// 新客户端导入扩展
+				else if (key === "importExtensionName") {
+					lib.config.extensions.add(value);
+					game.saveConfig("extensions", lib.config.extensions);
+					game.saveConfig(`extension_${value}_enable`, true);
+					alert(`扩展${value}已导入成功，点击确定重启游戏`);
+					const url = new URL(location.href);
+					url.searchParams.delete("importExtensionName");
+					location.href = url.toString();
+				}
 			}
 		}
-	}
-});
+	})
+	.then(onload);

--- a/game/entry.js
+++ b/game/entry.js
@@ -164,12 +164,18 @@ waitUpdate
 				// 新客户端导入扩展
 				else if (key === "importExtensionName") {
 					lib.config.extensions.add(value);
-					game.saveConfig("extensions", lib.config.extensions);
-					game.saveConfig(`extension_${value}_enable`, true);
+
+					let waitings = [];
+
+					waitings.push(new Promise(resolve => game.saveConfig("extensions", lib.config.extensions, void 0, resolve)));
+					waitings.push(new Promise(resolve => game.saveConfig(`extension_${value}_enable`, true, void 0, resolve)));
 					alert(`扩展${value}已导入成功，点击确定重启游戏`);
-					const url = new URL(location.href);
-					url.searchParams.delete("importExtensionName");
-					location.href = url.toString();
+
+					return Promise.allSettled(waitings).then(() => {
+						const url = new URL(location.href);
+						url.searchParams.delete("importExtensionName");
+						location.href = url.toString();
+					});
 				}
 			}
 		}

--- a/noname.js
+++ b/noname.js
@@ -7,4 +7,4 @@ export { Get, get, setGet } from "./noname/get/index.js";
 export { Library, lib, setLibrary } from "./noname/library/index.js";
 export { status, _status, setStatus } from "./noname/status/index.js";
 export { UI, ui, setUI } from "./noname/ui/index.js";
-export { boot } from "./noname/init/index.js";
+export { boot, onload } from "./noname/init/index.js";

--- a/noname/init/index.js
+++ b/noname/init/index.js
@@ -9,7 +9,6 @@ import { userAgent, nonameInitialized, AsyncFunction, device, leaveCompatibleEnv
 import * as config from "../util/config.js";
 import { promiseErrorHandlerMap } from "../util/browser.js";
 import { importCardPack, importCharacterPack, importExtension, importMode } from "./import.js";
-import { onload } from "./onload.js";
 import { initializeSandboxRealms } from "../util/initRealms.js";
 import { ErrorManager } from "../util/error.js";
 
@@ -25,14 +24,14 @@ export function canUseHttpProtocol() {
 			// 直接确定包名
 			// 因为懒人包作者不一定会改成什么版本
 			// @ts-ignore
-			if (nonameInitialized.endsWith("com.noname.shijian/") && window.noname_shijianInterfaces && typeof window.noname_shijianInterfaces.sendUpdate === 'function') {
+			if (nonameInitialized.endsWith("com.noname.shijian/") && window.noname_shijianInterfaces && typeof window.noname_shijianInterfaces.sendUpdate === "function") {
 				// 每个app自定义能升级的渠道，比如判断版本
 				// @ts-ignore
 				return window.noname_shijianInterfaces.getApkVersion() >= 16000;
 			}
 			// 由理版判断，后续所有app都通过此接口来升级协议
 			// @ts-ignore
-			if (window.NonameAndroidBridge && typeof window.NonameAndroidBridge.sendUpdate === 'function') {
+			if (window.NonameAndroidBridge && typeof window.NonameAndroidBridge.sendUpdate === "function") {
 				return true;
 			}
 		}
@@ -65,7 +64,7 @@ export function sendUpdate() {
 	if (window.cordova) {
 		// 直接确定包名
 		// @ts-ignore
-		if (nonameInitialized && nonameInitialized.includes("com.noname.shijian") && window.noname_shijianInterfaces && typeof window.noname_shijianInterfaces.sendUpdate === 'function') {
+		if (nonameInitialized && nonameInitialized.includes("com.noname.shijian") && window.noname_shijianInterfaces && typeof window.noname_shijianInterfaces.sendUpdate === "function") {
 			// 给诗笺版apk的java层传递升级完成的信息
 			// @ts-ignore
 			const url = new URL(window.noname_shijianInterfaces.sendUpdate());
@@ -74,7 +73,7 @@ export function sendUpdate() {
 		}
 		// 由理版判断
 		// @ts-ignore
-		if (window.NonameAndroidBridge && typeof window.NonameAndroidBridge.sendUpdate === 'function') {
+		if (window.NonameAndroidBridge && typeof window.NonameAndroidBridge.sendUpdate === "function") {
 			// 给由理版apk的java层传递升级完成的信息
 			// @ts-ignore
 			const url = new URL(window.NonameAndroidBridge.sendUpdate());
@@ -95,10 +94,7 @@ export function sendUpdate() {
 				fs.writeFileSync(path.join(__dirname, "Home", "saveProtocol.txt"), "");
 				// 启动http
 				const cp = require("child_process");
-				cp.exec(
-					`start /min ${__dirname}\\noname-server.exe -platform=electron`,
-					(err, stdout, stderr) => { }
-				);
+				cp.exec(`start /min ${__dirname}\\noname-server.exe -platform=electron`, (err, stdout, stderr) => {});
 				return `http://localhost:8089/app.html?sendUpdate=true`;
 			}
 		}
@@ -709,8 +705,10 @@ export async function boot() {
 		delete _status.importing;
 	}
 
-	await onload(resetGameTimeout);
+	Reflect.set(window, "resetGameTimeout", resetGameTimeout);
 }
+
+export { onload } from "./onload.js";
 
 function initSheet(libConfig) {
 	if (libConfig.player_style && libConfig.player_style != "default" && libConfig.player_style != "custom") {
@@ -726,47 +724,19 @@ function initSheet(libConfig) {
 				str = "linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4))";
 				break;
 		}
-		Reflect.get(ui, "css").player_stylesheet = lib.init.sheet(
-			"#window .player{background-image:" + str + "}"
-		);
+		Reflect.get(ui, "css").player_stylesheet = lib.init.sheet("#window .player{background-image:" + str + "}");
 	}
-	if (
-		libConfig.border_style &&
-		libConfig.border_style != "default" &&
-		libConfig.border_style != "custom" &&
-		libConfig.border_style != "auto"
-	) {
+	if (libConfig.border_style && libConfig.border_style != "default" && libConfig.border_style != "custom" && libConfig.border_style != "auto") {
 		Reflect.get(ui, "css").border_stylesheet = lib.init.sheet();
 		var bstyle = libConfig.border_style;
 		if (bstyle.startsWith("dragon_")) {
 			bstyle = bstyle.slice(7);
 		}
-		Reflect.get(ui, "css").border_stylesheet.sheet.insertRule(
-			'#window .player>.framebg,#window #arena.long.mobile:not(.fewplayer) .player[data-position="0"]>.framebg{display:block;background-image:url("' +
-			lib.assetURL +
-			"theme/style/player/" +
-			bstyle +
-			'1.png")}',
-			0
-		);
-		Reflect.get(ui, "css").border_stylesheet.sheet.insertRule(
-			'#window #arena.long:not(.fewplayer) .player>.framebg, #arena.oldlayout .player>.framebg{background-image:url("' +
-			lib.assetURL +
-			"theme/style/player/" +
-			bstyle +
-			'3.png")}',
-			0
-		);
-		Reflect.get(ui, "css").border_stylesheet.sheet.insertRule(
-			".player>.count{z-index: 3 !important;border-radius: 2px !important;text-align: center !important;}",
-			0
-		);
+		Reflect.get(ui, "css").border_stylesheet.sheet.insertRule('#window .player>.framebg,#window #arena.long.mobile:not(.fewplayer) .player[data-position="0"]>.framebg{display:block;background-image:url("' + lib.assetURL + "theme/style/player/" + bstyle + '1.png")}', 0);
+		Reflect.get(ui, "css").border_stylesheet.sheet.insertRule('#window #arena.long:not(.fewplayer) .player>.framebg, #arena.oldlayout .player>.framebg{background-image:url("' + lib.assetURL + "theme/style/player/" + bstyle + '3.png")}', 0);
+		Reflect.get(ui, "css").border_stylesheet.sheet.insertRule(".player>.count{z-index: 3 !important;border-radius: 2px !important;text-align: center !important;}", 0);
 	}
-	if (
-		libConfig.control_style &&
-		libConfig.control_style != "default" &&
-		libConfig.control_style != "custom"
-	) {
+	if (libConfig.control_style && libConfig.control_style != "default" && libConfig.control_style != "custom") {
 		var str = "";
 		switch (libConfig.control_style) {
 			case "wood":
@@ -776,22 +746,13 @@ function initSheet(libConfig) {
 				str = "linear-gradient(#4b4b4b, #464646);color:white;text-shadow:black 0 0 2px";
 				break;
 			case "simple":
-				str =
-					"linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4));color:white;text-shadow:black 0 0 2px";
+				str = "linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4));color:white;text-shadow:black 0 0 2px";
 				break;
 		}
 		if (libConfig.control_style == "wood") {
-			Reflect.get(ui, "css").control_stylesheet = lib.init.sheet(
-				"#window .control,#window .menubutton,#window #system>div>div,#window #system>div>.pressdown2{background-image:" +
-				str +
-				"}"
-			);
+			Reflect.get(ui, "css").control_stylesheet = lib.init.sheet("#window .control,#window .menubutton,#window #system>div>div,#window #system>div>.pressdown2{background-image:" + str + "}");
 		} else {
-			Reflect.get(ui, "css").control_stylesheet = lib.init.sheet(
-				"#window .control,.menubutton:not(.active):not(.highlight):not(.red):not(.blue),#window #system>div>div{background-image:" +
-				str +
-				"}"
-			);
+			Reflect.get(ui, "css").control_stylesheet = lib.init.sheet("#window .control,.menubutton:not(.active):not(.highlight):not(.red):not(.blue),#window #system>div>div{background-image:" + str + "}");
 		}
 	}
 	if (libConfig.menu_style && libConfig.menu_style != "default" && libConfig.menu_style != "custom") {
@@ -804,13 +765,10 @@ function initSheet(libConfig) {
 				str = "linear-gradient(#4b4b4b, #464646);color:white;text-shadow:black 0 0 2px";
 				break;
 			case "simple":
-				str =
-					"linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4));color:white;text-shadow:black 0 0 2px";
+				str = "linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4));color:white;text-shadow:black 0 0 2px";
 				break;
 		}
-		Reflect.get(ui, "css").menu_stylesheet = lib.init.sheet(
-			"html #window>.dialog.popped,html .menu,html .menubg{background-image:" + str + "}"
-		);
+		Reflect.get(ui, "css").menu_stylesheet = lib.init.sheet("html #window>.dialog.popped,html .menu,html .menubg{background-image:" + str + "}");
 	}
 }
 
@@ -826,7 +784,7 @@ async function loadConfig() {
 			const idbOpenDBRequest = window.indexedDB.open(`${lib.configprefix}data`, 4);
 			idbOpenDBRequest.onerror = reject;
 			idbOpenDBRequest.onsuccess = resolve;
-			idbOpenDBRequest.onupgradeneeded = (idbVersionChangeEvent) => {
+			idbOpenDBRequest.onupgradeneeded = idbVersionChangeEvent => {
 				// @ts-expect-error MaybeHave
 				const idbDatabase = idbVersionChangeEvent.target.result;
 				if (!idbDatabase.objectStoreNames.contains("video"))
@@ -852,8 +810,8 @@ async function loadConfig() {
 			} catch (err) {
 				result = {};
 			}
-			Object.keys(result).forEach((key) => game.saveConfig(key, result[key]));
-			Object.keys(lib.mode).forEach((key) => {
+			Object.keys(result).forEach(key => game.saveConfig(key, result[key]));
+			Object.keys(lib.mode).forEach(key => {
 				try {
 					const item = localStorage.getItem(`${lib.configprefix}${key}`);
 					if (!item) throw "err";
@@ -899,7 +857,7 @@ async function loadCss() {
  * @deprecated
  * @return {Promise<void>}
  */
-async function onWindowReady() { }
+async function onWindowReady() {}
 
 function setBackground() {
 	let htmlbg = localStorage.getItem(lib.configprefix + "background");
@@ -918,8 +876,7 @@ function setBackground() {
 			}
 		}
 		if (htmlbg) {
-			document.documentElement.style.backgroundImage =
-				'url("' + lib.assetURL + "image/background/" + htmlbg + '.jpg")';
+			document.documentElement.style.backgroundImage = 'url("' + lib.assetURL + "image/background/" + htmlbg + '.jpg")';
 			document.documentElement.style.backgroundSize = "cover";
 			document.documentElement.style.backgroundPosition = "50% 50%";
 		}
@@ -943,25 +900,18 @@ function setServerIndex() {
 async function setOnError() {
 	const [core] = get.coreInfo();
 
-	const promiseErrorHandler = new (
-		core in promiseErrorHandlerMap ? promiseErrorHandlerMap[core] : promiseErrorHandlerMap.other
-	)();
+	const promiseErrorHandler = new (core in promiseErrorHandlerMap ? promiseErrorHandlerMap[core] : promiseErrorHandlerMap.other)();
 
 	if (promiseErrorHandler.onLoad) await promiseErrorHandler.onLoad();
 
-	window.onunhandledrejection = async (event) => {
+	window.onunhandledrejection = async event => {
 		if (promiseErrorHandler.onHandle) await promiseErrorHandler.onHandle(event);
 	};
 
 	window.onerror = function (msg, src, line, column, err) {
 		if (promiseErrorHandler.onErrorPrepare) promiseErrorHandler.onErrorPrepare();
-		const winPath = window.__dirname
-			? "file:///" + (__dirname.replace(new RegExp("\\\\", "g"), "/") + "/")
-			: "";
-		let str = `错误文件: ${typeof src == "string"
-				? decodeURI(src).replace(lib.assetURL, "").replace(winPath, "")
-				: "未知文件"
-			}`;
+		const winPath = window.__dirname ? "file:///" + (__dirname.replace(new RegExp("\\\\", "g"), "/") + "/") : "";
+		let str = `错误文件: ${typeof src == "string" ? decodeURI(src).replace(lib.assetURL, "").replace(winPath, "") : "未知文件"}`;
 		str += `\n错误信息: ${msg}`;
 		const tip = lib.getErrorTip(msg);
 		if (tip) str += `\n错误提示: ${tip}`;
@@ -971,24 +921,19 @@ async function setOnError() {
 		const reg = /[^\d.]/;
 		const match = version.match(reg) != null;
 		str += "\n" + `${match ? "游戏" : "无名杀"}版本: ${version || "未知版本"}`;
-		if (match)
-			str +=
-				"\n⚠️您使用的游戏代码不是源于libccy/noname无名杀官方仓库，请自行寻找您所使用的游戏版本开发者反馈！";
+		if (match) str += "\n⚠️您使用的游戏代码不是源于libccy/noname无名杀官方仓库，请自行寻找您所使用的游戏版本开发者反馈！";
 		if (_status && _status.event) {
 			let evt = _status.event;
 			str += `\nevent.name: ${evt.name}\nevent.step: ${evt.step}`;
 			// @ts-ignore
-			if (evt.parent)
-				str += `\nevent.parent.name: ${evt.parent.name}\nevent.parent.step: ${evt.parent.step}`;
+			if (evt.parent) str += `\nevent.parent.name: ${evt.parent.name}\nevent.parent.step: ${evt.parent.step}`;
 			// @ts-ignore
-			if (evt.parent && evt.parent.parent)
-				str += `\nevent.parent.parent.name: ${evt.parent.parent.name}\nevent.parent.parent.step: ${evt.parent.parent.step}`;
+			if (evt.parent && evt.parent.parent) str += `\nevent.parent.parent.name: ${evt.parent.parent.name}\nevent.parent.parent.step: ${evt.parent.parent.step}`;
 			if (evt.player || evt.target || evt.source || evt.skill || evt.card) {
 				str += "\n-------------";
 			}
 			if (evt.player) {
-				if (lib.translate[evt.player.name])
-					str += `\nplayer: ${lib.translate[evt.player.name]}[${evt.player.name}]`;
+				if (lib.translate[evt.player.name]) str += `\nplayer: ${lib.translate[evt.player.name]}[${evt.player.name}]`;
 				else str += "\nplayer: " + evt.player.name;
 				let distance = get.distance(_status.roundStart, evt.player, "absolute");
 				if (distance != Infinity) {
@@ -996,13 +941,11 @@ async function setOnError() {
 				}
 			}
 			if (evt.target) {
-				if (lib.translate[evt.target.name])
-					str += `\ntarget: ${lib.translate[evt.target.name]}[${evt.target.name}]`;
+				if (lib.translate[evt.target.name]) str += `\ntarget: ${lib.translate[evt.target.name]}[${evt.target.name}]`;
 				else str += "\ntarget: " + evt.target.name;
 			}
 			if (evt.source) {
-				if (lib.translate[evt.source.name])
-					str += `\nsource: ${lib.translate[evt.source.name]}[${evt.source.name}]`;
+				if (lib.translate[evt.source.name]) str += `\nsource: ${lib.translate[evt.source.name]}[${evt.source.name}]`;
 				else str += "\nsource: " + evt.source.name;
 			}
 			if (evt.skill) {
@@ -1010,8 +953,7 @@ async function setOnError() {
 				else str += "\nskill: " + evt.skill;
 			}
 			if (evt.card) {
-				if (lib.translate[evt.card.name])
-					str += `\ncard: ${lib.translate[evt.card.name]}[${evt.card.name}]`;
+				if (lib.translate[evt.card.name]) str += `\ncard: ${lib.translate[evt.card.name]}[${evt.card.name}]`;
 				else str += "\ncard: " + evt.card.name;
 			}
 		}
@@ -1019,10 +961,7 @@ async function setOnError() {
 		const errorReporter = ErrorManager.getErrorReporter(err);
 		if (errorReporter) game.print(errorReporter.report(str + "\n代码出现错误"));
 		else {
-			if (
-				typeof line == "number" &&
-				(typeof Reflect.get(game, "readFile") == "function" || location.origin != "file://")
-			) {
+			if (typeof line == "number" && (typeof Reflect.get(game, "readFile") == "function" || location.origin != "file://")) {
 				const createShowCode = function (lines) {
 					let showCode = "";
 					if (lines.length >= 10) {
@@ -1036,18 +975,14 @@ async function setOnError() {
 							}
 						}
 					} else {
-						showCode = lines
-							.map((_line, i) => `${i + 1}| ${line == i + 1 ? "⚠️" : ""}${_line}\n`)
-							.toString();
+						showCode = lines.map((_line, i) => `${i + 1}| ${line == i + 1 ? "⚠️" : ""}${_line}\n`).toString();
 					}
 					return showCode;
 				};
 				//协议名须和html一致(网页端防跨域)，且文件是js
 				if (typeof src == "string" && src.startsWith(location.protocol) && src.endsWith(".js")) {
 					//获取代码
-					const codes = lib.init.reqSync(
-						"local:" + decodeURI(src).replace(lib.assetURL, "").replace(winPath, "")
-					);
+					const codes = lib.init.reqSync("local:" + decodeURI(src).replace(lib.assetURL, "").replace(winPath, ""));
 					if (codes) {
 						const lines = codes.split("\n");
 						str += "\n" + createShowCode(lines);
@@ -1059,7 +994,7 @@ async function setOnError() {
 				else if (
 					err &&
 					err.stack &&
-					["at Object.eval [as content]", "at Proxy.content"].some((str) => {
+					["at Object.eval [as content]", "at Proxy.content"].some(str => {
 						let stackSplit1 = err.stack.split("\n")[1];
 						if (stackSplit1) {
 							return stackSplit1.trim().startsWith(str);
@@ -1075,12 +1010,7 @@ async function setOnError() {
 					}
 				}
 			}
-			if (err && err.stack)
-				str +=
-					"\n" +
-					decodeURI(err.stack)
-						.replace(new RegExp(lib.assetURL, "g"), "")
-						.replace(new RegExp(winPath, "g"), "");
+			if (err && err.stack) str += "\n" + decodeURI(err.stack).replace(new RegExp(lib.assetURL, "g"), "").replace(new RegExp(winPath, "g"), "");
 			alert(str);
 			game.print(str);
 		}
@@ -1092,8 +1022,7 @@ async function setOnError() {
 		if (promiseErrorHandler.onErrorFinish) promiseErrorHandler.onErrorFinish();
 		// @ts-ignore
 		if (!lib.config.errstop && _status && _status.event) {
-			if (_status.event.content instanceof AsyncFunction ||
-				Array.isArray(_status.event.contents)) return;
+			if (_status.event.content instanceof AsyncFunction || Array.isArray(_status.event.contents)) return;
 			_status.withError = true;
 			game.loop();
 		}

--- a/noname/init/onload.js
+++ b/noname/init/onload.js
@@ -671,7 +671,7 @@ async function tryLoadCustomStyle(id, keys, fallback) {
 
 	if (lib.config[id] === "custom") {
 		await Promise.allSettled(
-			Object.entries(keys).map(async (key, callback) => {
+			Object.entries(keys).map(async ([key, callback]) => {
 				const fileToLoad = await game.getDB("image", key);
 				if (fileToLoad) {
 					const fileLoadedEvent = await new Promise((resolve, reject) => {
@@ -681,7 +681,7 @@ async function tryLoadCustomStyle(id, keys, fallback) {
 						fileReader.readAsDataURL(fileToLoad, "UTF-8");
 					});
 
-					await callback(fileLoadedEvent.target.result);
+					await callback?.(fileLoadedEvent.target.result);
 				} else {
 					fallback?.();
 				}

--- a/noname/init/onload.js
+++ b/noname/init/onload.js
@@ -10,7 +10,7 @@ import { importMode } from "./import.js";
 import { jumpToCatchBlock } from "../util/index.js";
 import { Mutex } from "../util/mutex.js";
 
-export async function onload(resetGameTimeout) {
+export async function onload() {
 	const libOnload = lib.onload;
 	delete lib.onload;
 	await runCustomContents(libOnload);
@@ -86,7 +86,6 @@ export async function onload(resetGameTimeout) {
 	lib.onloadSplashes.forEach(splash => {
 		lib.configMenu.appearence.config.splash_style.item[splash.id] = splash.name;
 	});
-	Reflect.set(window, "resetGameTimeout", resetGameTimeout);
 
 	// 改不动，暂时不改了
 	const proceed2 = async () => {
@@ -533,7 +532,7 @@ export async function onload(resetGameTimeout) {
 	localStorage.removeItem(lib.configprefix + "directstart");
 	if (!lib.imported.mode?.[lib.config.mode]) {
 		window.inSplash = true;
-		clearTimeout(resetGameTimeout);
+		clearTimeout(window.resetGameTimeout);
 
 		if (lib.config.splash_style == undefined) game.saveConfig("splash_style", lib.onloadSplashes[0].id);
 		let splash = lib.onloadSplashes.find(item => item.id == lib.config.splash_style);


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
Android由理版

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
有人反应，通过由理版打开扩展压缩包导入扩展，会提示已导入完成，文件也存在，但进入游戏，并没有正常导入

### PR描述
<!-- 详细描述您的更改 -->
调整了一下加载顺序，现在导入扩展将必然等待`game.saveConfig`完毕才重启


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
使用由理兼容版测试
最初的状态:
![Screenshot_2024 07 09_19 04 45 850](https://github.com/libccy/noname/assets/29033099/8b8c6ffb-0259-4c6d-a5f8-f522ebb56200)
通过由理版导入扩展:
![Screenshot_2024 07 09_19 05 06 216](https://github.com/libccy/noname/assets/29033099/40817477-80de-4258-9e76-12a76a788841)
导入后的状态，可以看到扩展存在:
![Screenshot_2024 07 09_19 05 20 933](https://github.com/libccy/noname/assets/29033099/f1cf94b6-02e0-49c5-b5e9-ff201f2718e1)



### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需适配，除非用了之前导致的一些未知特性，因为更改了加载逻辑

> 不要问啥特性，因为我也不知道


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
