### PR TITLE
轮次开始判定改onround垃圾桶；司马炎bugfix

### DIFF
--- a/character/offline/skill.js
+++ b/character/offline/skill.js
@@ -40,10 +40,16 @@ const skills = {
 				.forResult();
 		},
 		async content(event, trigger, player) {
+			if (!lib.onround.includes(lib.skill.jdfengtu.onRound)) {
+				lib.onround.push(lib.skill.jdfengtu.onRound);
+			}
 			const target = event.targets[0];
 			await target.loseMaxHp();
 			target.addSkill("jdfengtu_phase");
 			target.markAuto("jdfengtu_phase", [trigger.player]);
+		},
+		onRound(event) {
+			return (event.relatedEvent || event.getParent(2)).name != "jdfengtu_phase";
 		},
 		check(source, player) {
 			const players = game.players
@@ -80,7 +86,7 @@ const skills = {
 		trigger: { global: "phaseZhunbeiBegin" },
 		filter(event, player) {
 			const storage = player.storage.jdjuqi;
-			return event.player == player || event.player.countCards("he", card => (get.color(card, event.player) == storage ? "red" : "black"));
+			return event.player == player || event.player.countCards("h", card => _status.connectMode || (get.color(card, event.player) == storage ? "red" : "black"));
 		},
 		async cost(event, trigger, player) {
 			const target = trigger.player;
@@ -89,7 +95,7 @@ const skills = {
 			} else {
 				const color = player.storage.jdjuqi ? "red" : "black";
 				event.result = await target
-					.chooseCard((card, player) => get.color(card, player) == color, "he", `举棋：你可以交给${get.translation(player)}一张${get.translation(color)}牌`)
+					.chooseCard((card, player) => get.color(card, player) == color, `举棋：你可以交给${get.translation(player)}一张${get.translation(color)}手牌`)
 					.set("ai", card => {
 						const player = get.player(),
 							target = get.event("target");
@@ -102,8 +108,8 @@ const skills = {
 		},
 		async content(event, trigger, player) {
 			const target = trigger.player;
-			if (trigger.player == player) {
-				player.changeZhuanhuanji(event.name);
+			player.changeZhuanhuanji(event.name);
+			if (target == player) {
 				if (player.storage[event.name]) await player.draw(3);
 				else player.addTempSkill(event.name + "_effect");
 			} else {

--- a/character/xianding/skill.js
+++ b/character/xianding/skill.js
@@ -10202,6 +10202,7 @@ const skills = {
 							current.getStat().isSkipped = true;
 						});
 					var evt = player.insertPhase();
+					evt.relatedEvent = trigger.getParent(2);
 					if (trigger.skill) evt.skill = trigger.skill;
 					else delete evt.skill;
 					game.broadcastAll(function (player) {

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -3228,7 +3228,7 @@ export const Content = {
 		}
 		//规则集中的“回合开始后①”，更新游戏轮数，触发“一轮游戏开始时”
 		var isRound = false;
-		if (!event.skill) {
+		if (lib.onround.every(i => i(event, player))) {
 			isRound = _status.roundSkipped;
 			if (_status.isRoundFilter) {
 				isRound = _status.isRoundFilter(event, player);

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -107,6 +107,11 @@ export class Library {
 	onresize = [];
 	onphase = [];
 	onwash = [];
+	onround = [
+		function roundSkillCheck(event) {
+			return !event.skill;
+		},
+	];
 	onover = [];
 	ondb = [];
 	ondb2 = [];
@@ -324,28 +329,28 @@ export class Library {
 														return ai - get.value(cardx);
 													} else if (get.attitude(player, source) <= 0) return 0;
 													return 5 - get.value(cardx);
-												},
+											  },
 								});
 								if (!game.online) return;
 								_status.event._resultid = id;
 								game.resume();
 							};
-							("step 1");
+							"step 1";
 							var type = get.type2(card);
 							event.list = game.filterPlayer(current => current != player && current.countCards("h") && (_status.connectMode || current.hasCard(cardx => get.type2(cardx) == type, "h"))).sortBySeat(_status.currentPhase || player);
 							event.id = get.id();
-							("step 2");
+							"step 2";
 							if (!event.list.length) event.finish();
 							else if (_status.connectMode && (event.list[0].isOnline() || event.list[0] == game.me)) event.goto(4);
 							else event.send((event.current = event.list.shift()), event.card, player, trigger.targets, event.id, trigger.parent.id, trigger.yingbianZhuzhanAI);
-							("step 3");
+							"step 3";
 							if (result.bool) {
 								event.zhuzhanresult = event.current;
 								event.zhuzhanresult2 = result;
 								if (event.current != game.me) game.delayx();
 								event.goto(8);
 							} else event.goto(2);
-							("step 4");
+							"step 4";
 							var id = event.id,
 								sendback = (result, player) => {
 									if (result && result.id == id && !event.zhuzhanresult && result.bool) {
@@ -382,16 +387,16 @@ export class Library {
 									if (value != player) value.showTimer();
 								});
 							event.withol = withol;
-							("step 5");
+							"step 5";
 							if (!result || !result.bool || event.zhuzhanresult) return;
 							game.broadcast("cancel", event.id);
 							event.zhuzhanresult = game.me;
 							event.zhuzhanresult2 = result;
-							("step 6");
+							"step 6";
 							if (event.withol && !event.resultOL) game.pause();
-							("step 7");
+							"step 7";
 							game.players.forEach(value => value.hideTimer());
-							("step 8");
+							"step 8";
 							if (event.zhuzhanresult) {
 								var target = event.zhuzhanresult;
 								target.line(player, "green");
@@ -8109,7 +8114,7 @@ export class Library {
 		}
 	}
 	/**
-	 * @param {Function} fn 
+	 * @param {Function} fn
 	 */
 	genAsync(fn) {
 		return gnc.of(fn);
@@ -8120,7 +8125,7 @@ export class Library {
 					for (const content of item) {
 						yield content;
 					}
-				})()
+			  })()
 			: Promise.resolve(item);
 	}
 	gnc = {
@@ -10709,7 +10714,7 @@ export class Library {
 								storage: {
 									stratagem_buffed: 1,
 								},
-							})
+						  })
 						: new lib.element.VCard();
 				}
 				return null;
@@ -11109,7 +11114,7 @@ export class Library {
 			},
 			filterx: function (skill, player) {
 				const zhengsus = player.storage[skill];
-				if(!zhengsus || !zhengsus.length) return false;
+				if (!zhengsus || !zhengsus.length) return false;
 				return zhengsus.some(zhengsu => player.storage[zhengsu]);
 			},
 			content: function () {
@@ -11878,7 +11883,7 @@ export class Library {
 				"step 0";
 				event.dying = trigger.player;
 				if (!event.acted) event.acted = [];
-				("step 1");
+				"step 1";
 				if (trigger.player.isDead()) {
 					event.finish();
 					return;
@@ -11933,7 +11938,7 @@ export class Library {
 				} else {
 					event._result = { bool: false };
 				}
-				("step 2");
+				"step 2";
 				if (result.bool) {
 					var player = trigger.player;
 					if (player.hp <= 0 && !trigger.nodying && !player.nodying && player.isAlive() && !player.isOut() && !player.removed) event.goto(0);
@@ -12023,7 +12028,7 @@ export class Library {
 			content: function () {
 				"step 0";
 				event.logvid = trigger.getLogv();
-				("step 1");
+				"step 1";
 				event.targets = game.filterPlayer(function (current) {
 					return current != event.player && current.isLinked();
 				});
@@ -12033,7 +12038,7 @@ export class Library {
 				event._args = [trigger.num, trigger.nature, trigger.cards, trigger.card];
 				if (trigger.source) event._args.push(trigger.source);
 				else event._args.push("nosource");
-				("step 2");
+				"step 2";
 				if (event.targets.length) {
 					var target = event.targets.shift();
 					if (target.isLinked()) target.damage.apply(target, event._args.slice(0));
@@ -13023,7 +13028,7 @@ export class Library {
 
 						player.directgain(info.handcards);
 						lib.playerOL[i] = player;
-						if(info.vcardsMap){
+						if (info.vcardsMap) {
 							for (var i = 0; i < info.vcardsMap.equips.length; i++) {
 								player.addVirtualEquip(info.vcardsMap.equips[i], info.vcardsMap.equips[i].cards);
 							}


### PR DESCRIPTION
### PR受影响的平台
所有平台
### 诱因和背景
越来越多的古怪回合执行导致目前的轮次判定已不够用
修复@xizifu的司马炎bug（牢戏看到了记得帮我打下次的排位武将[憋笑]）
### PR描述
添加`lib.onround`（数组），使用方法通lib.onwash，轮次开始的判定前提须让lib.onround里面的所有判定值均为真才执行
修复司马炎【举棋】他人对自己发动技能不变更技能形态的bug
### PR测试
测了，暂未发现问题
### 扩展适配
无
### 检查清单
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 我没有把该PR提交到`master`分支
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
