### PR TITLE
修复判定牌无法移动的情况 (#1679)

### DIFF
--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -6681,7 +6681,7 @@ export const Content = {
 							return event.filter(card) && targets[1].canAddJudge(card);
 					  });
 			if (es.length) {
-				dialogArgs.push(`<div class="text center">判定区</div>`);
+				dialogArgs.push(`<div class="text center">装备区</div>`);
 				dialogArgs.push([es, "vcard"]);
 			}
 			if (js.length) {

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -6737,7 +6737,7 @@ export const Content = {
 				event.targets[1].equip(link);
 			} else {
 				if (!link.cards?.length) event.targets[0].removeVirtualJudge(link);
-				event.targets[1].addJudge(link);
+				event.targets[1].addJudge(link, link?.cards);
 			}
 			if (link.cards?.length) event.targets[0].$give(link.cards, event.targets[1], false);
 			game.log(event.targets[0], "的", link, "被移动给了", event.targets[1]);


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有平台

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
由 #1679 提出，使用`moveCard`移动判定牌会出现有动画无逻辑的情况，该情况由于`moveCard`只将判定牌的`card`传给了`addJudge`，然而`addJudge`因为转向`addVirtualJudge`需要将实体牌也传入进去，所以本质上相当于移动了国王的新牌，故无事发生；由于动画重点在于vcard而非cards，故动画无明显问题

### PR描述
<!-- 详细描述您的更改 -->
在`moveCard`中，将`card.cards`传入给`addJudge`

顺带修了 *指装备区为判定区*

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->

重复杨彪【让节】移动判定区的牌

![图片](https://github.com/user-attachments/assets/7baefb0f-c5eb-4904-81d5-4d43a0972a1a)

可以看到判定区的牌被正常移动

![图片](https://github.com/user-attachments/assets/5ab1fac1-220d-4545-ae79-ffee57c72ca2)


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需适配，除非改了`moveCard`

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 我没有把该PR提交到`master`分支
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
