### PR TITLE
修复本体中所有错误传参的get.type

### DIFF
--- a/character/clan/skill.js
+++ b/character/clan/skill.js
@@ -773,7 +773,7 @@ const skills = {
 			result: {
 				target(player, target) {
 					var cards = player.getCards("hs", card => {
-						if (get.name(card, player) != "sha" && get.type(card, player) != "trick") return false;
+						if (get.name(card, player) != "sha" && get.type(card, null, player) != "trick") return false;
 						return player.hasValueTarget(card);
 					});
 					if (cards.some(card => player.canUse(card, target) && get.effect(target, card, player, player) > 0)) {

--- a/character/ddd/skill.js
+++ b/character/ddd/skill.js
@@ -2029,7 +2029,7 @@ const skills = {
 			if (event.type != "discard") return false;
 			var cards = event.getd();
 			for (var i of cards) {
-				if (get.position(i, true) == "d" && get.color(i, false) == "black" && get.type(i, null, true) == "basic") {
+				if (get.position(i, true) == "d" && get.color(i, false) == "black" && get.type(i) == "basic") {
 					var card = get.autoViewAs({ name: "bingliang" }, [i]);
 					if (
 						game.hasPlayer(function (current) {
@@ -2045,7 +2045,7 @@ const skills = {
 			"step 0";
 			if (!event.cards) event.cards = [];
 			var cards = trigger.getd().filter(function (i) {
-				if (!event.cards.includes(i) && get.position(i, true) == "d" && get.color(i, false) == "black" && get.type(i, null, true) == "basic") {
+				if (!event.cards.includes(i) && get.position(i, true) == "d" && get.color(i, false) == "black" && get.type(i) == "basic") {
 					var card = get.autoViewAs({ name: "bingliang" }, [i]);
 					if (
 						game.hasPlayer(function (current) {
@@ -5589,7 +5589,7 @@ const skills = {
 		filter(event, player) {
 			if (event.player == player) return false;
 			if (event.name == "recover") return player.isDamaged();
-			return get.type(event.card, false) == "equip" && event.cards.some(i => get.position(i, true) == "o" && player.canEquip(i, true));
+			return get.type(event.card, null, false) == "equip" && event.cards.some(i => get.position(i, true) == "o" && player.canEquip(i, true));
 		},
 		limited: true,
 		skillAnimation: true,
@@ -5621,7 +5621,7 @@ const skills = {
 				trigger: { player: ["recoverAfter", "useCardAfter"] },
 				filter(event, player) {
 					if (event.getParent().name == "dddjiexing") return false;
-					if (event.name == "useCard") return get.type(event.card, false) == "equip";
+					if (event.name == "useCard") return get.type(event.card, null, false) == "equip";
 					return true;
 				},
 				forced: true,

--- a/character/diy/skill.js
+++ b/character/diy/skill.js
@@ -216,7 +216,7 @@ const skills = {
 					return player.hasHistory("lose", function (evt) {
 						if (evt.type != "discard" || evt.getParent("phaseDiscard") != event) return false;
 						for (var i of evt.cards2) {
-							if (get.type(i, false) == "basic" && get.position(i, true) == "d" && player.hasUseTarget(i)) return true;
+							if (get.type(i, null, false) == "basic" && get.position(i, true) == "d" && player.hasUseTarget(i)) return true;
 						}
 						return false;
 					});
@@ -227,7 +227,7 @@ const skills = {
 					player.getHistory("lose", function (evt) {
 						if (evt.type != "discard" || evt.getParent("phaseDiscard") != trigger) return false;
 						for (var i of evt.cards2) {
-							if (get.type(i, false) == "basic" && get.position(i, true) == "d") cards.push(i);
+							if (get.type(i, null, false) == "basic" && get.position(i, true) == "d") cards.push(i);
 						}
 						return false;
 					});
@@ -291,7 +291,7 @@ const skills = {
 			"step 1";
 			if (result.index == 0) {
 				var card = get.cardPile2(function (card) {
-					return get.type(card, false) == "basic";
+					return get.type(card, null, false) == "basic";
 				});
 				if (card) player.gain(card, "gain2");
 				event.finish();
@@ -920,7 +920,7 @@ const skills = {
 		delay: false,
 		check(card) {
 			var player = _status.event.player;
-			if (get.type(card, player) == "basic") {
+			if (get.type(card) == "basic") {
 				if (
 					game.hasPlayer(function (current) {
 						return get.attitude(current, player) > 0 && current.getUseValue(card) > player.getUseValue(card, null, true);

--- a/character/extra/skill.js
+++ b/character/extra/skill.js
@@ -2571,7 +2571,7 @@ const skills = {
 		audio: 2,
 		trigger: { player: "useCardAfter" },
 		filter(event, player) {
-			if (!event._dccuixin || get.type(event.card, false) == "delay" || get.type(event.card, false) == "equip") return false;
+			if (!event._dccuixin || get.type(event.card, null, false) == "delay" || get.type(event.card, null, false) == "equip") return false;
 			var card = {
 					name: event.card.name,
 					nature: event.card.nature,
@@ -4225,7 +4225,7 @@ const skills = {
 				trigger: { player: "useCardToTargeted" },
 				forced: true,
 				filter(event, player) {
-					if (get.type(event.card, false) != "equip" || player != event.target || event.card.name.indexOf("changandajian_equip") == 0) return false;
+					if (get.type(event.card, null, false) != "equip" || player != event.target || event.card.name.indexOf("changandajian_equip") == 0) return false;
 					if (!player.storage.yuheng) return false;
 					var list = ["xinfu_guanchao", "drlt_jueyan", "lanjiang"];
 					for (var i of list) {

--- a/character/huicui/skill.js
+++ b/character/huicui/skill.js
@@ -4370,7 +4370,7 @@ const skills = {
 				filter: function (event, player) {
 					if (!player.hasMark("dcgonghu_basic") || !player.hasMark("dcgonghu_damage")) return false;
 					var card = event.card;
-					if (get.color(card, false) != "red" || get.type(card, null, true) != "trick") return false;
+					if (get.color(card, false) != "red" || get.type(card, null, false) != "trick") return false;
 					var info = get.info(card);
 					if (info.allowMultiple == false) return false;
 					if (event.targets && !info.multitarget) {
@@ -6166,7 +6166,7 @@ const skills = {
 						Math.min(
 							5,
 							player.countCards("h", function (card) {
-								return get.type(card, player) == "basic";
+								return get.type(card, null, player) == "basic";
 							})
 						)
 					);
@@ -6184,7 +6184,7 @@ const skills = {
 				var num = Math.min(
 					5,
 					player.countCards("h", function (cardx) {
-						var type = get.type(cardx, player);
+						var type = get.type(cardx, null, player);
 						return (name == "dcneifa_basic") != (type == "basic") && type != "equip";
 					})
 				);
@@ -10415,7 +10415,7 @@ const skills = {
 				charlotte: true,
 				logTarget: "target",
 				filter: function (event, player) {
-					return event.target != player && (event.card.name == "sha" || get.type(event.card, false) == "trick") && event.target.countCards("he") > 0;
+					return event.target != player && (event.card.name == "sha" || get.type(event.card, null, false) == "trick") && event.target.countCards("he") > 0;
 				},
 				content: function () {
 					"step 0";
@@ -10429,7 +10429,7 @@ const skills = {
 				ai: {
 					effect: {
 						player_use(card, player, target) {
-							if (player !== target && get.itemtype(target) === "player" && (card.name === "sha" || get.type(card, false) === "trick") && target.countCards("he") && !target.hasSkillTag("noh")) return [1, 0, 1, -1];
+							if (player !== target && get.itemtype(target) === "player" && (card.name === "sha" || get.type(card, null, false) === "trick") && target.countCards("he") && !target.hasSkillTag("noh")) return [1, 0, 1, -1];
 						},
 					},
 				},
@@ -12824,7 +12824,7 @@ const skills = {
 				filter: function (event, player) {
 					if (!player.hasMark("zhtongyuan_basic") || !player.hasMark("zhtongyuan_trick")) return false;
 					var card = event.card;
-					if (get.color(card, false) != "red" || get.type(card, null, true) != "basic") return false;
+					if (get.color(card, false) != "red" || get.type(card, null, false) != "basic") return false;
 					var info = get.info(card);
 					if (info.allowMultiple == false) return false;
 					if (event.targets && !info.multitarget) {
@@ -13178,7 +13178,7 @@ const skills = {
 		filter: function (event, player) {
 			if (player == event.player || event.targets.length != 1) return false;
 			var bool = function (card) {
-				return (card.name == "sha" || get.type(card, false) == "trick") && get.color(card, false) == "black";
+				return (card.name == "sha" || get.type(card, null, false) == "trick") && get.color(card, false) == "black";
 			};
 			if (!bool(event.card)) return false;
 			var evt = event.getParent("phaseUse");

--- a/character/key/skill.js
+++ b/character/key/skill.js
@@ -110,7 +110,7 @@ const skills = {
 			player.showCards(cards, get.translation(player) + "发动了【天全】");
 			game.cardsGotoOrdering(cards).relatedEvent = trigger.getParent();
 			var num = cards.filter(function (card) {
-				return get.type(card, false) == "basic";
+				return get.type(card, null, false) == "basic";
 			}).length;
 			if (num) {
 				if (trigger.card.name == "sha") {
@@ -138,7 +138,7 @@ const skills = {
 					)
 						player.gain(
 							cards.filter(function (card) {
-								return get.type(card, false) != "basic";
+								return get.type(card, null, false) != "basic";
 							}),
 							"gain2"
 						);
@@ -278,7 +278,7 @@ const skills = {
 				charlotte: true,
 				filter(event, player) {
 					if (event.card.name == "sha") return true;
-					return get.type(event.card, false) == "trick" && get.tag(event.card, "damage") > 0;
+					return get.type(event.card, null, false) == "trick" && get.tag(event.card, "damage") > 0;
 				},
 				content() {
 					player.draw();
@@ -591,7 +591,7 @@ const skills = {
 				player.showCards(cards, get.translation(player) + "发动了【天全】");
 				game.cardsGotoOrdering(cards).relatedEvent = trigger.getParent();
 				var num = cards.filter(function (card) {
-					return get.type(card, false) == "basic";
+					return get.type(card, null, false) == "basic";
 				}).length;
 				if (num) {
 					if (trigger.card.name == "sha") {
@@ -626,7 +626,7 @@ const skills = {
 						)
 							player.gain(
 								cards.filter(function (card) {
-									return get.type(card, false) != "basic";
+									return get.type(card, null, false) != "basic";
 								}),
 								"gain2"
 							);
@@ -1756,7 +1756,7 @@ const skills = {
 		promptfunc: () => "出牌阶段，你可以赠予一张“米券”，然后执行一项本回合内未被选择过的效果：⒈对其造成1点伤害；⒉摸两张牌；⒊弃置其的两张牌；⒋亮出牌堆顶的一张牌，然后你可以使用之。",
 		check: card => {
 			const player = _status.event.player;
-			return get.type(card, false) == "equip" && game.hasPlayer(current => player.canGift(card, current, true) && !current.refuseGifts(card, player) && get.effect(current, card, player, player) > 0) ? 2 : 1 + Math.random();
+			return get.type(card) == "equip" && game.hasPlayer(current => player.canGift(card, current, true) && !current.refuseGifts(card, player) && get.effect(current, card, player, player) > 0) ? 2 : 1 + Math.random();
 		},
 		content() {
 			"step 0";
@@ -5298,7 +5298,7 @@ const skills = {
 				return true;
 			if (
 				player.getHistory("sourceDamage", function (evt) {
-					return get.type(evt.card, false) == "trick" && evt.getParent("phaseUse") == event;
+					return get.type(evt.card, null, false) == "trick" && evt.getParent("phaseUse") == event;
 				}).length == 0
 			)
 				return true;
@@ -5315,7 +5315,7 @@ const skills = {
 				num++;
 			if (
 				player.getHistory("sourceDamage", function (evt) {
-					return get.type(evt.card, false) == "trick" && evt.getParent("phaseUse") == trigger;
+					return get.type(evt.card, null, false) == "trick" && evt.getParent("phaseUse") == trigger;
 				}).length == 0
 			)
 				num++;
@@ -6394,7 +6394,7 @@ const skills = {
 				player(player) {
 					if (
 						player.countCards("he", function (card) {
-							if (get.type(card, player) == "equip") return get.value(card) < 6;
+							if (get.type(card, null, player) == "equip") return get.value(card) < 6;
 							return get.value(card) < 5;
 						}) < 2
 					)
@@ -6744,12 +6744,12 @@ const skills = {
 			return player.countCards("he", lib.skill.kaori_siyuan.filterCard);
 		},
 		filterCard(card) {
-			return ["equip", "delay"].includes(get.type(card, false));
+			return ["equip", "delay"].includes(get.type(card));
 		},
 		filterTarget(card, player, target) {
 			if (player == target) return false;
 			var card = ui.selected.cards[0];
-			if (get.type(card, false) == "delay") return target.canAddJudge({ name: card.name });
+			if (get.type(card) == "delay") return target.canAddJudge({ name: get.name(card, player) });
 			return target.canEquip(card);
 		},
 		discard: false,
@@ -6758,8 +6758,8 @@ const skills = {
 		content() {
 			"step 0";
 			var card = cards[0];
-			if (get.type(card, false) == "equip") target.equip(card);
-			else target.addJudge(card);
+			if (get.type(card) == "equip") target.equip(card);
+			else target.addJudge(get.name(card, player), [card]);
 			"step 1";
 			var list = [];
 			for (var i of lib.inpile) {

--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -1787,7 +1787,7 @@ const skills = {
 				names = [];
 			for (let i = 0; i < ui.discardPile.childElementCount; i++) {
 				let card = ui.discardPile.childNodes[i];
-				if (get.type(card, false) == "basic" && !names.includes(card.name)) {
+				if (get.type(card, null, false) == "basic" && !names.includes(card.name)) {
 					gains.push(card);
 					names.push(card.name);
 				}
@@ -4987,7 +4987,7 @@ const skills = {
 				event.redo();
 			}
 			"step 3";
-			var card = get.cardPile2(card => get.type(card, false) == "equip");
+			var card = get.cardPile2(card => get.type(card, null, false) == "equip");
 			if (card) player.gain(card, "gain2");
 		},
 		ai: {
@@ -5470,7 +5470,7 @@ const skills = {
 				direct: true,
 				onremove: true,
 				filter: function (event, player) {
-					var type = get.type(event.card, false);
+					var type = get.type(event.card, null, false);
 					return type == "basic" || type == "trick";
 				},
 				content: function () {
@@ -6045,13 +6045,13 @@ const skills = {
 		audio: 3,
 		liujing_filter: [
 			function (card) {
-				return get.type(card, false) == "trick" && get.tag(card, "damage", null, false) > 0;
+				return get.type(card, null, false) == "trick" && get.tag(card, "damage", null, false) > 0;
 			},
-			card => get.type(card, false) == "basic",
+			card => get.type(card, null, false) == "basic",
 			card => get.name(card, false) == "wuxie",
 			card => get.name(card, false) == "wuzhong",
 			card => get.name(card, false) == "lebu",
-			card => get.type(card, false) == "equip",
+			card => get.type(card, null, false) == "equip",
 		],
 		getLiujing: function (player, index) {
 			var filter = lib.skill.chengye.liujing_filter[index],
@@ -6074,7 +6074,7 @@ const skills = {
 			} else if (event.name != "cardsDiscard") {
 				var cards = event.getd(null, "cards2").filter(function (card) {
 					if (get.position(card, true) != "d") return false;
-					var type = get.type(card, false);
+					var type = get.type(card, null, false);
 					return type == "delay" || type == "equip";
 				});
 				cards.removeArray(event.getd(player, "cards2"));
@@ -6086,7 +6086,7 @@ const skills = {
 				if (evt2.name != "phaseJudge" || evt2.player == player) return;
 				var cards = event.cards.filter(function (card) {
 					if (get.position(card, true) != "d") return false;
-					var type = get.type(card, false);
+					var type = get.type(card, null, false);
 					return type == "delay";
 				});
 				if (!cards.length) return false;
@@ -6107,14 +6107,14 @@ const skills = {
 			} else if (trigger.name != "cardsDiscard") {
 				cards = trigger.getd().filter(function (card) {
 					if (card.original == "j" || get.position(card, true) != "d") return false;
-					var type = get.type(card, false);
+					var type = get.type(card, null, false);
 					return type == "delay" || type == "equip";
 				});
 				cards.removeArray(trigger.getd(player));
 			} else {
 				cards = trigger.cards.filter(function (card) {
 					if (get.position(card, true) != "d") return false;
-					var type = get.type(card, false);
+					var type = get.type(card, null, false);
 					return type == "delay";
 				});
 			}
@@ -6521,7 +6521,7 @@ const skills = {
 		filter: function (event, player) {
 			if (!player.countCards("he")) return false;
 			for (var i of lib.inpile) {
-				if (i != "du" && get.type(i, false) == "basic") {
+				if (i != "du" && get.type(i, null, false) == "basic") {
 					if (event.filterCard({ name: i }, player, event)) return true;
 					if (i == "sha") {
 						for (var j of lib.inpile_nature) {
@@ -6547,7 +6547,7 @@ const skills = {
 				var suit = event.xinjianying_suit || "",
 					str = get.translation(suit);
 				for (var i of lib.inpile) {
-					if (i != "du" && get.type(i, false) == "basic") {
+					if (i != "du" && get.type(i, null, false) == "basic") {
 						if (event.filterCard({ name: i }, player, event)) list.push(["基本", str, i]);
 						if (i == "sha") {
 							for (var j of lib.inpile_nature) {
@@ -8304,7 +8304,7 @@ const skills = {
 		direct: true,
 		filter: function (event, player) {
 			return (
-				get.type(event.card, false) != "delay" &&
+				get.type(event.card, null, false) != "delay" &&
 				game.hasPlayer(function (current) {
 					return player != current && (!player.storage.discretesidi || !player.storage.discretesidi.includes(current));
 				})
@@ -8371,7 +8371,7 @@ const skills = {
 				filter: function (event, player) {
 					if (!player.storage.discretesidi || !player.storage.discretesidi.includes(event.player)) return false;
 					if (event.name == "die") return true;
-					if (get.type(event.card, false) != "delay") {
+					if (get.type(event.card, null, false) != "delay") {
 						var index = player.storage.discretesidi.indexOf(event.player);
 						return index != -1 && (player.storage.discretesidi2[index] != event.target || event.targets.length != 1);
 					}
@@ -8388,7 +8388,7 @@ const skills = {
 				forced: true,
 				locked: false,
 				filter: function (event, player) {
-					if (get.type(event.card, false) == "delay" || !player.storage.discretesidi || event.targets.length != 1) return false;
+					if (get.type(event.card, null, false) == "delay" || !player.storage.discretesidi || event.targets.length != 1) return false;
 					var index = player.storage.discretesidi.indexOf(event.player);
 					return index != -1 && player.storage.discretesidi2[index] == event.target;
 				},
@@ -14852,7 +14852,7 @@ const skills = {
 	xinzhanyi_basic1: {
 		trigger: { player: "useCard" },
 		filter: function (event, player) {
-			return get.type(event.card, false) == "basic" && player.hasMark("xinzhanyi_basic1");
+			return get.type(event.card, null, false) == "basic" && player.hasMark("xinzhanyi_basic1");
 		},
 		forced: true,
 		silent: true,

--- a/character/newjiang/skill.js
+++ b/character/newjiang/skill.js
@@ -1254,8 +1254,8 @@ const skills = {
 		direct: true,
 		content: function () {
 			"step 0";
-			if (player.hasSkill("shiming_round")) {
-				var zhu = game.findPlayer(i => i.getSeatNum() == 1);
+			var zhu = game.findPlayer(i => i.getSeatNum() == 1);
+			if (zhu && player.hasSkill("shiming_round")) {
 				if (
 					game.getGlobalHistory("changeHp", evt => {
 						return evt.player == zhu && evt._dyinged;

--- a/character/offline/skill.js
+++ b/character/offline/skill.js
@@ -5121,7 +5121,7 @@ const skills = {
 			event.target.markAuto("yjxiandao_block", [get.suit(event.card, false)]);
 			event.target.addTempSkill("yjxiandao_block");
 			"step 1";
-			var type = get.type(card, false);
+			var type = get.type(card);
 			if (type == "trick") player.draw(2);
 			if (type == "equip") {
 				if (
@@ -5303,7 +5303,7 @@ const skills = {
 						max = 0;
 					for (var i of hs) {
 						val += get.value(i, player);
-						if (get.type(i, player) == "trick") max += 5;
+						if (get.type(i, null, player) == "trick") max += 5;
 					}
 					if (player.hasSkill("zhenjue")) max += 7;
 					return val <= max ? 1 : 0;

--- a/character/onlyOL/skill.js
+++ b/character/onlyOL/skill.js
@@ -1171,8 +1171,8 @@ const skills = {
 			if (event.getParent(3).name != "phaseDiscard") return false;
 			const cards = get.info("olzongxuan").getCards(event, player);
 			return game.hasPlayer(target => {
-				if (cards.some(i => get.type(i, target) == "equip") && (get.attitude(player, target) > 0 || get.recoverEffect(target, player, player) > 0)) return true;
-				if (cards.some(i => get.type(i, target) != "equip") && target.getHp() >= player.getHp() && get.effect(target, { name: "losehp" }, player, player) > 0) return true;
+				if (cards.some(i => get.type(i, null, target) == "equip") && (get.attitude(player, target) > 0 || get.recoverEffect(target, player, player) > 0)) return true;
+				if (cards.some(i => get.type(i, null, target) != "equip") && target.getHp() >= player.getHp() && get.effect(target, { name: "losehp" }, player, player) > 0) return true;
 				return false;
 			});
 		},
@@ -1188,8 +1188,8 @@ const skills = {
 					const cards = list[0][1].slice(),
 						cards2 = cards.filter(card => {
 							return game.hasPlayer(target => {
-								if (get.type(card, target) == "equip" && (get.attitude(player, target) > 0 || get.recoverEffect(target, player, player) > 0)) return true;
-								if (get.type(card, target) != "equip" && target.getHp() >= player.getHp() && get.effect(target, { name: "losehp" }, player, player) > 0) return true;
+								if (get.type(card, null, target) == "equip" && (get.attitude(player, target) > 0 || get.recoverEffect(target, player, player) > 0)) return true;
+								if (get.type(card, null, target) != "equip" && target.getHp() >= player.getHp() && get.effect(target, { name: "losehp" }, player, player) > 0) return true;
 								return false;
 							});
 						}),
@@ -1243,8 +1243,8 @@ const skills = {
 					if (!cards.length) return 0;
 					const card = cards[0],
 						att = get.attitude(player, target);
-					if (get.type(card, target) == "equip" && (get.attitude(player, target) > 0 || get.recoverEffect(target, player, player) > 0)) return get.recoverEffect(target, player, player) * 20 + att / 114514;
-					if (get.type(card, target) != "equip") {
+					if (get.type(card, null, target) == "equip" && (get.attitude(player, target) > 0 || get.recoverEffect(target, player, player) > 0)) return get.recoverEffect(target, player, player) * 20 + att / 114514;
+					if (get.type(card, null, target) != "equip") {
 						if (target.getHp() >= player.getHp()) return get.effect(target, { name: "losehp" }, player, player) * 20 - att / 114514;
 						return get.effect(target, { name: "draw" }, player, player);
 					}
@@ -1257,7 +1257,7 @@ const skills = {
 				const { result } = await target.draw("visible");
 				if (result) {
 					const card = result[0];
-					if (get.type(card, target) == "equip") {
+					if (get.type(card, null, target) == "equip") {
 						if (target.getCards("h").includes(card) && target.hasUseTarget(card)) {
 							const {
 								result: { bool },

--- a/character/refresh/skill.js
+++ b/character/refresh/skill.js
@@ -778,7 +778,7 @@ const skills = {
 			if (result.bool) {
 				var num = result.cards.length;
 				for (var i of result.cards) {
-					if (get.type(i, false) == "equip") num++;
+					if (get.type(i) == "equip") num++;
 				}
 				event.cards = game.cardsGotoOrdering(get.cards(num)).cards;
 				player.showCards(event.cards);
@@ -840,7 +840,7 @@ const skills = {
 				trigger: { player: "useCard" },
 				forced: true,
 				filter: function (event, player) {
-					if (event.card.name != "sha" && get.type(event.card, false) != "trick") return false;
+					if (event.card.name != "sha" && get.type(event.card, null, false) != "trick") return false;
 					for (var i = 2; i < 6; i++) {
 						if (!player.hasEmptySlot(i)) return false;
 					}
@@ -853,7 +853,7 @@ const skills = {
 				ai: {
 					directHit_ai: true,
 					skillTagFilter: function (player, tag, arg) {
-						if (!arg || !arg.card || !arg.target || (arg.card.name != "sha" && get.type(arg.card, false) != "trick")) return false;
+						if (!arg || !arg.card || !arg.target || (arg.card.name != "sha" && get.type(arg.card, null, false) != "trick")) return false;
 						for (var i = 2; i < 6; i++) {
 							if (!player.hasEmptySlot(i)) return false;
 						}
@@ -4275,7 +4275,7 @@ const skills = {
 			var card = result.cards[0],
 				target = trigger.player;
 			player.showCards(card, get.translation(player) + "对" + (player == target ? "自己" : get.translation(target)) + "发动了【补益】");
-			if (get.type(card, target) != "basic") {
+			if (get.type(card, null, target) != "basic") {
 				target.discard(card);
 				target.recover();
 				if (target.countCards("h") == 1) target.draw();

--- a/character/shenhua/skill.js
+++ b/character/shenhua/skill.js
@@ -429,13 +429,13 @@ const skills = {
 				filter(event, player) {
 					return (
 						player.getExpansions("olkongsheng").filter(function (card) {
-							return get.type(card, false) != "equip";
+							return get.type(card, null, false) != "equip";
 						}).length > 0
 					);
 				},
 				async content(event, trigger, player) {
 					let cards = player.getExpansions("olkongsheng").filter(function (card) {
-						return get.type(card, false) != "equip";
+						return get.type(card, null, false) != "equip";
 					});
 					if (cards.length) await player.gain(cards, "gain2");
 					cards = player.getExpansions("olkongsheng");
@@ -1626,7 +1626,7 @@ const skills = {
 			player.addTempSkill("kongsheng_ai", "kongsheng2After");
 			while (true) {
 				const cards = player.getExpansions("kongsheng2").filter(function (i) {
-					return get.type(i, false) == "equip" && player.hasUseTarget(i);
+					return get.type(i, null, false) == "equip" && player.hasUseTarget(i);
 				});
 				if (cards.length > 0) {
 					let [card] = cards;

--- a/character/shiji/skill.js
+++ b/character/shiji/skill.js
@@ -893,7 +893,7 @@ const skills = {
 		trigger: { global: "useCardToTarget" },
 		usable: 1,
 		filter: function (event, player) {
-			return (event.card.name == "sha" || get.type(event.card, false) == "delay") && event.player != player && !event.targets.includes(player) && player.inRange(event.target);
+			return (event.card.name == "sha" || get.type(event.card, null, false) == "delay") && event.player != player && !event.targets.includes(player) && player.inRange(event.target);
 		},
 		logTarget: "target",
 		check: function (event, player) {
@@ -1638,7 +1638,7 @@ const skills = {
 				} else event.finish();
 			}
 			"step 1";
-			if (player.getCards("h").includes(card) && get.type(card, player) == "equip" && player.hasUseTarget(card)) player.chooseUseTarget(card, true, "nopopup");
+			if (player.getCards("h").includes(card) && get.type(card, null, player) == "equip" && player.hasUseTarget(card)) player.chooseUseTarget(card, true, "nopopup");
 			"step 2";
 			var hs = target.getCards("h", function (card) {
 				return target.canUse(get.autoViewAs({ name: "sha" }, [card]), player, false);
@@ -2548,7 +2548,7 @@ const skills = {
 				event.targets.length == 1 &&
 				(event.target.countGainableCards(player, "h") > 0 ||
 					player.hasCard(function (i) {
-						return _status.connectMode || (get.type(i, player) == "basic" && lib.filter.cardDiscardable(i, player, "dbquedi"));
+						return _status.connectMode || (get.type(i, null, player) == "basic" && lib.filter.cardDiscardable(i, player, "dbquedi"));
 					}, "h"))
 			);
 		},
@@ -2560,7 +2560,7 @@ const skills = {
 			if (target.countGainableCards(player, "h") > 0) list.push("选项一");
 			if (
 				player.hasCard(function (i) {
-					return get.type(i, player) == "basic" && lib.filter.cardDiscardable(i, player, "dbquedi");
+					return get.type(i, null, player) == "basic" && lib.filter.cardDiscardable(i, player, "dbquedi");
 				}, "h")
 			)
 				list.push("选项二");
@@ -2579,7 +2579,7 @@ const skills = {
 					var bool1 = target.countGainableCards(player, "h") > 0;
 					var bool2 =
 						player.hasCard(function (i) {
-							return get.type(i, player) == "basic" && lib.filter.cardDiscardable(i, player, "dbquedi") && get.value(card, player) < 5;
+							return get.type(i, null, player) == "basic" && lib.filter.cardDiscardable(i, player, "dbquedi") && get.value(card, player) < 5;
 						}, "h") &&
 						!target.hasSkillTag("filterDamage", null, {
 							player: player,
@@ -2605,7 +2605,7 @@ const skills = {
 			if (
 				(event.control == "选项二" || event.control == "背水！") &&
 				player.hasCard(function (i) {
-					return get.type(i, player) == "basic" && lib.filter.cardDiscardable(i, player, "dbquedi");
+					return get.type(i, null, player) == "basic" && lib.filter.cardDiscardable(i, player, "dbquedi");
 				}, "h")
 			) {
 				player.chooseToDiscard("h", "弃置一张基本牌", { type: "basic" }, true);
@@ -2870,7 +2870,7 @@ const skills = {
 		forced: true,
 		locked: false,
 		filter: function (event, player) {
-			return get.type(event.card, false) != "delay" && !player.getStorage("xingqi").includes(event.card.name);
+			return get.type(event.card, null, false) != "delay" && !player.getStorage("xingqi").includes(event.card.name);
 		},
 		content: function () {
 			player.markAuto("xingqi", [trigger.card.name]);
@@ -4972,7 +4972,7 @@ const skills = {
 					if (player.hasSkill("ejian") && !player.getStorage("ejian").includes(target)) {
 						var dam = get.damageEffect(target, player, target);
 						if (dam > 0) return dam;
-						var type = get.type(card, target),
+						var type = get.type(card, null, target),
 							ts = target.getCards("he", function (card) {
 								return get.type(card) == type;
 							});
@@ -5313,7 +5313,7 @@ const skills = {
 				event.finish();
 			} else player.gain(card, "gain2");
 			"step 3";
-			if (player.isIn() && player.getCards("h").includes(card) && get.type(card, player) == "equip") player.chooseUseTarget(card, true, "nopopup");
+			if (player.isIn() && player.getCards("h").includes(card) && get.type(card, null, player) == "equip") player.chooseUseTarget(card, true, "nopopup");
 		},
 		onremove: true,
 		intro: { content: "已发动过#次" },

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -2069,7 +2069,7 @@ const skills = {
 					filterCard: true,
 					position: "h",
 					ai1(card) {
-						if (get.type(card, false) == "equip") return 1 - get.value(card);
+						if (get.type2(card, false) == "equip") return 1 - get.value(card);
 						return 7 - get.value(card);
 					},
 					ai2(target) {
@@ -7333,7 +7333,7 @@ const skills = {
 					for (var cardx of cards2) {
 						var type = get.type2(cardx, player);
 						var card = get.discardPile(function (card) {
-							return get.type(card, false) == type && !cards2.includes(card) && !cards.includes(card);
+							return get.type2(card, false) == type && !cards2.includes(card) && !cards.includes(card);
 						});
 						if (card) cards.push(card);
 					}
@@ -12242,7 +12242,7 @@ const skills = {
 		filter: function (event, player) {
 			return player.hasCard(function (card) {
 				if (_status.connectMode) return true;
-				var type = get.type(card, player);
+				var type = get.type(card, null, player);
 				return type == "basic" || type == "trick";
 			}, "h");
 		},
@@ -12250,7 +12250,7 @@ const skills = {
 			"step 0";
 			player
 				.chooseCard("h", get.prompt("zhaogujing_skill"), "展示并视为使用一张基本牌或普通锦囊牌", function (card, player) {
-					var type = get.type(card, player);
+					var type = get.type(card, null, player);
 					return type == "basic" || type == "trick";
 				})
 				.set("ai", function (card) {
@@ -14956,7 +14956,7 @@ const skills = {
 		usable: 1,
 		filter: function (event, player) {
 			if (event.olfengzi_buff || !event.targets.length || !player.isPhaseUsing() || player.hasSkill("olfengzi_buff")) return false;
-			var type = get.type(event.card, false);
+			var type = get.type(event.card, null, false);
 			if (type != "basic" && type != "trick") return false;
 			return player.hasCard(function (i) {
 				if (_status.connectMode) return true;
@@ -14966,7 +14966,7 @@ const skills = {
 		content: function () {
 			"step 0";
 			if (player != game.me && !player.isUnderControl() && !player.isOnline()) game.delayx();
-			var type = get.type(trigger.card, false);
+			var type = get.type(trigger.card, null, false);
 			player
 				.chooseToDiscard("h", get.prompt("olfengzi"), "弃置一张" + get.translation(type) + "牌，令" + get.translation(trigger.card) + "结算两次", function (card, player) {
 					return get.type2(card, player) == _status.event.type;
@@ -16037,7 +16037,7 @@ const skills = {
 		trigger: { player: "useCard" },
 		forced: true,
 		filter: function (event, player) {
-			return get.type(event.card, false) == "basic";
+			return get.type(event.card, null, false) == "basic";
 		},
 		content: function () {
 			player.addSkill("wangong2");
@@ -17086,7 +17086,7 @@ const skills = {
 				var card = result.cards[0];
 				trigger.player.$throw(card);
 				game.delayx();
-				if (get.type(card, false) == "delay") trigger.player.addJudge(card);
+				if (get.type(card, null, false) == "delay") trigger.player.addJudge(card);
 				else trigger.player.addJudge({ name: get.color(card, false) == "red" ? "lebu" : "bingliang" }, result.cards);
 			}
 		},
@@ -17184,7 +17184,7 @@ const skills = {
 					filterCard: true,
 					position: "h",
 					ai1: function (card) {
-						if (get.type(card, false) == "equip") return 1 - get.value(card);
+						if (get.type2(card, false) == "equip") return 1 - get.value(card);
 						return 7 - get.value(card);
 					},
 					ai2: function (target) {
@@ -17682,7 +17682,7 @@ const skills = {
 						return card != cardx && get.name(card, player) == "sha" && player.hasValueTarget(card);
 					});
 					var numx = player.countCards("h", function (card) {
-						return get.type(card, player) != "basic";
+						return get.type2(card, player) != "basic";
 					});
 					num += Math.min(numx, Math.max(0, shas.length - player.getCardUsable("sha"))) * 0.7;
 					num +=
@@ -17708,7 +17708,7 @@ const skills = {
 						Math.min(
 							5,
 							player.countCards("h", function (card) {
-								return get.type(card, player) == "basic";
+								return get.type2(card, player) == "basic";
 							})
 						)
 					);
@@ -17740,7 +17740,7 @@ const skills = {
 				var num = Math.min(
 					5,
 					player.countCards("h", function (cardx) {
-						return (name == "neifa_basic") != (get.type(cardx, player) == "basic");
+						return (name == "neifa_basic") != (get.type2(cardx, player) == "basic");
 					})
 				);
 				if (num > 0) player.addMark(name, num, false);
@@ -18439,7 +18439,7 @@ const skills = {
 				for (var j = 0; j < history[i].lose.length; j++) {
 					if (history[i].lose[j].parent.name == "useCard") continue;
 					num += history[i].lose[j].cards2.filter(function (card) {
-						return get.type(card, false) == "equip";
+						return get.type(card) == "equip";
 					}).length;
 				}
 			}
@@ -25498,7 +25498,7 @@ const skills = {
 					if (
 						list.includes("trick") &&
 						source.countCards("h", function (card) {
-							return get.type(card, source) == "trick" && source.hasValueTarget(card);
+							return get.type(card, null, source) == "trick" && source.hasValueTarget(card);
 						}) > 1
 					)
 						return "trick";

--- a/character/sp2/skill.js
+++ b/character/sp2/skill.js
@@ -1566,7 +1566,9 @@ const skills = {
 						return result.winner.canUse({ name: 'sha' }, current, false) && get.effect(current, { name: 'sha' }, result.winner, result.winner) > 0;
 					})) return '选项一';
 					const eff1 = result.winner.getUseValue({ name: 'sha' });
-					const eff2 = (get.value(cards[0], result.winner) + get.value(cards[1], result.winner));
+					const eff2 = 0;
+					if (cards[0]) eff2 = get.value(cards[0], result.winner);
+					if (cards[1]) eff2 += get.value(cards[1], result.winner);
 					if (eff1 > eff2 * 2.5) return '选项二';
 					return '选项一';
 				}()).forResult();

--- a/character/sp2/skill.js
+++ b/character/sp2/skill.js
@@ -715,7 +715,7 @@ const skills = {
 		enable: "phaseUse",
 		filter(event, player) {
 			const cards = player.getCards("h", card => {
-				const type = get.type(card, player);
+				const type = get.type(card, null, player);
 				if (type != "basic" && type != "trick") return false;
 				return (
 					lib.filter.cardUsable(card, player) &&
@@ -733,7 +733,7 @@ const skills = {
 		filterCard(card, player) {
 			if (ui.selected.cards.length) return false;
 			const cards = player.getCards("h", card => {
-				const type = get.type(card, player);
+				const type = get.type(card, null, player);
 				if (type != "basic" && type != "trick") return false;
 				return (
 					lib.filter.cardUsable(card, player) &&
@@ -4424,7 +4424,7 @@ const skills = {
 				trigger: { source: ["damageBegin1", "recoverBegin"] },
 				filter: function (event, player) {
 					var evt = event.getParent();
-					return evt.type == "card" && get.type(evt.card, false) == "basic";
+					return evt.type == "card" && get.type(evt.card, null, false) == "basic";
 				},
 				forced: true,
 				logTarget: "player",
@@ -6259,7 +6259,7 @@ const skills = {
 		animationColor: "gray",
 		filter: function (event, player) {
 			return player.countCards("h", function (card) {
-				var type = get.type(card, player);
+				var type = get.type(card, null, player);
 				return (type == "basic" || type == "trick") && get.tag(card, "damage") > 0;
 			});
 		},
@@ -6281,7 +6281,7 @@ const skills = {
 				.set(
 					"aiCards",
 					player.getCards("h", function (card) {
-						var type = get.type(card, player);
+						var type = get.type(card, null, player);
 						return (type == "basic" || type == "trick") && get.tag(card, "damage") > 0;
 					})
 				);
@@ -6291,7 +6291,7 @@ const skills = {
 				player.logSkill("qljsuiren", target);
 				player.give(
 					player.getCards("h", function (card) {
-						var type = get.type(card, player);
+						var type = get.type(card, null, player);
 						return (type == "basic" || type == "trick") && get.tag(card, "damage") > 0;
 					}),
 					target,
@@ -7365,7 +7365,7 @@ const skills = {
 		forced: true,
 		filter: function (event, player) {
 			if (player == _status.currentPhase || player.countCards("h")) return false;
-			return event.card.name == "sha" || get.type(event.card, false) == "trick";
+			return event.card.name == "sha" || get.type(event.card, null, false) == "trick";
 		},
 		content: function () {
 			player.draw(2);
@@ -9084,7 +9084,7 @@ const skills = {
 				},
 				content: function () {
 					var card = get.cardPile2(function (card) {
-						var type = get.type(card, false);
+						var type = get.type(card, null, false);
 						if (type != "basic" && type != "trick") return false;
 						return get.tag(card, "damage") > 0;
 					});

--- a/character/tw/skill.js
+++ b/character/tw/skill.js
@@ -6826,7 +6826,7 @@ const skills = {
 			var cards = [];
 			for (var i = 0; i < ui.cardPile.childNodes.length; i++) {
 				var card = ui.cardPile.childNodes[i];
-				if (get.type(card) == "basic") cards.push(card);
+				if (get.type(card, null, false) == "basic") cards.push(card);
 			}
 			event.set("twmouli", cards);
 		},
@@ -6901,7 +6901,7 @@ const skills = {
 				var list = [];
 				for (var i = 0; i < ui.cardPile.childNodes.length; i++) {
 					var card = ui.cardPile.childNodes[i];
-					if (get.type(card, player) == "basic" && !list.includes(card.name)) list.push(card.name);
+					if (get.type(card, null, false) == "basic" && !list.includes(card.name)) list.push(card.name);
 				}
 				if (tag == "respondSha") return list.includes("sha");
 				if (tag == "respondShan") return list.includes("shan");
@@ -7029,7 +7029,7 @@ const skills = {
 			var evt = event.getl(player);
 			if (!evt || !evt.cards2 || !evt.cards2.length) return false;
 			for (var i of evt.cards2) {
-				if (get.type(i, player) != "basic") return true;
+				if (get.type(i, null, player) != "basic") return true;
 			}
 			return false;
 		},
@@ -7038,7 +7038,7 @@ const skills = {
 			var num = 0,
 				evt = trigger.getl(player);
 			for (var i of evt.cards2) {
-				if (get.type(i, player) != "basic" && num < 5) num++;
+				if (get.type(i, null, player) != "basic" && num < 5) num++;
 			}
 			player.chooseToGuanxing(num);
 			player.chooseBool("羽化：是否摸" + get.cnNumber(num) + "张牌？").set("frequentSkill", "twyuhua");
@@ -7313,7 +7313,7 @@ const skills = {
 					if (get.attitude(player, target) < 0 && player.hasSkill("twejian")) {
 						var dam = get.damageEffect(target, player, target);
 						if (dam > 0) return dam;
-						var type = get.type(card, target),
+						var type = get.type2(card, target),
 							ts = target.getCards("he", function (card) {
 								return get.type(card) == type;
 							});
@@ -14248,7 +14248,7 @@ const skills = {
 		direct: true,
 		usable: 1,
 		filter: function (event, player) {
-			return event.isFirstTarget && event.targets.length > 0 && (event.card.name == "sha" || (get.type(event.card, false) == "trick" && get.tag(event.card, "damage") > 0));
+			return event.isFirstTarget && event.targets.length > 0 && (event.card.name == "sha" || (get.type(event.card, null, false) == "trick" && get.tag(event.card, "damage") > 0));
 		},
 		content: function () {
 			"step 0";
@@ -14752,7 +14752,7 @@ const skills = {
 			} else event.finish();
 			"step 2";
 			var target = trigger.player;
-			if (target.getCards("h").includes(card) && get.type(card, target) == "equip" && target.hasUseTarget(card)) target.chooseUseTarget(card, "nopopup");
+			if (target.getCards("h").includes(card) && get.type(card, null, target) == "equip" && target.hasUseTarget(card)) target.chooseUseTarget(card, "nopopup");
 		},
 	},
 	//Powered by @污言噫对
@@ -16518,7 +16518,7 @@ const skills = {
 				names = [];
 			for (var i = 0; i < ui.discardPile.childNodes.length; i++) {
 				var card = ui.discardPile.childNodes[i];
-				if (get.type(card, false) == "basic" && !names.includes(card.name)) {
+				if (get.type(card, null, false) == "basic" && !names.includes(card.name)) {
 					cards.push(card);
 					names.push(card.name);
 				}
@@ -16535,7 +16535,7 @@ const skills = {
 				names = [];
 			for (var i = 0; i < ui.discardPile.childNodes.length; i++) {
 				var card = ui.discardPile.childNodes[i];
-				if (get.type(card, false) == "basic" && !names.includes(card.name)) {
+				if (get.type(card, null, false) == "basic" && !names.includes(card.name)) {
 					cards.push(card);
 					names.push(card.name);
 				}
@@ -16572,7 +16572,7 @@ const skills = {
 			return (
 				!player.hasSkill("twhengjiang2") &&
 				event.targets.length == 1 &&
-				["basic", "trick"].includes(get.type(event.card, false)) &&
+				["basic", "trick"].includes(get.type(event.card, null, false)) &&
 				player.isPhaseUsing() &&
 				game.hasPlayer(function (current) {
 					return player.inRange(current) && lib.filter.targetEnabled2(event.card, player, current);

--- a/character/xianding/skill.js
+++ b/character/xianding/skill.js
@@ -6275,7 +6275,7 @@ const skills = {
 		filter: function (event, player) {
 			if (player != _status.currentPhase) return false;
 			if (!event.isFirstTarget) return false;
-			if (event.card.name != "sha" && get.type(event.card, false) != "trick") return false;
+			if (event.card.name != "sha" && get.type(event.card, null, false) != "trick") return false;
 			if (player.countCards("h") != player.getHistory("useCard").indexOf(event.getParent()) + 1) return false;
 			return event.targets.some(target => {
 				return target != player && target.isIn();
@@ -6318,7 +6318,7 @@ const skills = {
 				var del = player.countCards("h") - cardsh.length - player.getHistory("useCard").length - 1;
 				if (del < 0) return;
 				if (del > 0) {
-					if (card.name == "sha" || get.type(card, false) != "trick") return num / 3;
+					if (card.name == "sha" || get.type(card, null, player) != "trick") return num / 3;
 					return num + 1;
 				}
 				return num + 15;
@@ -6343,7 +6343,7 @@ const skills = {
 				})
 			)
 				return false;
-			if (!["basic", "trick"].includes(get.type(event.card, false))) return false;
+			if (!["basic", "trick"].includes(get.type(event.card, null, false))) return false;
 			if (event.getParent(2).name == "dcchanjuan") return false;
 			return !player.storage.dcchanjuan[event.card.name] || player.storage.dcchanjuan[event.card.name] < 2;
 		},

--- a/character/xinghuoliaoyuan/skill.js
+++ b/character/xinghuoliaoyuan/skill.js
@@ -1677,7 +1677,7 @@ const skills = {
 			},
 			effect: {
 				target(card, player, target) {
-					if (target.isPhaseUsing() && typeof card === "object" && get.type(card, target) === "delay" && !target.countCards("j")) {
+					if (target.isPhaseUsing() && typeof card === "object" && get.type(card, null, target) === "delay" && !target.countCards("j")) {
 						let shas =
 							target.getCards("hs", i => {
 								if (card === i || (card.cards && card.cards.includes(i))) return false;

--- a/character/yijiang/skill.js
+++ b/character/yijiang/skill.js
@@ -4467,7 +4467,7 @@ const skills = {
 			dialog: function (event, player) {
 				var list = [];
 				for (var i of lib.inpile) {
-					var type = get.type(i, false);
+					var type = get.type(i, null, false);
 					if (type == "basic" || type == "trick") {
 						var card = {
 							name: i,
@@ -10618,7 +10618,7 @@ const skills = {
 			next.set("processAI", function (list) {
 				var cards = list[0][1].slice(0),
 					cards2 = cards.filter(function (i) {
-						return get.type(i, false) == "equip";
+						return get.type(i, null, false) == "equip";
 					}),
 					cards3;
 				if (cards2.length) {

--- a/character/yingbian/skill.js
+++ b/character/yingbian/skill.js
@@ -387,7 +387,7 @@ const skills = {
 		audio: "wanyi",
 		trigger: { player: "useCardToTargeted" },
 		filter: function (event, player) {
-			return player != event.target && event.targets.length == 1 && (event.card.name == "sha" || get.type(event.card, false) == "trick") && event.target.countCards("he") > 0;
+			return player != event.target && event.targets.length == 1 && (event.card.name == "sha" || get.type(event.card, null, false) == "trick") && event.target.countCards("he") > 0;
 		},
 		locked: false,
 		logTarget: "target",
@@ -2926,7 +2926,7 @@ const skills = {
 		mod: {
 			cardEnabled2: function (card, player) {
 				var stat = player.getStat("skill");
-				if (stat.xinquanbian && stat.xinquanbian >= player.maxHp && get.position(card) == "h" && get.type(card, player) != "equip") return false;
+				if (stat.xinquanbian && stat.xinquanbian >= player.maxHp && get.position(card) == "h" && get.type(card, null, player) != "equip") return false;
 			},
 		},
 	},
@@ -3833,7 +3833,7 @@ const skills = {
 			}
 			var next = player.chooseToDiscard(`是否弃置一枚“爵”和一张${get.mode() == "guozhan" ? "基本" : "手"}牌，对${get.translation(trigger.player)}发动【骁果】？`, "h", function (card, player) {
 				if (get.mode() != "guozhan") return true;
-				return get.type(card, player) == "basic";
+				return get.type(card, null, player) == "basic";
 			});
 			next.set("ai", function (card) {
 				if (_status.event.nono) return 0;

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -1793,7 +1793,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				filter: function (event, player) {
 					if (player == event.player || event.targets.length != 1 || event.player.countCards("h") >= event.player.hp) return false;
 					var bool = function (card) {
-						return (card.name == "sha" || get.type(card, false) == "trick") && get.color(card, false) == "black";
+						return (card.name == "sha" || get.type(card, null, false) == "trick") && get.color(card, false) == "black";
 					};
 					if (!bool(event.card)) return false;
 					var evt = event.getParent("phaseUse");
@@ -7584,7 +7584,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 							if (
 								list.includes("trick") &&
 								source.countCards("h", function (card) {
-									return get.type(card, source) == "trick" && source.hasValueTarget(card);
+									return get.type(card, null, source) == "trick" && source.hasValueTarget(card);
 								}) > 1
 							)
 								return "trick";

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -281,7 +281,7 @@ export const Content = {
 		player.$give(card, target, false);
 		game.delay(0.5);
 		event.trigger("giftAccept");
-		if (get.type(card, false) == "equip") target.equip(card).log = false;
+		if (get.type(card) == "equip") target.equip(card).log = false;
 		else target.gain(card, player).visible = true;
 		event.trigger("giftAccepted");
 		"step 3";

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -908,7 +908,7 @@ export class Player extends HTMLDivElement {
 	 */
 	getGiftAIResultTarget(card, target) {
 		if (!card || target.refuseGifts(card, this)) return 0;
-		if (get.type(card, false) == "equip") return get.effect(target, card, target, target);
+		if (get.type(card, null, target) == "equip") return get.effect(target, card, target, target);
 		if (card.name == "du") return this.hp > target.hp ? -1 : 0;
 		if (target.hasSkillTag("nogain")) return 0;
 		return Math.max(1, get.value(card, this) - get.value(card, target));

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -9812,7 +9812,7 @@ export class Library {
 		cardGiftable: (card, player, target, strict) => {
 			const mod = game.checkMod(card, player, target, "unchanged", "cardGiftable", player);
 			if (!mod || (strict && ((mod == "unchanged" && (get.position(card) != "h" || !get.cardtag(card, "gifts"))) || player == target))) return false;
-			return get.type(card, false) != "equip" || target.canEquip(card, true);
+			return get.type(card, null, target) != "equip" || target.canEquip(card, true);
 		},
 		/**
 		 * Check if the card is recastable


### PR DESCRIPTION
### PR受影响的平台
所有平台


### 诱因和背景
测试其他bug时遇到的



### PR描述
将本因写在第三个参数位置的传参（false Player）修正；
修复部分错误写法导致的“普通锦囊牌”“锦囊牌”错用的问题；
为部分明确在手牌中且有player的get.type添加第三个参数player；
其他琐碎调整



### 扩展适配
请检查您扩展中的get.type(card, method, player)和get.type2(card, player)函数传参是否正确：
1、get.type(card, method, player)
card: 所检测卡牌，可以是字符串，不得为空
method: 若为"trick"，对于延时锦囊牌会返回"trick"，否则返回"delay"
player: 持有者，用于经过诸如〖红颜〗〖武魂〗这种Mod技能修改，不为Player则使用_status.event.player，为false则不检测Mod
2、get.type2(card, player)
等价为get.type(card, "trick", player)，普通锦囊和延时锦囊都会返回"trick"


### 检查清单
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 我没有把该PR提交到`master`分支
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
