### PR TITLE
使打包脚本不会打包非官方扩展

### DIFF
--- a/game/generateChanged.js
+++ b/game/generateChanged.js
@@ -17,7 +17,7 @@ function formatDate(date = new Date()) {
 	return `${year}${month}${day}`;
 }
 
-function collectFilesSync(paths, filter = () => true) {
+function collectFilesSync(paths, filter = (_path) => true) {
 	const fileList = [];
 
 	function collectFilesInDirectory(directoryPath) {
@@ -65,7 +65,7 @@ function collectFilesSync(paths, filter = () => true) {
 
 function compareFilesWithCommit(commitHash = "HEAD") {
 	console.log(`exec git diff --name-only ${commitHash}`);
-	exec(`git diff --name-only ${commitHash}`, async (error, stdout) => {
+	exec(`git diff --name-only ${commitHash}`, (error, stdout) => {
 		if (error) {
 			console.error(`exec error: ${error}`);
 			return;
@@ -79,7 +79,7 @@ function compareFilesWithCommit(commitHash = "HEAD") {
 
 		});
 
-		const nonameExtensions = ["boss", "cardpile", "coin", "wuxing"].map(name => joinRootPath("extension", name));
+		const nonameExtensions = ["boss", "cardpile", "coin", "wuxing"].map(name => joinRootPath(`extension/${name}`));
 
 		filesArray.push(...collectFilesSync([joinRootPath("card"), joinRootPath("character"), joinRootPath("game"), joinRootPath("layout"), joinRootPath("mode"), joinRootPath("noname"), joinRootPath("theme"), joinRootPath("index.html"), joinRootPath("LICENSE"), joinRootPath("noname-compatible.js"), joinRootPath("noname.js"), joinRootPath("README.md"), joinRootPath("service-worker.js"), joinRootPath("tsconfig.json")]));
 
@@ -107,7 +107,8 @@ function compareFilesWithCommit(commitHash = "HEAD") {
 			}
 		});
 
-		const result = await zip.generateAsync({ type: "nodebuffer" });
+		// noinspection JSDeprecatedSymbols
+		const result = zip.generate({ type: "nodebuffer" });
 		fs.writeFileSync(path.join(__dirname, `测试包-${formatDate()}.zip`), result);
 	});
 }

--- a/game/generateChanged.js
+++ b/game/generateChanged.js
@@ -63,7 +63,7 @@ function collectFilesSync(paths) {
 
 function compareFilesWithCommit(commitHash = "HEAD") {
 	console.log(`exec git diff --name-only ${commitHash}`);
-	exec(`git diff --name-only ${commitHash}`, (error, stdout, stderr) => {
+	exec(`git diff --name-only ${commitHash}`, async (error, stdout) => {
 		if (error) {
 			console.error(`exec error: ${error}`);
 			return;
@@ -73,10 +73,8 @@ function compareFilesWithCommit(commitHash = "HEAD") {
 
 		let filesArray = stdout.split("\n").filter(v => {
 			const filePath = path.join(__dirname, "../", v);
-			if (fs.existsSync(filePath) && fs.lstatSync(filePath).isFile()) {
-				return true;
-			}
-			return false;
+			return fs.existsSync(filePath) && fs.lstatSync(filePath).isFile();
+
 		});
 
 		filesArray.push(...collectFilesSync([joinRootPath("card"), joinRootPath("character"), joinRootPath("extension"), joinRootPath("game"), joinRootPath("layout"), joinRootPath("mode"), joinRootPath("noname"), joinRootPath("theme"), joinRootPath("index.html"), joinRootPath("LICENSE"), joinRootPath("noname-compatible.js"), joinRootPath("noname.js"), joinRootPath("README.md"), joinRootPath("service-worker.js"), joinRootPath("tsconfig.json")]));
@@ -102,7 +100,7 @@ function compareFilesWithCommit(commitHash = "HEAD") {
 			}
 		});
 
-		const result = zip.generate({ type: "nodebuffer" });
+		const result = await zip.generateAsync({ type: "nodebuffer" });
 		fs.writeFileSync(path.join(__dirname, `测试包-${formatDate()}.zip`), result);
 	});
 }

--- a/game/generateChanged.js
+++ b/game/generateChanged.js
@@ -17,7 +17,7 @@ function formatDate(date = new Date()) {
 	return `${year}${month}${day}`;
 }
 
-function collectFilesSync(paths) {
+function collectFilesSync(paths, filter = () => true) {
 	const fileList = [];
 
 	function collectFilesInDirectory(directoryPath) {
@@ -28,6 +28,8 @@ function collectFilesSync(paths) {
 
 			for (const entry of entries) {
 				const fullPath = path.join(directoryPath, entry.name);
+				// 添加过滤函数
+				if (!filter(fullPath)) continue;
 
 				if (entry.isDirectory()) {
 					// 如果是目录，则递归进入
@@ -77,7 +79,12 @@ function compareFilesWithCommit(commitHash = "HEAD") {
 
 		});
 
-		filesArray.push(...collectFilesSync([joinRootPath("card"), joinRootPath("character"), joinRootPath("extension"), joinRootPath("game"), joinRootPath("layout"), joinRootPath("mode"), joinRootPath("noname"), joinRootPath("theme"), joinRootPath("index.html"), joinRootPath("LICENSE"), joinRootPath("noname-compatible.js"), joinRootPath("noname.js"), joinRootPath("README.md"), joinRootPath("service-worker.js"), joinRootPath("tsconfig.json")]));
+		const nonameExtensions = ["boss", "cardpile", "coin", "wuxing"].map(name => joinRootPath("extension", name));
+
+		filesArray.push(...collectFilesSync([joinRootPath("card"), joinRootPath("character"), joinRootPath("game"), joinRootPath("layout"), joinRootPath("mode"), joinRootPath("noname"), joinRootPath("theme"), joinRootPath("index.html"), joinRootPath("LICENSE"), joinRootPath("noname-compatible.js"), joinRootPath("noname.js"), joinRootPath("README.md"), joinRootPath("service-worker.js"), joinRootPath("tsconfig.json")]));
+
+		// 单独处理extension目录，使扩展不会被打包
+		filesArray.push(...collectFilesSync([joinRootPath("extension")], path => nonameExtensions.some(extPath => path.startsWith(extPath))));
 
 		filesArray = [...new Set(filesArray.map(v => v.replace(/\\/g, "/")))].sort((a, b) => {
 			if (a > b) return 1;


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
由于一些测试需求，故一般会在项目仓库中放一些扩展，这些扩展并不期望被打包，然而打包脚本依然会将这些扩展打包进整合包中

### PR描述
<!-- 详细描述您的更改 -->
对遍历`extension`目录的地方进行筛选，只考虑遍历无名杀自带的扩展

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->

经过测试，可以看到`extension`目录下存在除自带扩展以外的扩展，而打包的包并未包含非自带扩展

![图片](https://github.com/user-attachments/assets/58b4c1ca-b6fd-4a2a-b52c-0f30da54a3b4)


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需适配

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 我没有把该PR提交到`master`分支
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
