### PR TITLE
ai fix

### DIFF
--- a/card/extra.js
+++ b/card/extra.js
@@ -922,7 +922,7 @@ game.import("card", function () {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target, current) {
+						target(card, player, target, current) {
 							if (target.hasSkillTag("unequip2")) return;
 							if (
 								player.hasSkillTag("unequip", false, {
@@ -937,12 +937,11 @@ game.import("card", function () {
 								})
 							)
 								return;
-							//if(card.name=='nanman'||card.name=='wanjian'||card.name=='chuqibuyi') return 'zerotarget';
-							if (card.name == "nanman" || card.name == "wanjian") return "zerotarget";
+							if (card.name == "nanman" || card.name == "wanjian") return "zeroplayertarget";
 							if (card.name == "sha") {
 								var equip1 = player.getEquip("zhuque");
 								if (equip1 && equip1.name == "zhuque") return 1.9;
-								if (!game.hasNature(card)) return "zerotarget";
+								if (!game.hasNature(card)) return "zeroplayertarget";
 							}
 						},
 					},

--- a/card/guozhan.js
+++ b/card/guozhan.js
@@ -1463,7 +1463,7 @@ game.import("card", function () {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target, current) {
+						target(card, player, target, current) {
 							if (
 								["huoshaolianying", "huogong"].includes(card.name) ||
 								(card.name == "sha" && game.hasNature(card, "fire"))

--- a/card/guozhan.js
+++ b/card/guozhan.js
@@ -1825,7 +1825,7 @@ game.import("card", function () {
 								return;
 							if (get.tag(card, "natureDamage")) return "zeroplayertarget";
 							if (card.name == "tiesuo") {
-								return [0, 0];
+								return 0.01;
 							}
 						},
 					},

--- a/card/gwent.js
+++ b/card/gwent.js
@@ -2003,7 +2003,11 @@ game.import("card", function () {
 					weather: true,
 					effect: {
 						player_use(card, player) {
-							if (!player.needsToDiscard()) return "zeroplayertarget";
+							return [1, (player.needsToDiscard(0, (i, p) => {
+								if (p.canIgnoreHandcard(i)) return false;
+								if (i === card || card.cards && card.cards.includes(i)) return false;
+								return true;
+							}) ? -0.4 : -1)];
 						},
 					},
 				},

--- a/card/gwent.js
+++ b/card/gwent.js
@@ -1961,7 +1961,7 @@ game.import("card", function () {
 					nodamage: true,
 					effect: {
 						target: function (card, player, target, current) {
-							if (get.tag(card, "damage") && !get.tag(card, "natureDamage")) return [0, 0];
+							if (get.tag(card, "damage") && !get.tag(card, "natureDamage")) return "zeroplayertarget";
 						},
 					},
 				},

--- a/card/huanlekapai.js
+++ b/card/huanlekapai.js
@@ -167,7 +167,7 @@ game.import("card", function () {
 					noturnOver: true,
 					effect: {
 						target: function (card, player, target, current) {
-							if (get.tag(card, "turnOver")) return [0, 0];
+							if (get.tag(card, "turnOver")) return "zeroplayertarget";
 						},
 					},
 				},

--- a/card/standard.js
+++ b/card/standard.js
@@ -3144,7 +3144,7 @@ game.import("card", function () {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target) {
+						target(card, player, target) {
 							if (typeof card !== "object" || target.hasSkillTag("unequip2")) return;
 							if (
 								player.hasSkillTag("unequip", false, {

--- a/card/yingbian.js
+++ b/card/yingbian.js
@@ -763,7 +763,7 @@ game.import("card", function () {
 			heiguangkai_ai: {
 				ai: {
 					effect: {
-						player_use(card, player, target) {
+						player(card, player, target) {
 							if (
 								typeof card !== "object" ||
 								!target ||

--- a/character/clan/skill.js
+++ b/character/clan/skill.js
@@ -1077,7 +1077,7 @@ const skills = {
 				target(card, player, target) {
 					if (!get.tag(card, "damage") || player.hasSkillTag("jueqing", false, target)) return;
 					let num = get.cardNameLength(card) - target.getDamagedHp();
-					if (num > 0) return [1, num + 0.1];
+					if (num > 0) return [1, 0.8 * num + 0.1];
 				},
 			},
 		},

--- a/character/collab/skill.js
+++ b/character/collab/skill.js
@@ -1091,17 +1091,17 @@ const skills = {
 			maixie_hp: true,
 			effect: {
 				target(card, player, target) {
-					if (player.hasSkillTag("jueqing", false, target)) return [1, -1];
 					if (get.tag(card, "damage") && player != target) {
+						if (player.hasSkillTag("jueqing", false, target)) return [1, -1];
 						var cards = card.cards,
 							evt = _status.event;
 						if (evt.player == target && card.name == "damage" && evt.getParent().type == "card") cards = evt.getParent().cards.filterInD();
 						if (target.hp <= 1) return;
 						if (get.itemtype(cards) != "cards") return;
 						for (var i of cards) {
-							if (get.name(i, target) == "tao") return [1, 5 + player.countMark("dcjianxiong") / 2];
+							if (get.name(i, target) == "tao") return [1, 2.5 + player.countMark("dcjianxiong") / 2];
 						}
-						if (get.value(cards, target) >= 7 - player.countMark("dcjianxiong") / 2 + target.getDamagedHp()) return [1, 3 + player.countMark("dcjianxiong") / 2];
+						if (get.value(cards, target) >= 7 - player.countMark("dcjianxiong") / 2 + target.getDamagedHp()) return [1, 1.5 + player.countMark("dcjianxiong") / 2];
 						return [1, 0.6 + player.countMark("dcjianxiong") / 2];
 					}
 				},
@@ -1572,7 +1572,7 @@ const skills = {
 			nofire: true,
 			effect: {
 				target(card, player, target, current) {
-					if (get.tag(card, "fireDamage")) return "zerotarget";
+					if (get.tag(card, "fireDamage")) return "zeroplayertarget";
 				},
 			},
 		},

--- a/character/diy/skill.js
+++ b/character/diy/skill.js
@@ -2819,7 +2819,7 @@ const skills = {
 			nothunder: true,
 			effect: {
 				target(card, player, target) {
-					if (get.tag(card, "natureDamage")) return "zerotarget";
+					if (get.tag(card, "natureDamage")) return "zeroplayertarget";
 				}
 			}
 		}
@@ -4631,7 +4631,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target, current) {
+						target(card, player, target, current) {
 							if (get.type(card, "trick") == "trick" && _status.currentPhase == player) return "zeroplayertarget";
 						},
 					},
@@ -6268,7 +6268,7 @@ const skills = {
 			effect: {
 				target_use(card, player, target) {
 					if (get.tag(card, "multineg")) {
-						return "zerotarget";
+						return "zeroplayertarget";
 					}
 					if (get.tag(card, "multitarget")) {
 						var info = get.info(card);
@@ -7059,7 +7059,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target(card) {
+				target_use(card) {
 					if (get.type(card) == "delay") return [0, 0.5];
 				},
 			},
@@ -7159,8 +7159,8 @@ const skills = {
 		ai: {
 			effect: {
 				target(card, player, target, current) {
-					if (card.name == "tiesuo") return 0;
-					if (get.tag(card, "thunderDamage")) return 0;
+					if (card.name == "tiesuo") return 0.1;
+					if (get.tag(card, "thunderDamage")) return "zeroplayertarget";
 				},
 			},
 			threaten: 0.5,
@@ -7654,7 +7654,7 @@ const skills = {
 		ai: {
 			effect: {
 				target(card, player, target) {
-					if (get.type(card) == "delay") return "zerotarget";
+					if (get.type(card) == "delay") return "zeroplayertarget";
 				},
 			},
 		},

--- a/character/diy/skill.js
+++ b/character/diy/skill.js
@@ -6757,7 +6757,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use(card, player, target) {
+				target(card, player, target) {
 					if (get.color(card) == "red") return [1, 1];
 				},
 			}

--- a/character/extra/skill.js
+++ b/character/extra/skill.js
@@ -2494,7 +2494,7 @@ const skills = {
 					if (
 						!get.tag(card, "damage") ||
 						player.countMark("dcxianjin") % 2 ||
-						!player.hasSkillTag("jueqing", false, target)
+						player.hasSkillTag("jueqing", false, target)
 					) return;
 					if (player.isMaxHandcard()) return [1, 1];
 					return [1, Math.min(3, 1 + player.getStorage("dctuoyu").length)];
@@ -3060,7 +3060,12 @@ const skills = {
 				ai: {
 					effect: {
 						target(card, player, target, current) {
-							if (get.tag(card, "damage") && current < 0) return 1.6;
+							if (get.tag(card, "damage") && current < 0 && !target._shencai_losehp_effect) {
+								target._shencai_losehp_effect = true;
+								let eff = get.effect(target, { name: "losehp" }, target, target) / 10;
+								delete target._shencai_losehp_effect;
+								return [1, eff];
+							}
 						},
 					},
 				},
@@ -4065,7 +4070,7 @@ const skills = {
 				ai: {
 					effect: {
 						target(card) {
-							if (get.type(card) == "delay") return "zerotarget";
+							if (get.type(card) == "delay") return "zeroplayertarget";
 						},
 					},
 				},
@@ -4799,7 +4804,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target) {
+						target(card, player, target) {
 							if (card && card.name == "qizhengxiangsheng") return "zeroplayertarget";
 						},
 					},
@@ -4930,7 +4935,7 @@ const skills = {
 							let num = 0,
 								nohave = true;
 							game.countPlayer(i => {
-								if (i.hasSkill("lingce")) {
+								if (i.hasSkill("lingce", null, null, false)) {
 									nohave = false;
 									if (i.isIn() && lib.skill.lingce.filter({ card: card }, i)) num += get.sgnAttitude(player, i);
 								}

--- a/character/gujian.js
+++ b/character/gujian.js
@@ -1464,7 +1464,7 @@ game.import("character", function () {
 				ai: {
 					halfneg: true,
 					effect: {
-						player_use(card, player, target, current) {
+						player(card, player, target, current) {
 							if (get.color(card) == "red") return [1, 0, 1, -2];
 						},
 					},

--- a/character/gujian.js
+++ b/character/gujian.js
@@ -2680,7 +2680,7 @@ game.import("character", function () {
 					threaten: 0.8,
 					effect: {
 						target(card, player, target) {
-							if (card.name == "bingliang") return 0;
+							if (card.name == "bingliang") return [0, 0];
 							if (card.name == "lebu") return 1.5;
 							if (card.name == "guohe") {
 								if (!target.countCards("e")) return 0;

--- a/character/gujian.js
+++ b/character/gujian.js
@@ -1273,7 +1273,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target, current) {
+						target(card, player, target, current) {
 							if (get.color(card) == "red" && target.isDamaged()) return [1, 1];
 						},
 					},

--- a/character/gwent.js
+++ b/character/gwent.js
@@ -1109,10 +1109,10 @@ game.import("character", function () {
 								target.countCards("he") &&
 								current < 0
 							) {
-								return 0;
+								return [1, 2];
 							}
 						},
-						player(card, player) {
+						player_use(card, player) {
 							if (player.hujia >= 3) return;
 							if (_status.event.name != "chooseToUse" || _status.event.player != player) return;
 							if (get.type(card) == "basic") return;
@@ -1237,7 +1237,7 @@ game.import("character", function () {
 					nodamage: true,
 					effect: {
 						target(card, player, target, current) {
-							if (get.tag(card, "damage")) return [0, 0];
+							if (get.tag(card, "damage")) return "zeroplayertarget";
 						},
 					},
 				},
@@ -2284,7 +2284,7 @@ game.import("character", function () {
 					effect: {
 						target(card, player, target) {
 							if (game.roundNumber % 3 != 0 && get.tag(card, "damage")) {
-								return [0, 0];
+								return "zeroplayertarget";
 							}
 						},
 					},

--- a/character/hearth.js
+++ b/character/hearth.js
@@ -2496,7 +2496,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target) {
+						target(card, player, target) {
 							if (get.type(card, "trick") == "trick" && player == target) return [1, 1];
 						},
 					},

--- a/character/hearth.js
+++ b/character/hearth.js
@@ -5234,11 +5234,6 @@ game.import("character", function () {
 				},
 				ai: {
 					threaten: 1.3,
-					effect: {
-						target(card, player, target) {
-							if (card.name == "guiyoujie") return [0, 1];
-						},
-					},
 				},
 			},
 			fbeifa: {

--- a/character/hearth.js
+++ b/character/hearth.js
@@ -2251,7 +2251,7 @@ game.import("character", function () {
 							effect: {
 								target(card, player, target, current) {
 									if (get.tag(card, "damage") && !get.tag(card, "fireDamage"))
-										return [0, 0];
+										return "zeroplayertarget";
 								},
 							},
 						},
@@ -5946,7 +5946,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						player(card, player) {
+						player_use(card, player) {
 							if (_status.currentPhase != player) return;
 							if (get.type(card) == "equip" && get.equipValueNumber(card) < 7) {
 								if (player.needsToDiscard(2)) return;
@@ -7182,7 +7182,7 @@ game.import("character", function () {
 					nofire: true,
 					effect: {
 						target(card, player, target, current) {
-							if (get.tag(card, "fireDamage")) return 0;
+							if (get.tag(card, "fireDamage")) return "zeroplayertarget";
 						},
 					},
 				},
@@ -8246,7 +8246,7 @@ game.import("character", function () {
 					expose: 0.3,
 					effect: {
 						target(card, player, target) {
-							if (get.tag(card, "loseCard") && target.countCards("he")) {
+							if (get.tag(card, "discard") && target.countCards("he")) {
 								return 0.7;
 							}
 						},

--- a/character/huicui/skill.js
+++ b/character/huicui/skill.js
@@ -2223,7 +2223,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use(card, player, target, current) {
+				target(card, player, target, current) {
 					if (get.tag(card, "damage") && target != player) {
 						if (_status.event.name == "dckrmingshi") return;
 						if (get.attitude(player, target) > 0 && current < 0) return "zerotarget";

--- a/character/huicui/skill.js
+++ b/character/huicui/skill.js
@@ -2226,7 +2226,7 @@ const skills = {
 				target(card, player, target, current) {
 					if (get.tag(card, "damage") && target != player) {
 						if (_status.event.name == "dckrmingshi") return;
-						if (get.attitude(player, target) > 0 && current < 0) return "zerotarget";
+						if (get.attitude(player, target) > 0 && current < 0) return "zeroplayertarget";
 						var bs = player.getCards("h");
 						bs.remove(card);
 						if (card.cards) bs.removeArray(card.cards);

--- a/character/jiange.js
+++ b/character/jiange.js
@@ -379,7 +379,7 @@ game.import("character", function () {
 					nodamage: true,
 					effect: {
 						target: function (card, player, target, current) {
-							if (get.tag(card, "damage") && !get.tag(card, "thunderDamage")) return [0, 0];
+							if (get.tag(card, "damage") && !get.tag(card, "thunderDamage")) return "zeroplayertarget";
 						},
 					},
 				},

--- a/character/jsrg/skill.js
+++ b/character/jsrg/skill.js
@@ -160,7 +160,7 @@ const skills = {
 		check(event, player) {
 			if (
 				event.targets.reduce((p, c) => {
-					return p + get.effect_use(c, event.card, event.player, player) > 0;
+					return p + get.effect(c, event.card, event.player, player);
 				}, 0) >= 0
 			)
 				return false;
@@ -412,7 +412,6 @@ const skills = {
 	jsrgyansha: {
 		trigger: { player: "phaseZhunbeiBegin" },
 		async cost(event, trigger, player) {
-			//AI摆了，交给157了
 			event.result = await player
 				.chooseTarget(get.prompt("jsrgyansha"), "你可以选择任意名角色，视为对这些角色使用【五谷丰登】，然后未被选择的角色依次可以将一张装备牌当作【杀】对目标角色使用。", [1, Infinity], (card, player, target) => {
 					return player.canUse({ name: "wugu", isCard: true }, target);

--- a/character/jsrg/skill.js
+++ b/character/jsrg/skill.js
@@ -8832,7 +8832,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target, current) {
+				target_use: function (card, player, target, current) {
 					if (get.type(card) == "delay" && current < 0) {
 						if (target.countCards("j")) return;
 						return "zerotarget";

--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -2217,10 +2217,10 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use: function (card, player, target, current) {
+				target: function (card, player, target, current) {
 					if (get.tag(card, "damage") && get.attitude(player, target) < 0 && target != player) {
 						if (_status.event.name == "zhouxian") return;
-						if (get.attitude(player, target) > 0 && current < 0) return "zerotarget";
+						if (get.attitude(player, target) > 0 && current < 0) return "zeroplayertarget";
 						var bs = player.getDiscardableCards(player, "he");
 						bs.remove(card);
 						if (card.cards) bs.removeArray(card.cards);
@@ -9222,7 +9222,7 @@ const skills = {
 		ai: {
 			effect: {
 				target: function (card, player, target, current) {
-					if (get.tag(card, "damage") && !player.hasSkillTag("jueqing", false, target)) return "zerotarget";
+					if (get.tag(card, "damage") && !player.hasSkillTag("jueqing", false, target)) return "zeroplayertarget";
 				},
 			},
 		},
@@ -16485,7 +16485,7 @@ const skills = {
 			nofire: true,
 			effect: {
 				target: function (card, player, target, current) {
-					if (get.tag(card, "fireDamage")) return "zerotarget";
+					if (get.tag(card, "fireDamage")) return "zeroplayertarget";
 				},
 			},
 		},

--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -15345,9 +15345,9 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use(card, player, target, current) {
+				target(card, player, target, current) {
 					if (["tiesuo", "lulitongxin"].includes(card.name)) {
-						return "zerotarget";
+						return "zeroplayertarget";
 					}
 				},
 			},
@@ -15370,7 +15370,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use(card, player, target) {
+				target(card, player, target) {
 					if (typeof card !== "object" || target.hasSkillTag("unequip2")) return;
 					if (
 						player.hasSkillTag("unequip", false, {
@@ -15403,7 +15403,7 @@ const skills = {
 		inherit: "rw_minguangkai_link",
 		ai: {
 			effect: {
-				target_use(card, player, target, current) {
+				target(card, player, target, current) {
 					if (["tiesuo", "lulitongxin"].includes(card.name)) {
 						return "zeroplayertarget";
 					}

--- a/character/offline/skill.js
+++ b/character/offline/skill.js
@@ -428,7 +428,7 @@ const skills = {
 			nofire: true,
 			effect: {
 				target(card, player, target, current) {
-					if (get.tag(card, "fireDamage")) return "zerotarget";
+					if (get.tag(card, "fireDamage")) return "zeroplayertarget";
 				},
 			},
 		},
@@ -2018,7 +2018,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use(card, player, target) {
+				target(card, player, target) {
 					if (card.name === "sha" && game.hasNature(card) && target.hasEmptySlot(2)) return "zeroplayertarget";
 					if (get.subtype(card) == "equip2" && target.isEmpty(2)) return [0.6, -0.8];
 				},
@@ -2731,7 +2731,7 @@ const skills = {
 			threaten: 1.1,
 			combo: "psshiyin",
 			effect: {
-				target_use(card, player, target, current) {
+				target(card, player, target, current) {
 					var list = target.getExpansions("psshiyin");
 					for (var cardx of list) {
 						if (get.suit(cardx) == get.suit(card)) return "zeroplayertarget";
@@ -5517,7 +5517,7 @@ const skills = {
 				},
 			},
 			effect: {
-				target: function (card, player, target) {
+				target_use: function (card, player, target) {
 					if (player == target && get.type(card) == "equip") {
 						if (player.countCards("e", { subtype: get.subtype(card) })) {
 							if (
@@ -6877,7 +6877,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use(card, player, target) {
+				target(card, player, target) {
 					var type = get.type2(card);
 					var list = target.getExpansions("zuixiang2");
 					for (var i of list) {
@@ -6948,8 +6948,8 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target: function (card, player, target) {
-					if (get.type(card) == "delay" && target.hasJudge("yanxiao_card")) return [0, 0, 0, 0.1];
+				target_use: function (card, player, target) {
+					if (get.type(card) == "delay" && target.hasJudge("yanxiao_card")) return [0, 0.1];
 				},
 			},
 		},
@@ -7223,7 +7223,7 @@ const skills = {
 			nodamage: true,
 			effect: {
 				target: function (card, player, target, current) {
-					if (get.tag(card, "damage")) return [0, 0];
+					if (get.tag(card, "damage")) return "zeroplayertarget";
 				},
 			},
 		},

--- a/character/onlyOL/skill.js
+++ b/character/onlyOL/skill.js
@@ -1113,7 +1113,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player(card, player, target) {
+				player_use(card, player, target) {
 					if (_status.currentPhase != player) return;
 					if (card.name == "sha" && !player.getExpansions("olchunlao").length && target.hp > 1) {
 						return "zeroplayertarget";
@@ -1328,27 +1328,29 @@ const skills = {
 		global: "olsbhetao_ai",
 		subSkill: {
 			ai: {
-				effect: {
-					player_use(card, player) {
-						if (
-							!game.hasPlayer(target => {
-								return target.hasSkill("olsbhetao") && (get.attitude(player, target) < 0 || get.attitude(target, player) < 0);
-							}) ||
-							game.countPlayer(target => {
-								return player.canUse(card, target);
-							}) < 2
-						)
-							return;
-						const select = get.copy(get.info(card).selectTarget);
-						let range;
-						if (select == undefined) range = [1, 1];
-						else if (typeof select == "number") range = [select, select];
-						else if (get.itemtype(select) == "select") range = select;
-						else if (typeof select == "function") range = select(card, player);
-						game.checkMod(card, player, range, "selectTarget", player);
-						if (range[1] == -1 || (range[1] > 1 && ui.selected.targets && ui.selected.targets.length)) return "zeroplayertarget";
+				ai: {
+					effect: {
+						player_use(card, player) {
+							if (
+								!game.hasPlayer(target => {
+									return target.hasSkill("olsbhetao") && (get.attitude(player, target) < 0 || get.attitude(target, player) < 0);
+								}) ||
+								game.countPlayer(target => {
+									return player.canUse(card, target);
+								}) < 2
+							)
+								return;
+							const select = get.copy(get.info(card).selectTarget);
+							let range;
+							if (select == undefined) range = [1, 1];
+							else if (typeof select == "number") range = [select, select];
+							else if (get.itemtype(select) == "select") range = select;
+							else if (typeof select == "function") range = select(card, player);
+							game.checkMod(card, player, range, "selectTarget", player);
+							if (range[1] == -1 || (range[1] > 1 && ui.selected.targets && ui.selected.targets.length)) return "zeroplayertarget";
+						},
 					},
-				},
+				}
 			},
 		},
 	},

--- a/character/ow.js
+++ b/character/ow.js
@@ -3576,11 +3576,6 @@ game.import("character", function () {
 				},
 				ai: {
 					expose: 0.1,
-					effect: {
-						target: function (card) {
-							if (card.name == "guiyoujie") return [0, 0];
-						},
-					},
 				},
 			},
 			shanxian2: {

--- a/character/ow.js
+++ b/character/ow.js
@@ -266,7 +266,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target, current) {
+						target(card, player, target, current) {
 							if (card.name == "sha") {
 								if (_status.event.name == "qianggu2") return;
 								if (get.attitude(player, target) > 0) return;

--- a/character/refresh/skill.js
+++ b/character/refresh/skill.js
@@ -13935,7 +13935,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use(card, player, target) {
+				target(card, player, target) {
 					if (player == target || !target.hasFriend()) return;
 					var type = get.type(card);
 					var nh = Math.min(

--- a/character/refresh/skill.js
+++ b/character/refresh/skill.js
@@ -5503,7 +5503,7 @@ const skills = {
 		ai: {
 			effect: {
 				target: function (card, player, target) {
-					if (target == _status.currentPhase && get.tag(card, "damage")) return [0, 1];
+					if (target == _status.currentPhase && get.tag(card, "damage")) return [0, 2, 0, 0];
 				},
 			},
 		},
@@ -7639,8 +7639,8 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use: function (card, player, target) {
-					if (target != _status.currentPhase && target.countCards("h") >= target.getHandcardLimit() && (get.type(card) == "delay" || get.color(card) == "none")) return "zerotarget";
+				target: function (card, player, target) {
+					if (target != _status.currentPhase && target.countCards("h") >= target.getHandcardLimit() && (get.type(card) == "delay" || get.color(card) == "none")) return "zeroplayertarget";
 				},
 			},
 		},
@@ -8000,7 +8000,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				player_use: function (card, player, target) {
+				player: function (card, player, target) {
 					if (
 						player == target &&
 						get.type(card) == "equip" &&
@@ -11642,7 +11642,7 @@ const skills = {
 		ai: {
 			useShan: true,
 			effect: {
-				target: function (card, player, target, current) {
+				target_use: function (card, player, target, current) {
 					let name;
 					if (typeof card == "object") {
 						if (card.viewAs) name = card.viewAs;
@@ -11701,6 +11701,8 @@ const skills = {
 						if (pos == "e") return [1, Math.min((Math.max(1, target.countCards("hs")) * (club + spade)) / 4, Math.max(club, spade))];
 						return [1, (club + spade) / 4];
 					}
+				},
+				target(card, player, target) {
 					if (name == "lebu" || name == "bingliang") return [target.hasSkillTag("rejudge") ? 0.4 : 1, 2, target.hasSkillTag("rejudge") ? 0.4 : 1, 0];
 				},
 			},
@@ -12398,9 +12400,9 @@ const skills = {
 						if (target.hp <= 1) return;
 						if (get.itemtype(cards) != "cards") return;
 						for (var i of cards) {
-							if (get.name(i, target) == "tao") return [1, 5];
+							if (get.name(i, target) == "tao") return [1, 4.5];
 						}
-						if (get.value(cards, target) >= 7 + target.getDamagedHp()) return [1, 3];
+						if (get.value(cards, target) >= 7 + target.getDamagedHp()) return [1, 2.5];
 						return [1, 0.6];
 					}
 				},
@@ -13999,8 +14001,11 @@ const skills = {
 		ai: {
 			threaten: 0.8,
 			effect: {
-				target: function (card) {
-					if (card.name == "guohe" || card.name == "liuxinghuoyu") return 0.5;
+				player_use(card, player, target) {
+					if (player.countCards("h") === 1) return [1, 0.8];
+				},
+				target(card, player, target) {
+					if (get.tag(card, "loseCard") && target.countCards("h") === 1) return 0.5;
 				},
 			},
 			noh: true,

--- a/character/refresh/skill.js
+++ b/character/refresh/skill.js
@@ -1348,7 +1348,6 @@ const skills = {
 					},
 					effect: {
 						target: function (card, player, target) {
-							if (card.name == "guiyoujie") return [0, 0.5];
 							if (target.isTurnedOver()) {
 								if (get.tag(card, "damage")) {
 									if (player.hasSkillTag("jueqing", false, target)) return [1, -2];
@@ -9868,7 +9867,6 @@ const skills = {
 			},
 			effect: {
 				target: function (card, player, target) {
-					if (card.name == "guiyoujie") return [0, 0.5];
 					if (target.isTurnedOver()) {
 						if (get.tag(card, "damage")) {
 							if (player.hasSkillTag("jueqing", false, target)) return [1, -2];

--- a/character/sb/skill.js
+++ b/character/sb/skill.js
@@ -1924,7 +1924,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player_use(card, player, target) {
+						player(card, player, target) {
 							if (player.getStorage("sbyijue_effect").includes(target)) return "zeroplayertarget";
 						},
 					},
@@ -3130,7 +3130,7 @@ const skills = {
 			expose: 0.05,
 			effect: {
 				target: function (card) {
-					if (card.name == "nanman") return [0, 1];
+					if (card.name == "nanman") return [0, 1, 0, 0];
 				},
 			},
 		},
@@ -5710,9 +5710,9 @@ const skills = {
 						if (target.hp <= 1) return;
 						if (get.itemtype(cards) != "cards") return;
 						for (var i of cards) {
-							if (get.name(i, target) == "tao") return [1, 5];
+							if (get.name(i, target) == "tao") return [1, 4.5];
 						}
-						if (get.value(cards, target) >= 7 + target.getDamagedHp()) return [1, 3];
+						if (get.value(cards, target) >= 7 + target.getDamagedHp()) return [1, 2];
 						return [1, 0.55 + 0.05 * Math.max(0, 1 - target.countMark("sbjianxiong"))];
 					}
 				},
@@ -6252,7 +6252,7 @@ const skills = {
 										card: card,
 									})
 								)
-									return "zerotarget";
+									return 0.1;
 							}
 						},
 					},

--- a/character/shenhua/skill.js
+++ b/character/shenhua/skill.js
@@ -2660,13 +2660,6 @@ const skills = {
 				}
 			}
 		},
-		ai: {
-			effect: {
-				target(card, player, target) {
-					if (card.name == "guiyoujie") return [0, 1];
-				},
-			},
-		},
 	},
 	xinjiewei: {
 		audio: 2,
@@ -6379,13 +6372,6 @@ const skills = {
 			await player.draw(3);
 			await player.turnOver();
 		},
-		ai: {
-			effect: {
-				target(card, player, target) {
-					if (card.name == "guiyoujie") return [0, 1];
-				},
-			},
-		},
 	},
 	moon_jushou: {
 		audio: "xinjushou",
@@ -6396,13 +6382,6 @@ const skills = {
 		async content(event, trigger, player) {
 			await player.draw();
 			await player.turnOver();
-		},
-		ai: {
-			effect: {
-				target(card, player, target) {
-					if (card.name == "guiyoujie") return [0, 1];
-				},
-			},
 		},
 	},
 	liegong: {

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -25963,13 +25963,6 @@ const skills = {
 			player.draw(2 + num);
 			player.addSkill("kuiwei2");
 		},
-		ai: {
-			effect: {
-				target: function (card) {
-					if (card.name == "guiyoujie") return [0, 2];
-				},
-			},
-		},
 	},
 	kuiwei2: {
 		trigger: { player: "phaseDrawBegin" },
@@ -28230,11 +28223,6 @@ const skills = {
 				},
 			},
 			threaten: 1.5,
-			effect: {
-				target: function (card) {
-					if (card.name == "guiyoujie") return [0, 2];
-				},
-			},
 		},
 	},
 	lihun2: {

--- a/character/sp2/skill.js
+++ b/character/sp2/skill.js
@@ -1254,7 +1254,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player_use(card, player, target) {
+						player(card, player, target) {
 							var targets = game.filterPlayer(targetx => targetx != player && targetx.getStorage("starcanxi_xiangsi").includes(player.group));
 							if (!targets.length) return;
 							if (get.tag(card, "recover") && target == player && target.hp > 2) return 0;

--- a/character/standard/skill.js
+++ b/character/standard/skill.js
@@ -2763,8 +2763,11 @@ const skills = {
 		ai: {
 			threaten: 0.8,
 			effect: {
-				target(card) {
-					if (card.name == "guohe" || card.name == "liuxinghuoyu") return 0.5;
+				player_use(card, player, target) {
+					if (player.countCards("h") === 1) return [1, 0.8];
+				},
+				target(card, player, target) {
+					if (get.tag(card, "loseCard") && target.countCards("h") === 1) return 0.5;
 				},
 			},
 			noh: true,

--- a/character/swd.js
+++ b/character/swd.js
@@ -1258,7 +1258,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target, current) {
+						target(card, player, target, current) {
 							if (
 								target == player &&
 								lib.skill.gaizao.filterx(card, target) &&
@@ -8398,7 +8398,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target) {
+						target(card, player, target) {
 							if (
 								get.color(card) == "black" &&
 								get.attitude(target, player) < 0 &&

--- a/character/swd.js
+++ b/character/swd.js
@@ -3176,13 +3176,6 @@ game.import("character", function () {
 							return 0;
 						},
 					},
-					effect: {
-						target: function (card, player, target) {
-							if (!target.storage.pingshen2) {
-								if (card.name == "guiyoujie") return [0, 1];
-							}
-						},
-					},
 				},
 			},
 			pingshen3: {
@@ -9961,7 +9954,6 @@ game.import("character", function () {
 				ai: {
 					effect: {
 						target: function (card, player, target, current) {
-							if (card.name == "guiyoujie") return [0, 2];
 							if (target.isTurnedOver()) {
 								if (get.tag(card, "damage")) return 0;
 							}

--- a/character/swd.js
+++ b/character/swd.js
@@ -4364,7 +4364,7 @@ game.import("character", function () {
 						},
 					},
 					effect: {
-						player: function (card, player) {
+						player_use: function (card, player) {
 							if (_status.currentPhase != player) return;
 							if (
 								get.type(card) == "equip" &&
@@ -8520,9 +8520,10 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
-							if (card.name == "sha" && get.color(card) == "red") {
-								return [1, -2];
+						player: function (card, player, target, current) {
+							if (get.tag(card, "damage") && !player.hasSkill("xiaomoyu2")) {
+								if (player.isDamaged()) return [1, 1.6];
+								return [1, 0.8];
 							}
 						},
 					},
@@ -9955,7 +9956,7 @@ game.import("character", function () {
 					effect: {
 						target: function (card, player, target, current) {
 							if (target.isTurnedOver()) {
-								if (get.tag(card, "damage")) return 0;
+								if (get.tag(card, "damage")) return "zeroplayertarget";
 							}
 						},
 					},
@@ -10185,7 +10186,7 @@ game.import("character", function () {
 						player: 1,
 					},
 					effect: {
-						target: function (card, player, target) {
+						target_use: function (card, player, target) {
 							if (player != target) return;
 							if (get.subtype(card) == "equip5") {
 								if (get.equipValue(card) <= 7) return 0;
@@ -10221,7 +10222,7 @@ game.import("character", function () {
 						return get.order({ name: "sha" }) + 0.1;
 					},
 					effect: {
-						target: function (card, player) {
+						target_use: function (card, player) {
 							if (get.subtype(card) == "equip1") {
 								var num = 0,
 									players = game.filterPlayer();

--- a/character/xianding/skill.js
+++ b/character/xianding/skill.js
@@ -9800,7 +9800,7 @@ const skills = {
 				},
 				ai: {
 					effect: {
-						player_use(card, player, target) {
+						player(card, player, target) {
 							if (get.tag(card, "recover") && target.hp > 0) return 0;
 							if (get.tag(card, "damage")) return 0.5;
 						},

--- a/character/xianjian.js
+++ b/character/xianjian.js
@@ -164,7 +164,7 @@ game.import("character", function () {
 					threaten: 2,
 					expose: 0.2,
 					effect: {
-						player: function (card, player) {
+						player_use: function (card, player) {
 							if (_status.currentPhase != player) return;
 							if (_status.event.name != "chooseToUse" || _status.event.player != player) return;
 							var num = player.needsToDiscard();
@@ -506,7 +506,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						player: function (card, player, target) {
+						player_use: function (card, player, target) {
 							if (_status.currentPhase != player) return;
 							if (
 								card.name == "sha" &&
@@ -823,7 +823,7 @@ game.import("character", function () {
 					nodamage: true,
 					effect: {
 						target: function (card, player, target, current) {
-							if (get.tag(card, "damage")) return [0, 0];
+							if (get.tag(card, "damage")) return "zeroplayertarget";
 						},
 					},
 				},
@@ -3074,7 +3074,7 @@ game.import("character", function () {
 						return get.order({ name: "sha" }) + 0.1;
 					},
 					effect: {
-						player: function (card, player) {
+						player_use: function (card, player) {
 							if (_status.currentPhase != player) return;
 							if (
 								card.name == "sha" &&
@@ -3255,7 +3255,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						player: function (card, player) {
+						player_use: function (card, player) {
 							if (_status.currentPhase != player) return;
 							if (get.is.altered("shuiyun")) return;
 							if (
@@ -4328,9 +4328,9 @@ game.import("character", function () {
 					nothunder: true,
 					effect: {
 						target: function (card, player, target, current) {
-							if (card.name == "tiesuo") return 0;
-							if (get.tag(card, "fireDamage")) return 0;
-							if (get.tag(card, "thunderDamage")) return 0;
+							if (card.name == "tiesuo") return [0, 0];
+							if (get.tag(card, "fireDamage")) return [0, 0, 0, 0];
+							if (get.tag(card, "thunderDamage")) return [0, 0, 0, 0];
 						},
 					},
 				},

--- a/character/xianjian.js
+++ b/character/xianjian.js
@@ -778,7 +778,7 @@ game.import("character", function () {
 				ai: {
 					effect: {
 						target: function (card, player, target) {
-							if (card.name == "bingliang" || card.name == "caomu") return 0;
+							if (card.name == "bingliang" || card.name == "caomu") return [0, 0];
 						},
 					},
 				},

--- a/character/xianjian.js
+++ b/character/xianjian.js
@@ -4157,7 +4157,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target) {
+						target(card, player, target) {
 							if (
 								target.storage.xjzhimeng2 &&
 								get.type(card, "trick") == get.type(target.storage.xjzhimeng2, "trick")

--- a/character/yijiang/skill.js
+++ b/character/yijiang/skill.js
@@ -9180,7 +9180,7 @@ const skills = {
 		},
 		ai: {
 			effect: {
-				target_use(card, player, target) {
+				target(card, player, target) {
 					if (get.type(card) == "trick" && player !== target) return [1, 1];
 				},
 			}

--- a/character/yijiang/skill.js
+++ b/character/yijiang/skill.js
@@ -10864,7 +10864,7 @@ const skills = {
 				return arg && arg.jiu == true;
 			},
 			effect: {
-				target_use(card, player, target) {
+				target(card, player, target) {
 					if (target.hp <= 0 && target.hasSkill("zhenlie_lose") && get.tag(card, "recover")) return [1, 1.2];
 				},
 			},

--- a/character/yijiang/skill.js
+++ b/character/yijiang/skill.js
@@ -11259,7 +11259,6 @@ const skills = {
 			},
 			effect: {
 				target: function (card, player, target) {
-					if (card.name == "guiyoujie") return [0, 0.5];
 					if (target.isTurnedOver()) {
 						if (get.tag(card, "damage")) {
 							if (player.hasSkillTag("jueqing", false, target)) return [1, -2];

--- a/character/yxs.js
+++ b/character/yxs.js
@@ -1460,7 +1460,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target_use(card, player, target, current) {
+						target(card, player, target, current) {
 							if (get.type(card) == "trick" || card.name == "sha") return "zeroplayertarget";
 						},
 					},
@@ -2885,9 +2885,16 @@ game.import("character", function () {
 					player.draw(2);
 				},
 				ai: {
+					noh: true,
+					skillTagFilter(player, tag, arg) {
+						if (tag === "noh") return player.countCards("h") === 1;
+					},
 					effect: {
-						target: function (card) {
-							if (card.name == "guohe" || card.name == "liuxinghuoyu") return 0.5;
+						player_use(card, player, target) {
+							if (player.countCards("h") === 1) return [1, 0.8];
+						},
+						target(card, player, target) {
+							if (get.tag(card, "loseCard") && target.countCards("h") === 1) return 0.5;
 						},
 					},
 				},

--- a/character/zhuogui.js
+++ b/character/zhuogui.js
@@ -15,7 +15,7 @@ game.import("character", function () {
 				ai: {
 					effect: {
 						target: function (card, player, target, current) {
-							if (card.name == "lebu" && card.name == "bingliang") return 0.8;
+							if (card.name == "lebu" || card.name == "bingliang") return 0.8;
 						},
 					},
 				},

--- a/character/zhuogui.js
+++ b/character/zhuogui.js
@@ -200,7 +200,7 @@ game.import("character", function () {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target_use: function (card, player, target, current) {
 							if (get.type(card) == "delay" && target.countCards("j") == 0) return 0.1;
 						},
 					},

--- a/mode/boss.js
+++ b/mode/boss.js
@@ -3325,11 +3325,11 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 					effect: {
 						target: function (card, player, target, current) {
 							if (!target.hasEmptySlot("equip2")) return;
-							if (card.name == "nanman" || card.name == "wanjian") return "zerotarget";
+							if (card.name == "nanman" || card.name == "wanjian") return "zeroplayertarget";
 							if (card.name == "sha") {
 								var equip1 = player.getEquip(1);
 								if (equip1 && equip1.name == "zhuque") return 1.9;
-								if (!game.hasNature(card)) return "zerotarget";
+								if (!game.hasNature(card)) return "zeroplayertarget";
 							}
 						},
 					},

--- a/mode/boss.js
+++ b/mode/boss.js
@@ -7136,7 +7136,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 			boss_zhangwu_ai: {
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target_use: function (card, player, target) {
 							if (get.tag(card, "recover") && card.name != "recover") {
 								for (var i = 0; i < game.players.length; i++) {
 									if (
@@ -7590,7 +7590,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target_use: function (card, player, target) {
 							if (get.tag(card, "respondShan")) {
 								var shans = target.countCards("h", "shan");
 								var hs = target.countCards("h");
@@ -7640,7 +7640,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				ai: {
 					mingzhi: false,
 					effect: {
-						target: function (card, player, target) {
+						target_use: function (card, player, target) {
 							if (get.tag(card, "respondShan")) {
 								var shans = target.countCards("h", "shan");
 								var hs = target.countCards("h");
@@ -8269,9 +8269,9 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				},
 				ai: {
 					effect: {
-						target_use: function (card, player, target, current) {
+						target: function (card, player, target, current) {
 							if (target.getEquip(2)) return;
-							return lib.skill.tengjia1.ai.effect.target_use.apply(this, arguments);
+							return lib.skill.tengjia1.ai.effect.target.apply(this, arguments);
 						},
 					},
 				},
@@ -8538,7 +8538,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target_use: function (card, player, target, current) {
 							if (get.tag(card, "respondShan")) {
 								var hastarget = false,
 									players = game.filterPlayer();
@@ -8764,7 +8764,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 					threaten: 0.8,
 					effect: {
 						target: function (card) {
-							if (card.name == "bingliang") return 0;
+							if (card.name == "bingliang") return "zeroplayertarget";
 						},
 					},
 				},
@@ -8946,7 +8946,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 					effect: {
 						target: function (card) {
 							if (get.tag(card, "fireDamage")) {
-								return [0, 2];
+								return [0, 2, 0, 0];
 							}
 						},
 					},
@@ -9206,7 +9206,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				},
 				ai: {
 					effect: {
-						player: function (card) {
+						player_use: function (card) {
 							if (get.color(card) == "black") {
 								return [1, 2];
 							}

--- a/mode/boss.js
+++ b/mode/boss.js
@@ -7921,7 +7921,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				ai: {
 					effect: {
 						target: function (card, player, target, current) {
-							if (card.name == "lebu" && card.name == "bingliang") return 0.8;
+							if (card.name == "lebu" || card.name == "bingliang") return 0.8;
 						},
 					},
 				},
@@ -8764,7 +8764,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 					threaten: 0.8,
 					effect: {
 						target: function (card) {
-							if (card.name == "bingliang") return "zeroplayertarget";
+							if (card.name == "bingliang") return [0, 0];
 						},
 					},
 				},

--- a/mode/chess.js
+++ b/mode/chess.js
@@ -5244,7 +5244,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				ai: {
 					order: 10,
 					effect: {
-						player: function (card, player) {
+						player_use: function (card, player) {
 							var num = 0;
 							for (var i = 0; i < game.players.length; i++) {
 								if (get.attitude(player, game.players[i]) < 0) {

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -11409,8 +11409,8 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				ai: {
 					threaten: 3,
 					effect: {
-						target: function (card, player, target, current) {
-							if (lib.skill.gzxingzhao.getNum() > 3 && get.type(card) == "equip" && !get.cardtag(card, "gifts")) return [1, 3];
+						target_use: function (card, player, target, current) {
+							if (lib.skill.gzxingzhao.getNum() > 3 && get.type(card) == "equip" && !get.cardtag(card, "gifts")) return [1, 2];
 						},
 					},
 					reverseEquip: true,
@@ -18128,7 +18128,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 						},
 					},
 					effect: {
-						target: function (card, player, target) {
+						target_use: function (card, player, target) {
 							if (player == target && get.type(card) == "equip") {
 								if (player.countCards("e", { subtype: get.subtype(card) })) {
 									var players = game.filterPlayer();

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -14116,13 +14116,6 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 						}
 					}
 				},
-				ai: {
-					effect: {
-						target: function (card, player, target) {
-							if (card.name == "guiyoujie") return [0, 1];
-						},
-					},
-				},
 			},
 			new_duanliang: {
 				subSkill: {

--- a/mode/stone.js
+++ b/mode/stone.js
@@ -7189,7 +7189,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				ai: {
 					effect: {
 						target: function (card) {
-							if (card.name == "bingliang") return 0;
+							if (card.name == "bingliang") return [0, 0];
 						},
 					},
 					noPhaseDelay: 1,
@@ -8308,7 +8308,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				ai: {
 					effect: {
 						target: function (card) {
-							if (card.name == "bingliang") return 0;
+							if (card.name == "bingliang") return [0, 0];
 						},
 					},
 					noPhaseDelay: 1,
@@ -9609,7 +9609,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				ai: {
 					effect: {
 						target: function (card) {
-							if (card.name == "bingliang") return 0;
+							if (card.name == "bingliang") return [0, 0];
 						},
 					},
 					noPhaseDelay: 1,

--- a/mode/versus.js
+++ b/mode/versus.js
@@ -6872,11 +6872,6 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 				},
 				ai: {
 					threaten: 1.5,
-					effect: {
-						target: function (card, player, target) {
-							if (card.name == "guiyoujie") return [0, 1];
-						},
-					},
 				},
 			},
 			boss_zhenwei: {
@@ -7002,13 +6997,6 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 						}
 						event.redo();
 					}
-				},
-				ai: {
-					effect: {
-						target: function (card, player, target) {
-							if (card.name == "guiyoujie") return [0, 1];
-						},
-					},
 				},
 			},
 			boss_tanshi: {

--- a/mode/versus.js
+++ b/mode/versus.js
@@ -7262,7 +7262,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 					nodamage: true,
 					effect: {
 						target: function (card, player, target, current) {
-							if (get.tag(card, "damage") && !get.tag(card, "thunderDamage")) return [0, 0];
+							if (get.tag(card, "damage") && !get.tag(card, "thunderDamage")) return "zeroplayertarget";
 						},
 					},
 				},
@@ -7359,7 +7359,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 					nofire: true,
 					effect: {
 						target: function (card, player, target, current) {
-							if (get.tag(card, "fireDamage")) return 0;
+							if (get.tag(card, "fireDamage")) return "zeroplayertarget";
 						},
 					},
 				},

--- a/mode/versus.js
+++ b/mode/versus.js
@@ -5727,7 +5727,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 								_status.shishengshibai % 10 == 9 &&
 								card.name == "tiesuo"
 							)
-								return "zerotarget";
+								return [0, 0, 0, 0];
 						},
 					},
 				},

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -9592,16 +9592,12 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 *
-	 * @param { number | Card[] | Card } [add]
-	 * @param { (card?: Card, player?: Player) => boolean } [filter]
-	 * @param { boolean } [pure]
+	 * @param { number | Card[] | Card } [add] (逻辑上)同时考虑“获得”的这张/些牌
+	 * @param { (card?: Card, player?: Player) => boolean } [filter] 代替默认策略(计入手牌数的手牌)进行筛选
+	 * @param { boolean } [pure] (手牌上限大于手牌数时)返回负值
+	 * @returns { number } 需要弃置的牌数
 	 */
 	needsToDiscard(add, filter, pure) {
-		/**
-		 * add: (逻辑上)同时考虑“获得”的这张/些牌
-		 * filter(function): 代替默认策略进行筛选
-		 * pure: 返回值可以为负数
-		 */
 		let cards = this.getCards("h"),
 			num = 0;
 		if (typeof add === "number") num = add;
@@ -9837,17 +9833,12 @@ export class Player extends HTMLDivElement {
 	/**
 	 * 以viewer视角猜测Player手里的杀
 	 * @param { Player } [viewer] 
-	 * @param { "use" | "respond" } [type] 
-	 * @param { Card[] | Card | null } [ignore] 
+	 * @param { "use" | "respond" } [type] 此杀用途："use"/"respond"，无则均加入
+	 * @param { Card[] | Card | null } [ignore] 此牌/这些牌不纳入考量
 	 * @param { "bool" | "count" | "odds" } [rvt] 
-	 * @returns { boolean | number }
+	 * @returns { boolean | number } 返回值：rvt:"bool"(默认)是否可能有杀，"count"推测有多少张杀，"odds"有杀的概率
 	 */
 	mayHaveSha(viewer, type, ignore, rvt) {
-		/**
-		 * type: skill tag type 'use', 'respond'
-		 * ignore: ignore cards, ui.selected.cards added
-		 * rvt: return value type 'count', 'odds', 'bool'(default)
-		 */
 		let count = 0;
 		if ((this.hp > 2 || (!this.isZhu && this.hp > 1)) && this.hasSkillTag("respondSha", true, type, true)) {
 			if (rvt === "count") count++;
@@ -9890,17 +9881,12 @@ export class Player extends HTMLDivElement {
 	/**
 	 * 以viewer视角猜测Player手里的闪
 	 * @param { Player } [viewer] 
-	 * @param { "use" | "respond" | object } [type] 
-	 * @param { Card[] | Card | null } [ignore] 
+	 * @param { "use" | "respond" } [type] 此闪用途："use"/"respond"，无则均加入
+	 * @param { Card[] | Card | null } [ignore] 此牌/这些牌不纳入考量
 	 * @param { "bool" | "count" | "odds" } [rvt] 
-	 * @returns { boolean | number }
+	 * @returns { boolean | number } 返回值：rvt:"bool"(默认)是否可能有闪，"count"推测有多少张闪，"odds"有闪的概率
 	 */
 	mayHaveShan(viewer, type, ignore, rvt) {
-		/**
-		 * type: skill tag type 'use', 'respond' or object
-		 * ignore: ignore cards, ui.selected.cards added
-		 * rvt: return value type 'count', 'odds', 'bool'(default)
-		 */
 		let count = 0;
 		if ((this.hp > 2 || (!this.isZhu && this.hp > 1)) && this.hasSkillTag("respondShan", true, type, true)) {
 			if (rvt === "count") count++;

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -11604,7 +11604,7 @@ export class Library {
 				nodamage: true,
 				effect: {
 					target: function (card, player, target, current) {
-						if (get.tag(card, "damage")) return [0, 0];
+						if (get.tag(card, "damage")) return "zeroplayertarget";
 					},
 				},
 			},


### PR DESCRIPTION
### PR受影响的平台
所有平台


### 诱因和背景
吧友反馈人机对藤甲敌人放aoe，经测试为藤甲ai失效所致，进一步测试发现本体effect_use和effect混用现象非常严重



### PR描述
具体详见commits标题



### 扩展适配
请在添加ai.effect时注意区分effect_use和effect（尤其是@mengxinzxz ）
1、如果添加的这个ai.effect是对应角色使用相应牌得以成功执行卡牌效果才能获得的收益或附加在卡牌上的收益，请使用ai.effect.player/ai.effect.target；
2、如果添加的这个ai.effect是针对牌无效化的技能，同1并且将返回值改为"zeroplayertarget"；
3、如果添加的这个ai.effect是对于像”跳过摸牌阶段“给"bingliang"添加ai或者“跳过出牌阶段”给"lebu"添加ai，同1.但由于它是间接导致牌无效的，牌在生效时依旧可能附加额外效果，请将返回值改为[0, 0]或者[0, 0, 0, 0]；
4、如果添加的这个ai.effect是针对卖血、流失体力等需要卡牌生效才能触发的”二级事件“，同1；
5、如果添加的这个ai.effect是对应角色只要使用了相应牌就能获得的(负)收益，不论这张牌有没有被无效化或抵消均会触发对应技能，建议使用ai.effect.player_use/ai.effect.target_use；
6、如果添加的这个ai.effect是鼓励/阻止目标装特定装备（比如【振鞘】，装上就废了），建议写在ai.effect.player_use/ai.effect.target_use内；
7、其他你分不清楚的ai就老老实实用ai.effect.player/ai.effect.target吧

特别地，牌被无效或被抵消，往往会跳过这些触发时机：useCardToBegin、${event.card.name}Begin、${event.card.name}End、${event.card.name}After、useCardToEnd、useCardToAfter
**请注意这些时机仍然存在：**useCardToBefore、${event.card.name}Before、useCardEnd、useCardAfter
那么如果你的ai.effect针对的技能触发时机在上述被跳过的里面，请老老实实用ai.effect.player/ai.effect.target


### 检查清单
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 我没有把该PR提交到`master`分支
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
