### PR TITLE
bugfix

### DIFF
--- a/character/huicui/skill.js
+++ b/character/huicui/skill.js
@@ -13203,7 +13203,7 @@ const skills = {
 			} else {
 				const targets = event.targets;
 				targets.sortBySeat();
-				game.asyncDraw(targets);
+				await game.asyncDraw(targets);
 			}
 		},
 	},


### PR DESCRIPTION
### PR受影响的平台
所有平台



### PR描述
修复国战【望归】只有自己摸牌的bug



### 扩展适配
无需适配



### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
