### PR TITLE
将README.md中的“内核版本大于等于77”修改为“内核版本大于等于85”

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker: [docker.md](./docker/docker.md)
 
 网页端推荐使用 Chrome 系内核浏览器游玩，不推荐使用低版本 Firefox 浏览器
 
-请尽量保证游玩的 Chrome 系浏览器或手机 Webview 的`内核版本大于等于77`
+请尽量保证游玩的 Chrome 系浏览器或手机 Webview 的`内核版本大于等于85`
 
 提交 Pull Request 时请推送到"PR-Branch"分支！
 


### PR DESCRIPTION
将“内核版本大于等于77”修改为“内核版本大于等于85”

<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
所有平台


### 诱因和背景
在v1.10.14中，无名杀的版本的最低内核需求已经从Chromium 77升级到Chromium 85，但是README.md中相关描述仍为“内核版本大于等于77”，尚未更新。



### PR描述
将README.md中的“内核版本大于等于77”修改为“内核版本大于等于85”


### PR测试
仅修改README.md中的一行字，对游戏无影响。



### 扩展适配
仅修改README.md中的一行字，不需要额外适配。



### 检查清单
-`[x]`我已经进行了充足的测试，且现有的测试都已通过
-`[x]`我没有把该PR提交到`master`分支
-`[x]`如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
-`[x]`如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
-`[x]`如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
-`[x]`如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
-`[x]`如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
-`[x]`我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
-`[x]`我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
