### PR TITLE
继续不同效果触发技不同配音修改；bugfix

### DIFF
--- a/card/yingbian.js
+++ b/card/yingbian.js
@@ -494,7 +494,7 @@ game.import("card", function () {
 					}, "he")
 				},
 				content: () => {
-					player.chooseToDiscard(true, (card) => get.event().getTrigger().cards?.includes(card), "he");
+					player.chooseToDiscard(true, (card) => !get.event().getTrigger().cards?.includes(card), "he");
 				},
 				subSkill: {
 					lose: {

--- a/character/clan/skill.js
+++ b/character/clan/skill.js
@@ -1238,6 +1238,9 @@ const skills = {
 			aiOrder(player, card, num) {
 				if (player.isPhaseUsing() && get.type(card) == "equip" && get.equipValue(card, player) > 0) return num + 3;
 			},
+			cardUsable(card) {
+				if (card.storage?.clanfuxun) return Infinity;
+			},
 		},
 		locked: false,
 		audio: 2,
@@ -1333,6 +1336,7 @@ const skills = {
 				var card = {
 					name: result.links[0][2],
 					nature: result.links[0][3],
+					storage: { clanfuxun: true },
 				};
 				game.broadcastAll(function (card) {
 					lib.skill.clanfuxun_backup.viewAs = card;

--- a/character/extra/skill.js
+++ b/character/extra/skill.js
@@ -203,12 +203,14 @@ const skills = {
 			global: "phaseBefore",
 			player: "enterGame",
 		},
-		forced: true,
-		locked: false,
 		filter(event, player) {
 			return event.name != "phase" || game.phaseNumber == 0;
 		},
+		forced: true,
+		popup: false,
+		locked: false,
 		async content(event, trigger, player) {
+			player.logSkill('jilin', null, null, null, 1);
 			const cards = get.cards(3);
 			const next = player.addToExpansion(cards, "draw");
 			next.gaintag.add(event.name);
@@ -255,7 +257,7 @@ const skills = {
 		group: ["jilin_kanpo", "jilin_change"],
 		subSkill: {
 			kanpo: {
-				audio: "jilin",
+				audio: ["jilin2.mp3", "jilin3.mp3"],
 				trigger: {
 					target: "useCardToTarget",
 				},
@@ -306,7 +308,7 @@ const skills = {
 				},
 			},
 			change: {
-				audio: "jilin",
+				audio: ["jilin4.mp3", "jilin5.mp3"],
 				trigger: {
 					player: "phaseBegin",
 				},
@@ -392,7 +394,9 @@ const skills = {
 				cost_data: links,
 			};
 		},
+		popup: false,
 		async content(event, trigger, player) {
+			player.logSkill('yingyou', null, null, null, get.rand(1, 2));
 			event.cost_data[0].storage.jilin = true;
 			const num = player.getExpansions("jilin").filter(card => card.storage.jilin).length;
 			await player.draw(num);
@@ -403,7 +407,7 @@ const skills = {
 		group: "yingyou_draw",
 		subSkill: {
 			draw: {
-				audio: "yingyou",
+				audio: ["yingyou3.mp3", "yingyou4.mp3"],
 				trigger: {
 					player: "loseAfter",
 					global: ["equipAfter", "addJudgeAfter", "gainAfter", "loseAsyncAfter", "addToExpansionAfter"],
@@ -5260,7 +5264,7 @@ const skills = {
 		group: ["tspowei_init", "tspowei_move", "tspowei_achieve", "tspowei_fail", "tspowei_use", "tspowei_remove"],
 		subSkill: {
 			remove: {
-				audio: "tspowei3",
+				audio: "tspowei3.mp3",
 				trigger: { global: "damageEnd" },
 				filter(event, player) {
 					return event.player && event.player.isIn() && event.player.hasMark("dulie");
@@ -5272,7 +5276,7 @@ const skills = {
 				},
 			},
 			use: {
-				audio: "tspowei3",
+				audio: "tspowei3.mp3",
 				trigger: { global: "phaseBegin" },
 				direct: true,
 				filter(event, player) {
@@ -5335,7 +5339,7 @@ const skills = {
 				},
 			},
 			init: {
-				audio: "tspowei3",
+				audio: "tspowei3.mp3",
 				trigger: {
 					global: "phaseBefore",
 					player: "enterGame",
@@ -5353,7 +5357,7 @@ const skills = {
 				},
 			},
 			move: {
-				audio: "tspowei3",
+				audio: "tspowei3.mp3",
 				trigger: { player: "phaseBegin" },
 				forced: true,
 				filter(event, player) {
@@ -5375,7 +5379,7 @@ const skills = {
 				},
 			},
 			achieve: {
-				audio: "tspowei1",
+				audio: "tspowei1.mp3",
 				trigger: { player: "phaseBegin" },
 				forced: true,
 				skillAnimation: true,
@@ -5392,7 +5396,7 @@ const skills = {
 				},
 			},
 			fail: {
-				audio: "tspowei2",
+				audio: "tspowei2.mp3",
 				trigger: { player: "dying" },
 				forced: true,
 				content() {
@@ -5407,9 +5411,6 @@ const skills = {
 			},
 		},
 	},
-	tspowei1: { audio: true },
-	tspowei2: { audio: true },
-	tspowei3: { audio: true },
 	shenzhu: {
 		audio: 2,
 		trigger: { player: "useCardAfter" },

--- a/character/extra/skill.js
+++ b/character/extra/skill.js
@@ -394,9 +394,8 @@ const skills = {
 				cost_data: links,
 			};
 		},
-		popup: false,
+		logAudio: ()=> get.rand(1, 2),
 		async content(event, trigger, player) {
-			player.logSkill('yingyou', null, null, null, get.rand(1, 2));
 			event.cost_data[0].storage.jilin = true;
 			const num = player.getExpansions("jilin").filter(card => card.storage.jilin).length;
 			await player.draw(num);

--- a/character/extra/skill.js
+++ b/character/extra/skill.js
@@ -207,10 +207,9 @@ const skills = {
 			return event.name != "phase" || game.phaseNumber == 0;
 		},
 		forced: true,
-		popup: false,
 		locked: false,
+		logAudio: ()=> 1,
 		async content(event, trigger, player) {
-			player.logSkill('jilin', null, null, null, 1);
 			const cards = get.cards(3);
 			const next = player.addToExpansion(cards, "draw");
 			next.gaintag.add(event.name);
@@ -257,7 +256,8 @@ const skills = {
 		group: ["jilin_kanpo", "jilin_change"],
 		subSkill: {
 			kanpo: {
-				audio: ["jilin2.mp3", "jilin3.mp3"],
+				audio: "jilin",
+				logAudio: ()=> get.rand(2, 3),
 				trigger: {
 					target: "useCardToTarget",
 				},
@@ -308,7 +308,8 @@ const skills = {
 				},
 			},
 			change: {
-				audio: ["jilin4.mp3", "jilin5.mp3"],
+				audio: "jilin",
+				logAudio: ()=> get.rand(4, 5),
 				trigger: {
 					player: "phaseBegin",
 				},
@@ -406,7 +407,8 @@ const skills = {
 		group: "yingyou_draw",
 		subSkill: {
 			draw: {
-				audio: ["yingyou3.mp3", "yingyou4.mp3"],
+				audio: "yingyou",
+				logAudio: ()=> get.rand(3, 4),
 				trigger: {
 					player: "loseAfter",
 					global: ["equipAfter", "addJudgeAfter", "gainAfter", "loseAsyncAfter", "addToExpansionAfter"],

--- a/character/jsrg/skill.js
+++ b/character/jsrg/skill.js
@@ -8110,7 +8110,7 @@ const skills = {
 				})
 				.set("max", trigger.target.countDiscardableCards(player, "he"))
 				.set("goon", get.attitude(player, trigger.target) < 0)
-				.set("logSkill", ["jsrgjuelie", trigger.target]);
+				.set("logSkill", ["jsrgjuelie", trigger.target, null, null, get.rand(3, 4)]);
 			"step 1";
 			if (result.bool) {
 				var num = result.cards.length;
@@ -8148,6 +8148,8 @@ const skills = {
 		group: "jsrgjuelie_pojun",
 		subSkill: {
 			pojun: {
+				audio: "jsrgjuelie",
+				logAudio: ()=> get.rand(1, 2),
 				trigger: { source: "damageBegin1" },
 				filter: function (event, player) {
 					if (!player.isMinHandcard() && !player.isMinHp()) return false;
@@ -9301,6 +9303,7 @@ const skills = {
 		check: function (event, player) {
 			return get.damageEffect(event.player, event.source, _status.event.player, event.nature) * event.num < get.effect(player, { name: "losehp" }, player, _status.event.player) + get.effect(player, { name: "draw" }, player, _status.event.player) + get.effect(event.player, { name: "draw" }, player, _status.event.player) / 2;
 		},
+		logAudio: ()=> get.rand(1, 2),
 		group: "jsrgjishan_recover",
 		content: function () {
 			"step 0";
@@ -9340,7 +9343,7 @@ const skills = {
 					"step 1";
 					if (result.bool) {
 						var target = result.targets[0];
-						player.logSkill("jsrgjishan_recover", target);
+						player.logSkill("jsrgjishan_recover", target, null, null, get.rand(3, 4));
 						target.recover();
 					} else player.storage.counttrigger.jsrgjishan_recover--;
 				},
@@ -9660,6 +9663,7 @@ const skills = {
 			if (num == 0) return "你可以摸一张牌";
 			return "你可以摸一张牌并令" + get.cnNumber(num) + "名角色获得“猎”标记";
 		},
+		logAudio: ()=> get.rand(1, 2),
 		content: function () {
 			"step 0";
 			player.draw();
@@ -9698,6 +9702,7 @@ const skills = {
 		subSkill: {
 			damage: {
 				audio: "jsrgzhenglve",
+				logAudio: ()=> get.rand(3, 4),
 				trigger: { source: "damageSource" },
 				usable: 1,
 				filter: function (event, player) {
@@ -9750,7 +9755,7 @@ const skills = {
 		},
 	},
 	jsrgpingrong: {
-		audio: 2,
+		audio: 3,
 		trigger: { global: "phaseEnd" },
 		filter: function (event, player) {
 			return !player.hasSkill("jsrgpingrong_used") && game.hasPlayer(current => current.hasMark("jsrgzhenglve_mark"));
@@ -9765,10 +9770,10 @@ const skills = {
 				.set("ai", target => {
 					return get.attitude(_status.event.player, target);
 				});
-			("step 1");
+			"step 1";
 			if (result.bool) {
 				var target = result.targets[0];
-				player.logSkill("jsrgpingrong", target);
+				player.logSkill("jsrgpingrong", target, null, null, get.rand(1, 2));
 				player.addTempSkill("jsrgpingrong_used", "roundStart");
 				target.removeMark("jsrgzhenglve_mark", target.countMark("jsrgzhenglve_mark"));
 				player.insertPhase();
@@ -9778,13 +9783,13 @@ const skills = {
 		subSkill: {
 			used: { charlotte: true },
 			check: {
-				audio: "jsrgpingrong",
-				trigger: { player: "phaseAfter" },
 				charlotte: true,
-				forced: true,
+				audio: "jsrgpingrong3.mp3",
+				trigger: { player: "phaseAfter" },
 				filter: function (event, player) {
 					return event.skill == "jsrgpingrong" && !player.getHistory("sourceDamage").length;
 				},
+				forced: true,
 				content: function () {
 					player.loseHp();
 				},

--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -23,6 +23,7 @@ const skills = {
 				event.result = await player.chooseBool(get.prompt2("mbbifeng")).set("choice", choice).forResult();
 			}
 		},
+		popup: false,
 		async content(event, trigger, player) {
 			if (event.triggername == "useCardAfter") {
 				player.unmarkAuto("mbbifeng", trigger.card);
@@ -34,10 +35,17 @@ const skills = {
 					return respondEvts.some(list => {
 						return list[1] == trigger.card;
 					});
-				})) await player.draw(2);
-				else await player.loseHp();
+				})) {
+					player.logSkill('mbbifeng', null, null, null, 3);
+					await player.draw(2);
+				}
+				else {
+					player.logSkill('mbbifeng', null, null, null, 2);
+					await player.loseHp();
+				}
 			}
 			else {
+				player.logSkill('mbbifeng', null, null, null, 1);
 				trigger.getParent().excluded.add(player);
 				player.markAuto("mbbifeng", trigger.card);
 			}
@@ -433,7 +441,9 @@ const skills = {
 				cost_data: list,
 			};
 		},
+		popup: false,
 		async content(event, trigger, player) {
+			player.logSkill('mbjiejian', event.targets, null, null, 1);
 			const list = event.cost_data;
 			await game.loseAsync({
 				gain_list: list,
@@ -450,7 +460,7 @@ const skills = {
 		group: ["mbjiejian_liuli", "mbjiejian_remove"],
 		subSkill: {
 			liuli: {
-				audio: "mbjiejian",
+				audio: "mbjiejian2.mp3",
 				trigger: {
 					global: "useCardToTarget",
 				},
@@ -474,7 +484,7 @@ const skills = {
 				},
 			},
 			remove: {
-				audio: "mbjiejian",
+				audio: "mbjiejian3.mp3",
 				trigger: {
 					global: "phaseEnd",
 				},
@@ -580,16 +590,19 @@ const skills = {
 		},
 		logTarget: "player",
 		onremove: true,
+		popup: false,
 		async content(event, trigger, player) {
 			const { control } = event.cost_data;
 			const { player: target, source } = trigger;
 			if (!player.storage.mbpanxiang) player.storage.mbpanxiang = {};
 			player.storage.mbpanxiang[target.playerid] = control;
 			if (control === "减伤") {
+				player.logSkill('mbpanxiang', null, null, null, get.rand(1, 2));
 				trigger.num--;
 				game.log(player, "令此伤害", "#y-1");
 				if (source && source.isIn()) await source.draw(2);
 			} else {
+				player.logSkill('mbpanxiang', null, null, null, get.rand(3, 4));
 				trigger.num++;
 				game.log(player, "令此伤害", "#y+1");
 				await target.draw(3);
@@ -2903,11 +2916,16 @@ const skills = {
 			return player.maxHp >= num;
 		},
 		forced: true,
+		popup: false,
 		content: function () {
 			if (trigger.name == "damage") {
+				player.logSkill('laishou', null, null, null, get.rand(1, 2));
 				player.gainMaxHp(trigger.num);
 				trigger.cancel();
-			} else player.die();
+			} else {
+				player.logSkill('laishou', null, null, null, 3);
+				player.die();
+			}
 		},
 	},
 	luanqun: {
@@ -4999,8 +5017,6 @@ const skills = {
 	spdaming: {
 		audio: 3,
 		trigger: { global: "phaseBefore", player: "enterGame" },
-		forced: true,
-		locked: false,
 		global: "spdaming_give",
 		filter: function (event, player) {
 			return event.name != "phase" || game.phaseNumber == 0;
@@ -5012,7 +5028,11 @@ const skills = {
 			player.markSkill("spdaming");
 			game.log(player, (num > 0 ? "获得了" : "减少了") + get.cnNumber(Math.abs(num)) + "点“达命”值");
 		},
+		forced: true,
+		popup: false,
+		locked: false,
 		content: function () {
+			player.logSkill('spdaming', null, null, null, get.rand(1, 2));
 			lib.skill.spdaming.change(player, 1);
 		},
 		intro: {
@@ -5071,7 +5091,7 @@ const skills = {
 				},
 				content: function () {
 					"step 0";
-					game.trySkillAudio("spdaming", target);
+					game.trySkillAudio("spdaming", target, null, null, null, get.rand(1, 2));
 					player.give(cards, target);
 					if (!game.hasPlayer(current => current != player && current != target)) event.finish();
 					target.addTempSkill("spdaming_used", "phaseUseAfter");
@@ -5100,6 +5120,9 @@ const skills = {
 						} else {
 							var cards = cards.filter(i => get.owner(i) == target);
 							if (cards.length) target.give(cards, player);
+							game.broadcastAll(function () {
+								if (lib.config.background_speak) game.playAudio("skill", "spdaming3");
+							});
 							event.finish();
 						}
 					} else event.finish();
@@ -5255,7 +5278,7 @@ const skills = {
 			"step 1";
 			if (result.bool) {
 				var target = result.targets[0];
-				player.logSkill("sbanguo", target);
+				player.logSkill("sbanguo", target, null, null, get.rand(1, 2));
 				target.addMark("sbanguo_mark", 1, false);
 				target.addAdditionalSkill("sbanguo_" + player.playerid, "sbanguo_mark");
 				target.addMark("sbanguo_marked", 1, false);
@@ -5278,7 +5301,7 @@ const skills = {
 				},
 			},
 			move: {
-				audio: "sbanguo",
+				audio: "sbanguo3.mp3",
 				direct: true,
 				trigger: { player: "phaseUseBegin" },
 				filter: function (event, player) {
@@ -5324,7 +5347,7 @@ const skills = {
 				},
 			},
 			damage: {
-				audio: "sbanguo",
+				audio: ["sbanguo1.mp3", "sbanguo2.mp3"],
 				forced: true,
 				locked: false,
 				trigger: { player: "damageBegin4" },
@@ -5406,7 +5429,7 @@ const skills = {
 			"step 0";
 			player
 				.chooseToDiscard(get.prompt2("sbbenxi"), [1, Infinity], "he")
-				.set("logSkill", "sbbenxi")
+				.set("logSkill", ["sbbenxi", null, null, null, 1])
 				.set("ai", card => {
 					var player = _status.event.player;
 					if (ui.selected.cards.length < _status.event.num) return 100 - (get.useful(card, player) + player.getUseValue(card) / 3);
@@ -5460,7 +5483,7 @@ const skills = {
 		},
 		subSkill: {
 			effect: {
-				audio: "sbbenxi",
+				audio: "sbbenxi2.mp3",
 				trigger: { player: "useCard2" },
 				forced: true,
 				charlotte: true,
@@ -5525,7 +5548,7 @@ const skills = {
 				},
 			},
 			effect2: {
-				audio: "sbbenxi",
+				audio: "sbbenxi3.mp3",
 				trigger: {
 					global: "useCardAfter",
 				},
@@ -5765,6 +5788,7 @@ const skills = {
 			} else event.finish();
 			"step 2";
 			var kane = result.control;
+			player.logSkill("yijin", target, null, null, ['yijin_jinmi', 'yijin_guxiong', 'yijin_yongbi'].includes(result.control) ? 2 : 1);
 			player.removeMark(kane, 1);
 			player.popup(kane, "metal");
 			player.addSkill("yijin_clear");
@@ -5788,7 +5812,7 @@ const skills = {
 				},
 			},
 			upstart: {
-				audio: "yijin",
+				audio: "yijin1.mp3",
 				trigger: {
 					global: "phaseBefore",
 					player: "enterGame",
@@ -5807,7 +5831,7 @@ const skills = {
 				},
 			},
 			die: {
-				audio: "yijin",
+				audio: "yijin3.mp3",
 				trigger: { player: "phaseBegin" },
 				forced: true,
 				check: () => false,
@@ -6702,100 +6726,97 @@ const skills = {
 	//蒋干
 	spdaoshu: {
 		audio: 3,
-		group: "spdaoshu_effect",
+		trigger: { global: "phaseUseBegin" },
+		filter: function (event, player) {
+			var goon = event.player != player && (get.mode() == "identity" || get.mode() == "guozhan" || event.player.isEnemyOf(player));
+			return goon && event.player.countCards("h") > 0 && event.player.hasUseTarget({ name: "jiu", isCard: true }, null, true);
+		},
+		round: 1,
+		logTarget: "player",
+		check: function (event, player) {
+			var target = event.player;
+			var att = get.attitude(player, target);
+			if (att > 0) return false;
+			if (att == 0) return !player.inRangeOf(target);
+			return true;
+		},
+		popup: false,
+		content: function () {
+			"step 0";
+			event.target = trigger.player;
+			player.logSkill("spdaoshu", event.target, null, null, 1);
+			event.target.chooseUseTarget("jiu", true);
+			"step 1";
+			if (!target.countCards("h")) {
+				event.finish();
+				return;
+			}
+			var list = [];
+			for (var i of lib.inpile) {
+				if (get.type(i) == "basic") list.push(i);
+			}
+			if (!list.length) {
+				event.finish();
+				return;
+			}
+			target
+				.chooseControl(list)
+				.set("prompt", "请声明一种基本牌")
+				.set("ai", () => _status.event.rand)
+				.set("rand", get.rand(0, list.length - 1));
+			"step 2";
+			event.cardname = result.control;
+			target.chat("我声明" + get.translation(event.cardname));
+			game.log(target, "声明的牌名为", "#y" + get.translation(event.cardname));
+			game.delayx();
+			player
+				.chooseControl("有！", "没有！")
+				.set("prompt", "你觉得" + get.translation(target) + "的手牌区里有" + get.translation(event.cardname) + "吗？")
+				.set("ai", function () {
+					return _status.event.choice;
+				})
+				.set(
+					"choice",
+					(function () {
+						var rand =
+							{
+								sha: 0.273,
+								shan: 0.149,
+								tao: 0.074,
+								jiu: 0.031,
+							}[event.cardname] || 0.1;
+						return 1 - Math.pow(1 - rand, target.countCards("h")) > 0.5 ? "有！" : "没有！";
+					})()
+				);
+			"step 3";
+			player.chat(result.control);
+			game.log(player, "认为", "#y" + result.control);
+			game.delayx();
+			"step 4";
+			var bool1 = result.index == 0;
+			var bool2 = target.hasCard(function (card) {
+				return get.name(card, target) == event.cardname;
+			}, "h");
+			if (bool1 == bool2) {
+				player.popup("判断正确", "wood");
+				game.broadcastAll(function () {
+					if (lib.config.background_speak) game.playAudio("skill", "spdaoshu2");
+				});
+				player.gainPlayerCard(target, "h", 2, true);
+				//var cards=target.getCards('h',function(card){
+				//	return lib.filter.canBeGained(card,player,target);
+				//}).randomGets(5);
+				//if(cards.length>0) player.gain(cards,target,'giveAuto','bySelf');
+			} else {
+				player.popup("判断错误", "fire");
+				game.broadcastAll(function () {
+					if (lib.config.background_speak) game.playAudio("skill", "spdaoshu3");
+				});
+				//player.addTempSkill('spdaoshu_respond');
+			}
+		},
+		ai: { expose: 0.3 },
 		subSkill: {
-			effect: {
-				audio: "spdaoshu1",
-				trigger: { global: "phaseUseBegin" },
-				filter: function (event, player) {
-					var goon = event.player != player && (get.mode() == "identity" || get.mode() == "guozhan" || event.player.isEnemyOf(player));
-					return goon && event.player.countCards("h") > 0 && event.player.hasUseTarget({ name: "jiu", isCard: true }, null, true);
-				},
-				round: 1,
-				logTarget: "player",
-				prompt2: () => lib.translate.spdaoshu_info,
-				check: function (event, player) {
-					var target = event.player;
-					var att = get.attitude(player, target);
-					if (att > 0) return false;
-					if (att == 0) return !player.inRangeOf(target);
-					return true;
-				},
-				content: function () {
-					"step 0";
-					event.target = trigger.player;
-					event.target.chooseUseTarget("jiu", true);
-					"step 1";
-					if (!target.countCards("h")) {
-						event.finish();
-						return;
-					}
-					var list = [];
-					for (var i of lib.inpile) {
-						if (get.type(i) == "basic") list.push(i);
-					}
-					if (!list.length) {
-						event.finish();
-						return;
-					}
-					target
-						.chooseControl(list)
-						.set("prompt", "请声明一种基本牌")
-						.set("ai", () => _status.event.rand)
-						.set("rand", get.rand(0, list.length - 1));
-					"step 2";
-					event.cardname = result.control;
-					target.chat("我声明" + get.translation(event.cardname));
-					game.log(target, "声明的牌名为", "#y" + get.translation(event.cardname));
-					game.delayx();
-					player
-						.chooseControl("有！", "没有！")
-						.set("prompt", "你觉得" + get.translation(target) + "的手牌区里有" + get.translation(event.cardname) + "吗？")
-						.set("ai", function () {
-							return _status.event.choice;
-						})
-						.set(
-							"choice",
-							(function () {
-								var rand =
-									{
-										sha: 0.273,
-										shan: 0.149,
-										tao: 0.074,
-										jiu: 0.031,
-									}[event.cardname] || 0.1;
-								return 1 - Math.pow(1 - rand, target.countCards("h")) > 0.5 ? "有！" : "没有！";
-							})()
-						);
-					"step 3";
-					player.chat(result.control);
-					game.log(player, "认为", "#y" + result.control);
-					game.delayx();
-					"step 4";
-					var bool1 = result.index == 0;
-					var bool2 = target.hasCard(function (card) {
-						return get.name(card, target) == event.cardname;
-					}, "h");
-					if (bool1 == bool2) {
-						player.popup("判断正确", "wood");
-						game.broadcastAll(function () {
-							if (lib.config.background_speak) game.playAudio("skill", "spdaoshu2");
-						});
-						player.gainPlayerCard(target, "h", 2, true);
-						//var cards=target.getCards('h',function(card){
-						//	return lib.filter.canBeGained(card,player,target);
-						//}).randomGets(5);
-						//if(cards.length>0) player.gain(cards,target,'giveAuto','bySelf');
-					} else {
-						player.popup("判断错误", "fire");
-						game.broadcastAll(function () {
-							if (lib.config.background_speak) game.playAudio("skill", "spdaoshu3");
-						});
-						//player.addTempSkill('spdaoshu_respond');
-					}
-				},
-				ai: { expose: 0.3 },
-			},
 			respond: {
 				trigger: { global: "useCard1" },
 				forced: true,
@@ -6809,7 +6830,6 @@ const skills = {
 			},
 		},
 	},
-	spdaoshu1: { audio: true },
 	mbdaoshu: {
 		audio: 3,
 		group: "mbdaoshu_use",

--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -5347,7 +5347,8 @@ const skills = {
 				},
 			},
 			damage: {
-				audio: ["sbanguo1.mp3", "sbanguo2.mp3"],
+				audio: "sbanguo",
+				logAudio: ()=> get.rand(1, 2),
 				forced: true,
 				locked: false,
 				trigger: { player: "damageBegin4" },

--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -441,7 +441,7 @@ const skills = {
 				cost_data: list,
 			};
 		},
-		popup: false,
+		logAudio: ()=> 1,
 		async content(event, trigger, player) {
 			player.logSkill('mbjiejian', event.targets, null, null, 1);
 			const list = event.cost_data;
@@ -590,19 +590,20 @@ const skills = {
 		},
 		logTarget: "player",
 		onremove: true,
-		popup: false,
+		logAudio(_, __, ___, ___, evt) {
+			const { control } = evt.cost_data;
+			return control == "减伤" ? get.rand(1, 2) : get.rand(3, 4);
+		},
 		async content(event, trigger, player) {
 			const { control } = event.cost_data;
 			const { player: target, source } = trigger;
 			if (!player.storage.mbpanxiang) player.storage.mbpanxiang = {};
 			player.storage.mbpanxiang[target.playerid] = control;
 			if (control === "减伤") {
-				player.logSkill('mbpanxiang', null, null, null, get.rand(1, 2));
 				trigger.num--;
 				game.log(player, "令此伤害", "#y-1");
 				if (source && source.isIn()) await source.draw(2);
 			} else {
-				player.logSkill('mbpanxiang', null, null, null, get.rand(3, 4));
 				trigger.num++;
 				game.log(player, "令此伤害", "#y+1");
 				await target.draw(3);
@@ -2916,16 +2917,15 @@ const skills = {
 			return player.maxHp >= num;
 		},
 		forced: true,
-		popup: false,
+		logAudio(event, player) {
+			if (event.name == "damage") get.rand(1, 2);
+			return 3;
+		},
 		content: function () {
 			if (trigger.name == "damage") {
-				player.logSkill('laishou', null, null, null, get.rand(1, 2));
 				player.gainMaxHp(trigger.num);
 				trigger.cancel();
-			} else {
-				player.logSkill('laishou', null, null, null, 3);
-				player.die();
-			}
+			} else player.die();
 		},
 	},
 	luanqun: {
@@ -2939,6 +2939,7 @@ const skills = {
 			"step 0";
 			var targets = game.filterPlayer(current => current.countCards("h")).sortBySeat();
 			event.targets = targets;
+			player.line(targets);
 			var next = player
 				.chooseCardOL(targets, "乱群：请选择要展示的牌", true)
 				.set("ai", function (card) {
@@ -5029,10 +5030,9 @@ const skills = {
 			game.log(player, (num > 0 ? "获得了" : "减少了") + get.cnNumber(Math.abs(num)) + "点“达命”值");
 		},
 		forced: true,
-		popup: false,
 		locked: false,
+		logAudio: ()=> get.rand(1, 2),
 		content: function () {
-			player.logSkill('spdaming', null, null, null, get.rand(1, 2));
 			lib.skill.spdaming.change(player, 1);
 		},
 		intro: {
@@ -6740,11 +6740,10 @@ const skills = {
 			if (att == 0) return !player.inRangeOf(target);
 			return true;
 		},
-		popup: false,
+		logAudio: ()=> 1,
 		content: function () {
 			"step 0";
 			event.target = trigger.player;
-			player.logSkill("spdaoshu", event.target, null, null, 1);
 			event.target.chooseUseTarget("jiu", true);
 			"step 1";
 			if (!target.countCards("h")) {

--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -590,7 +590,7 @@ const skills = {
 		},
 		logTarget: "player",
 		onremove: true,
-		logAudio(_, __, ___, ___, evt) {
+		logAudio(event, player, name, indexedData, evt) {
 			const { control } = evt.cost_data;
 			return control == "减伤" ? get.rand(1, 2) : get.rand(3, 4);
 		},

--- a/character/newjiang/skill.js
+++ b/character/newjiang/skill.js
@@ -2900,10 +2900,11 @@ const skills = {
 		filter: function (event, player) {
 			return player.countMark("spshidi") % 2 == ["phaseJieshu", "phaseZhunbei"].indexOf(event.name);
 		},
+		logAudio(event, player) {
+			return 1 + player.countMark("spshidi") % 2;
+		},
 		forced: true,
-		popup: false,
 		content: function () {
-			player.logSkill('spshidi', null, null, null, 2 - player.countMark("spshidi") % 2);
 			player.changeZhuanhuanji("spshidi");
 		},
 		mod: {

--- a/character/newjiang/skill.js
+++ b/character/newjiang/skill.js
@@ -2901,7 +2901,7 @@ const skills = {
 			return player.countMark("spshidi") % 2 == ["phaseJieshu", "phaseZhunbei"].indexOf(event.name);
 		},
 		logAudio(event, player) {
-			return 1 + player.countMark("spshidi") % 2;
+			return 2 - player.countMark("spshidi") % 2;
 		},
 		forced: true,
 		content: function () {

--- a/character/sb/skill.js
+++ b/character/sb/skill.js
@@ -5086,7 +5086,7 @@ const skills = {
 			"step 1";
 			if (result.bool) {
 				var target = result.targets[0];
-				player.logSkill("sbxieji", target);
+				player.logSkill("sbxieji", target, null, null, get.rand(1, 2));
 				//选择对方的协击条件
 				player.chooseCooperationFor(target, "sbxieji").set("ai", function (button) {
 					var base = 0;
@@ -5114,7 +5114,7 @@ const skills = {
 		},
 		subSkill: {
 			effect: {
-				audio: "sbxieji",
+				audio: "sbxieji3.mp3",
 				charlotte: true,
 				trigger: { global: "phaseJieshuBegin" },
 				direct: true,
@@ -6877,6 +6877,7 @@ const skills = {
 		filter: function (event, player) {
 			return game.hasPlayer(current => current.hasMark("sbjieyin_mark"));
 		},
+		logAudio: ()=> get.rand(1, 2),
 		content: function () {
 			"step 0";
 			var targets = game.filterPlayer(current => current.hasMark("sbjieyin_mark"));
@@ -6927,7 +6928,7 @@ const skills = {
 		},
 		subSkill: {
 			fail: {
-				audio: "sbjieyin",
+				audio: "sbjieyin2.mp3",
 				trigger: { global: "dieAfter" },
 				dutySkill: true,
 				forced: true,
@@ -6959,7 +6960,7 @@ const skills = {
 			},
 			marked: { charlotte: true },
 			init: {
-				audio: "sbjieyin",
+				audio: "sbjieyin1.mp3",
 				trigger: {
 					global: "phaseBefore",
 					player: "enterGame",

--- a/character/shiji/skill.js
+++ b/character/shiji/skill.js
@@ -268,38 +268,34 @@ const skills = {
 	},
 	houfeng: {
 		audio: 3,
-		group: "houfeng_zhengsu",
+		trigger: { global: "phaseUseBegin" },
+		filter: function (event, player) {
+			if (!["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].some(i => !event.player.hasSkill(i))) return false;
+			return player.inRange(event.player);
+		},
+		check: function (event, player) {
+			return get.attitude(player, event.player) > 0;
+		},
+		round: 1,
+		logAudio: ()=> 1,
+		logTarget: "player",
+		content: function () {
+			"step 0";
+			player.chooseButton(["选择" + get.translation(trigger.player) + "要进行的整肃类型", [["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].filter(i => !trigger.player.hasSkill(i)), "vcard"]], true).set("ai", () => Math.random());
+			"step 1";
+			if (result.bool) {
+				var name = result.links[0][2],
+					target = trigger.player;
+				target.addTempSkill("houfeng_share", {
+					player: ["phaseDiscardAfter", "phaseAfter"],
+				});
+				target.markAuto("houfeng_share", [player]);
+				target.addTempSkill(name, { player: ["phaseDiscardAfter", "phaseAfter"] });
+				target.popup(name, "thunder");
+				game.delayx();
+			}
+		},
 		subSkill: {
-			zhengsu: {
-				audio: "houfeng1",
-				trigger: { global: "phaseUseBegin" },
-				filter: function (event, player) {
-					if (!["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].some(i => !event.player.hasSkill(i))) return false;
-					return player.inRange(event.player);
-				},
-				check: function (event, player) {
-					return get.attitude(player, event.player) > 0;
-				},
-				prompt2: () => lib.translate.houfeng_info,
-				round: 1,
-				logTarget: "player",
-				content: function () {
-					"step 0";
-					player.chooseButton(["选择" + get.translation(trigger.player) + "要进行的整肃类型", [["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].filter(i => !trigger.player.hasSkill(i)), "vcard"]], true).set("ai", () => Math.random());
-					"step 1";
-					if (result.bool) {
-						var name = result.links[0][2],
-							target = trigger.player;
-						target.addTempSkill("houfeng_share", {
-							player: ["phaseDiscardAfter", "phaseAfter"],
-						});
-						target.markAuto("houfeng_share", [player]);
-						target.addTempSkill(name, { player: ["phaseDiscardAfter", "phaseAfter"] });
-						target.popup(name, "thunder");
-						game.delayx();
-					}
-				},
-			},
 			share: {
 				charlotte: true,
 				onremove: true,
@@ -356,31 +352,27 @@ const skills = {
 	//手杀皇甫嵩
 	spzhengjun: {
 		audio: 3,
-		group: "spzhengjun_zhengsu",
+		trigger: { player: "phaseUseBegin" },
+		filter: function (event, player) {
+			return ["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].some(i => !player.hasSkill(i));
+		},
+		direct: true,
+		content: function () {
+			"step 0";
+			player.chooseButton([get.prompt("spzhengjun"), [["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].filter(i => !player.hasSkill(i)), "vcard"]]).set("ai", () => Math.random());
+			"step 1";
+			if (result.bool) {
+				player.logSkill("spzhengjun_zhengsu", player, null, null, 1);
+				var name = result.links[0][2];
+				player.addTempSkill("spzhengjun_share", {
+					player: ["phaseDiscardAfter", "phaseAfter"],
+				});
+				player.addTempSkill(name, { player: ["phaseDiscardAfter", "phaseAfter"] });
+				player.popup(name, "thunder");
+				game.delayx();
+			}
+		},
 		subSkill: {
-			zhengsu: {
-				audio: "spzhengjun1",
-				trigger: { player: "phaseUseBegin" },
-				filter: function (event, player) {
-					return ["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].some(i => !player.hasSkill(i));
-				},
-				direct: true,
-				content: function () {
-					"step 0";
-					player.chooseButton([get.prompt("spzhengjun"), [["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].filter(i => !player.hasSkill(i)), "vcard"]]).set("ai", () => Math.random());
-					"step 1";
-					if (result.bool) {
-						player.logSkill("spzhengjun_zhengsu", player);
-						var name = result.links[0][2];
-						player.addTempSkill("spzhengjun_share", {
-							player: ["phaseDiscardAfter", "phaseAfter"],
-						});
-						player.addTempSkill(name, { player: ["phaseDiscardAfter", "phaseAfter"] });
-						player.popup(name, "thunder");
-						game.delayx();
-					}
-				},
-			},
 			share: {
 				charlotte: true,
 				trigger: { player: "phaseDiscardEnd" },
@@ -436,7 +428,6 @@ const skills = {
 			},
 		},
 	},
-	spzhengjun1: { audio: true },
 	spshiji: {
 		audio: 2,
 		trigger: { source: "damageBegin2" },
@@ -773,31 +764,27 @@ const skills = {
 	},
 	spyanji: {
 		audio: 3,
-		group: "spyanji_zhengsu",
+		trigger: { player: "phaseUseBegin" },
+		filter: function (event, player) {
+			return ["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].some(i => !player.hasSkill(i));
+		},
+		direct: true,
+		content: function () {
+			"step 0";
+			player.chooseButton([get.prompt("spyanji"), [["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].filter(i => !player.hasSkill(i)), "vcard"]]).set("ai", () => Math.random());
+			"step 1";
+			if (result.bool) {
+				player.logSkill("spyanji", player, null, null, 1);
+				var name = result.links[0][2];
+				player.addTempSkill("spyanji_share", {
+					player: ["phaseDiscardAfter", "phaseAfter"],
+				});
+				player.addTempSkill(name, { player: ["phaseDiscardAfter", "phaseAfter"] });
+				player.popup(name, "thunder");
+				game.delayx();
+			}
+		},
 		subSkill: {
-			zhengsu: {
-				audio: "spyanji",
-				trigger: { player: "phaseUseBegin" },
-				filter: function (event, player) {
-					return ["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].some(i => !player.hasSkill(i));
-				},
-				direct: true,
-				content: function () {
-					"step 0";
-					player.chooseButton([get.prompt("spyanji"), [["zhengsu_leijin", "zhengsu_bianzhen", "zhengsu_mingzhi"].filter(i => !player.hasSkill(i)), "vcard"]]).set("ai", () => Math.random());
-					"step 1";
-					if (result.bool) {
-						player.logSkill("spyanji_zhengsu", player);
-						var name = result.links[0][2];
-						player.addTempSkill("spyanji_share", {
-							player: ["phaseDiscardAfter", "phaseAfter"],
-						});
-						player.addTempSkill(name, { player: ["phaseDiscardAfter", "phaseAfter"] });
-						player.popup(name, "thunder");
-						game.delayx();
-					}
-				},
-			},
 			share: {
 				charlotte: true,
 				trigger: { player: "phaseDiscardEnd" },
@@ -823,7 +810,6 @@ const skills = {
 			},
 		},
 	},
-	spyanji1: { audio: true },
 	//蒋钦
 	spjianyi: {
 		audio: 2,
@@ -2315,7 +2301,8 @@ const skills = {
 		derivation: "zhangming",
 		subSkill: {
 			chuhai: {
-				audio: ["chuhai", 2],
+				audio: "chuhai",
+				logAudio: ()=> 1,
 				inherit: "chuhai",
 				prompt: "与一名其他角色进行拼点",
 			},
@@ -2333,7 +2320,7 @@ const skills = {
 				},
 			},
 			achieve: {
-				audio: ["chuhai", 2],
+				audio: "chuhai2.mp3",
 				trigger: { player: "equipAfter" },
 				forced: true,
 				skillAnimation: true,
@@ -2349,7 +2336,7 @@ const skills = {
 				},
 			},
 			fail: {
-				audio: "chuhai3",
+				audio: "chuhai3.mp3",
 				trigger: { player: "chooseToCompareAfter" },
 				forced: true,
 				filter: function (event, player) {
@@ -2362,7 +2349,6 @@ const skills = {
 			},
 		},
 	},
-	chuhai3: { audio: true },
 	zhangming: {
 		audio: 2,
 		trigger: { player: "useCard" },
@@ -2966,7 +2952,6 @@ const skills = {
 		dutySkill: true,
 		forced: true,
 		locked: false,
-		direct: true,
 		filter: function (event, player) {
 			if (!player.storage.xingqi || !player.storage.xingqi.length) return false;
 			var map = { basic: 0, trick: 0, equip: 0 };
@@ -2979,11 +2964,13 @@ const skills = {
 			}
 			return true;
 		},
+		logAudio: ()=> 1,
+		skillAnimation: true,
+		animationColor: "water",
 		content: function () {
 			"step 0";
-			player.logSkill("twmibei_achieve");
-			game.log(player, "成功完成使命");
 			player.awakenSkill("mibei");
+			game.log(player, "成功完成使命");
 			var list = ["basic", "equip", "trick"],
 				cards = [];
 			for (var i of list) {
@@ -3016,7 +3003,7 @@ const skills = {
 			},
 			mark: { charlotte: true },
 			fail: {
-				audio: "mibei2",
+				audio: "mibei2.mp3",
 				trigger: { player: "phaseJieshuBegin" },
 				filter: function (event, player) {
 					return !player.getStorage("xingqi").length && player.hasSkill("mibei_mark");
@@ -3030,8 +3017,6 @@ const skills = {
 			},
 		},
 	},
-	mibei1: { audio: true },
-	mibei2: { audio: true },
 	xinmouli: {
 		audio: "mouli",
 		enable: "phaseUse",
@@ -3424,7 +3409,7 @@ const skills = {
 		group: ["qingyu_achieve", "qingyu_fail", "qingyu_defend"],
 		subSkill: {
 			defend: {
-				audio: "qingyu1",
+				audio: "qingyu1.mp3",
 				trigger: { player: "damageBegin2" },
 				filter: function (event, player) {
 					return (
@@ -3440,7 +3425,7 @@ const skills = {
 				},
 			},
 			achieve: {
-				audio: "qingyu3",
+				audio: "qingyu3.mp3",
 				trigger: { player: "phaseZhunbeiBegin" },
 				forced: true,
 				skillAnimation: true,
@@ -3455,7 +3440,7 @@ const skills = {
 				},
 			},
 			fail: {
-				audio: "qingyu2",
+				audio: "qingyu2.mp3",
 				trigger: { player: "dying" },
 				forced: true,
 				content: function () {
@@ -3467,9 +3452,6 @@ const skills = {
 		},
 		derivation: "xuancun",
 	},
-	qingyu1: { audio: true },
-	qingyu2: { audio: true },
-	qingyu3: { audio: true },
 	xuancun: {
 		audio: 2,
 		trigger: { global: "phaseEnd" },

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -1968,7 +1968,7 @@ const skills = {
 						type = get.type(name),
 						infox = get.info({ name: name });
 					if (type != "basic" && type != "trick") return false;
-					if (type == "trick" && (!infox || !infox.filterTarget)) return false;
+					if (type == "trick" && (!infox || !infox.filterTarget || get.info("xunshi").isXunshi({ name: name }))) return false;
 					return (type != "basic") == (player.storage.olxuanzhu || false);
 				})
 				.some(card => event.filterCard({ name: card[2], nature: card[3] }, player, event));
@@ -1982,7 +1982,7 @@ const skills = {
 							type = get.type(name),
 							infox = get.info({ name: name });
 						if (type != "basic" && type != "trick") return false;
-						if (type == "trick" && (!infox || !infox.filterTarget)) return false;
+						if (type == "trick" && (!infox || !infox.filterTarget || get.info("xunshi").isXunshi({ name: name }))) return false;
 						return (type != "basic") == (player.storage.olxuanzhu || false);
 					})
 					.filter(card => event.filterCard({ name: card[2], nature: card[3] }, player, event));
@@ -2073,7 +2073,7 @@ const skills = {
 						type = get.type(name),
 						infox = get.info({ name: name });
 					if (type != "basic" && type != "trick") return false;
-					if (type == "trick" && (!infox || !infox.filterTarget)) return false;
+					if (type == "trick" && (!infox || !infox.filterTarget || get.info("xunshi").isXunshi({ name: name }))) return false;
 					return (type != "basic") == (player.storage.olxuanzhu || false);
 				})
 				.map(card => card[2])

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -9945,10 +9945,11 @@ const skills = {
 			return event.skill == "olbixin" && player.countMark("olbixin") < 3;
 		},
 		forced: true,
-		popup: false,
+		logAudio(event, player) {
+			return 1 + player.countMark("olbixin");
+		},
 		content: function () {
 			player.addMark("olbixin", 1, false);
-			player.logSkill('olximo', null, null, null, player.countMark("olbixin"));
 			game.log(player, "删除了", "#g【笔心】", "描述的前五个字符");
 			if (player.countMark("olbixin") == 3) {
 				game.log(player, "交换了", "#g【笔心】", "方括号中的两个数字");

--- a/character/tw/skill.js
+++ b/character/tw/skill.js
@@ -3322,6 +3322,9 @@ const skills = {
 			return event.hasNature();
 		},
 		forced: true,
+		logAudio(event, player, name) {
+			return name == "damageBegin2" ? 2 : 1;
+		},
 		content: function () {
 			"step 0";
 			if (event.triggername == "damageBegin2") {
@@ -6750,19 +6753,16 @@ const skills = {
 			}
 			return true;
 		},
+		logAudio: ()=> 1,
+		skillAnimation: true,
+		animationColor: "water",
 		content: function () {
 			player.awakenSkill("twmibei");
-			player.logSkill("twmibei_achieve");
 			game.log(player, "成功完成使命");
 			player.addSkills("twmouli");
 		},
 		intro: { content: "已使用牌名：$" },
 		subSkill: {
-			achieve: {
-				audio: "mibei1",
-				skillAnimation: true,
-				animationColor: "water",
-			},
 			mark: {
 				trigger: { player: "useCard1" },
 				filter: function (event, player) {
@@ -6777,7 +6777,7 @@ const skills = {
 				},
 			},
 			fail: {
-				audio: "mibei2",
+				audio: "mibei2.mp3",
 				trigger: { player: "phaseUseEnd" },
 				forced: true,
 				filter: function (event, player) {
@@ -13143,6 +13143,7 @@ const skills = {
 			return game.hasPlayer(current => current != player) && (event.name != "phase" || game.phaseNumber == 0);
 		},
 		forced: true,
+		logAudio: ()=> 1,
 		content: function () {
 			"step 0";
 			player.chooseTarget("请选择【随征】的目标", lib.translate.twsuizheng_info, lib.filter.notMe, true).set("ai", function (target) {
@@ -13164,7 +13165,7 @@ const skills = {
 		subSkill: {
 			draw: {
 				charlotte: true,
-				audio: "twsuizheng",
+				audio: "twsuizheng3.mp3",
 				trigger: { global: "damageSource" },
 				filter: function (event, player) {
 					return player.getStorage("twsuizheng").includes(event.source);
@@ -13176,7 +13177,7 @@ const skills = {
 				},
 			},
 			xianfu: {
-				audio: "twsuizheng",
+				audio: "twsuizheng2.mp3",
 				trigger: { global: "damageEnd" },
 				filter: function (event, player) {
 					return player.getStorage("twsuizheng").includes(event.player) && event.player.isIn();

--- a/character/yijiang/skill.js
+++ b/character/yijiang/skill.js
@@ -11723,7 +11723,8 @@ const skills = {
 		group: ["enyuan1", "enyuan2"],
 	},
 	enyuan1: {
-		audio: ["enyuan3.mp3", "enyuan4.mp3"],
+		audio: "enyuan",
+		logAudio: ()=> get.rand(3, 4),
 		trigger: { player: "damageEnd" },
 		forced: true,
 		filter: function (event, player) {
@@ -11762,7 +11763,8 @@ const skills = {
 		},
 	},
 	enyuan2: {
-		audio: ["enyuan1.mp3", "enyuan2.mp3"],
+		audio: "enyuan",
+		logAudio: ()=> get.rand(1, 2),
 		trigger: { player: "recoverEnd" },
 		forced: true,
 		logTarget: "source",

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -3386,7 +3386,7 @@ game.import("mode", function (lib, game, ui, get, ai, _status) {
 					if (gains.length) await player.gain(gains, "gain2");
 					if (
 						game.getGlobalHistory("everything", evt => {
-							return evt.name == "die" && evt.getParent(6).name == "fakezhouting" && evt.getParent(6).player == player;
+							return evt.name == "die" && evt.getParent(6) == event && evt.getParent(6).player == player;
 						}).length
 					)
 						player.restoreSkill("fakezhouting");


### PR DESCRIPTION
### PR受影响的平台
所有平台
### 诱因和背景
bug反馈
### PR描述
1.使用@AstralBarrage的`logAudio`和昨日提的`logSkill`修改，继续修改部分效果不同触发配音不同的技能的写法
2.修复OL陆凯【玄注】可印多目标锦囊牌的bug
3.修复族王浑【抚循】使用的基本牌有次数限制的bug
4.修复国战晋司马懿【骤霆】刷新bug
5.修复装备【天机图】后只能弃置【天机图】的bug
### PR测试
能跑
### 扩展适配
无
### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 我没有把该PR提交到`master`分支
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
