### PR TITLE
转化装备多转一修复，提前准备转化判定多转一

### DIFF
--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -3715,11 +3715,11 @@ export class Get extends GetCompatible {
 				}
 			}
 			if (!simple || get.is.phoneLayout()) {
-				var es = node.getCards("e");
+				var es = node.getVCards("e");
 				for (var i = 0; i < es.length; i++) {
-					var cardinfo = lib.card[es[i].name];
-					if (cardinfo && cardinfo.cardPrompt) uiintro.add('<div><div class="skill">' + es[i].outerHTML + "</div><div>" + cardinfo.cardPrompt(es[i]) + "</div></div>");
-					else uiintro.add('<div><div class="skill">' + es[i].outerHTML + "</div><div>" + lib.translate[es[i].name + "_info"] + "</div></div>");
+					const special = es[i].cards?.find(j => lib.card[j.name]?.cardPrompt);
+					var str = special ? lib.card[special.name].cardPrompt(special) : lib.translate[es[i].name + "_info"];
+					uiintro.add('<div><div class="skill">' + game.createCard(es[i]).outerHTML + "</div><div>" + str + "</div></div>");
 					uiintro.content.lastChild.querySelector(".skill>.card").style.transform = "";
 
 					if (lib.translate[es[i].name + "_append"]) {

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -11039,79 +11039,73 @@ export class Player extends HTMLDivElement {
 	}
 	$addVirtualEquip(card, cards) {
 		const player = this;
-		if (cards?.length) {
-			const beforeCards = [];
-			const disableEquips = Array.from(player.node.equips.childNodes).filter(cardx => {
-				return cardx.name?.startsWith("feichu_");
-			});
-			if (disableEquips.length) {
-				for (const cardx of disableEquips) player.node.equips.removeChild(cardx);
+		let beforeCards = [];
+		const disableEquips = Array.from(player.node.equips.childNodes).filter(cardx => {
+			return cardx.name?.startsWith("feichu_");
+		});
+		if (disableEquips.length) {
+			for (const cardx of disableEquips) player.node.equips.removeChild(cardx);
+		}
+		const isViewAsCard = cards.length !== 1 || cards[0].name !== card.name,
+			info = get.info(card, false);
+		let cardShownName = get.translation(card.name);
+		if (info.subtype === "equip3") {
+			cardShownName += "+";
+		} else if (info.subtype === "equip4") {
+			cardShownName += "-";
+		}
+		const cardx = isViewAsCard ? game.createCard(card) : cards[0];
+		cardx.fix();
+		cardx.card = card;
+		cardx.style.transform = "";
+		cardx.classList.remove("drawinghidden");
+		delete cardx._transform;
+		const suit = get.translation(cardx.suit),
+			number = get.strNumber(cardx.number);
+		if (isViewAsCard) {
+			cardx.cards = cards || [];
+			cardx.viewAs = card.name;
+			cardx.node.name2.innerHTML = `${suit}${number} [${cardShownName}]`;
+			cardx.classList.add("fakeequip");
+		} else {
+			delete cardx.viewAs;
+			cardx.node.name2.innerHTML = `${suit}${number} ${cardShownName}`;
+			cardx.classList.remove("fakeequip");
+		}
+		this.vcardsMap?.equips.some(card2 => {
+			if (card2 === card) return true;
+			beforeCards.add(card);
+		});
+		let equipped = false;
+		for (let i = 0; i < player.node.equips.childNodes.length; i++) {
+			if (beforeCards.length === 0) {
+				equipped = true;
+				player.node.equips.insertBefore(cardx, player.node.equips.childNodes[i]);
+				break;
+			} else {
+				beforeCards.remove(player.node.equips.childNodes[i]);
 			}
-			const isViewAsCard = cards.length !== 1 || cards[0].name !== card.name,
-				info = get.info(card, false);
-			let cardShownName = get.translation(card.name);
-			if (info.subtype === "equip3") {
-				cardShownName += "+";
-			} else if (info.subtype === "equip4") {
-				cardShownName += "-";
-			}
-			cards.forEach(cardx => {
-				cardx.fix();
-				cardx.style.transform = "";
-				cardx.classList.remove("drawinghidden");
-				delete cardx._transform;
-				const suit = get.translation(cardx.suit),
-					number = get.strNumber(cardx.number);
-				if (isViewAsCard) {
-					cardx.viewAs = card.name;
-					cardx.node.name2.innerHTML = `${suit}${number} [${cardShownName}]`;
-					cardx.classList.add("fakeequip");
-				} else {
-					delete cardx.viewAs;
-					cardx.node.name2.innerHTML = `${suit}${number} ${cardShownName}`;
-					cardx.classList.remove("fakeequip");
-				}
-			});
-			this.vcardsMap?.equips.some(card2 => {
-				if (card2 === card) return true;
-				beforeCards.addArray(card2.cards ?? []);
-			});
-			let equipped = false;
-			for (let i = 0; i < player.node.equips.childNodes.length; i++) {
-				if (beforeCards.length === 0) {
-					equipped = true;
-					cards.forEach(card => {
-						player.node.equips.insertBefore(card, player.node.equips.childNodes[i]);
-					});
-					break;
-				} else {
-					beforeCards.remove(player.node.equips.childNodes[i]);
-				}
-			}
-			if (equipped === false) {
-				cards.reverse();
-				cards.forEach(card => {
-					player.node.equips.appendChild(card);
-				});
-				if (_status.discarded) _status.discarded.removeArray(cards);
-			}
-			if (disableEquips.length) {
-				for (const cardx of disableEquips) {
-					const equipNum = get.equipNum(cardx);
-					let equipped = false;
-					for (let j = 0; j < player.node.equips.childNodes.length; j++) {
-						const card2 = player.vcardsMap.equips.find(i => i.cards?.includes(player.node.equips.childNodes[j]));
-						const card3 = card2 ? card2 : player.node.equips.childNodes[j];
-						if (get.equipNum(card3) >= equipNum) {
-							player.node.equips.insertBefore(cardx, player.node.equips.childNodes[j]);
-							equipped = true;
-							break;
-						}
+		}
+		if (equipped === false) {
+			player.node.equips.appendChild(cardx);
+			if (cards?.length && _status.discarded) _status.discarded.removeArray(cards);
+		}
+		if (disableEquips.length) {
+			for (const cardx of disableEquips) {
+				const equipNum = get.equipNum(cardx);
+				let equipped = false;
+				for (let j = 0; j < player.node.equips.childNodes.length; j++) {
+					const card2 = player.vcardsMap.equips.find(i => i.cards?.includes(player.node.equips.childNodes[j]));
+					const card3 = card2 ? card2 : player.node.equips.childNodes[j];
+					if (get.equipNum(card3) >= equipNum) {
+						player.node.equips.insertBefore(cardx, player.node.equips.childNodes[j]);
+						equipped = true;
+						break;
 					}
-					if (!equipped) {
-						player.node.equips.appendChild(cardx);
-						if (_status.discarded) _status.discarded.remove(cardx);
-					}
+				}
+				if (!equipped) {
+					player.node.equips.appendChild(cardx);
+					if (_status.discarded) _status.discarded.remove(cardx);
 				}
 			}
 		}


### PR DESCRIPTION
### PR受影响的平台
无
### 诱因和背景
尝试解决转化装备牌的非1转1遗留问题
修复武将信息页仍然获取`Player.getCards('e')`而非`Player.getVCards('e')`的bug
### PR描述
非1转1装备牌均同1转1显示为一张，`Player.getCards('e')`受此影响，获取的牌也均为转化后的牌（类别为`card`而非`vcard`）
非1转1装备牌作为一张牌的整体，仅能共同失去
修复武将信息页仍然获取`Player.getCards('e')`而非`Player.getVCards('e')`的bug，并进行了上述适配
### PR测试
测了大部分拆顺失的情况，**目前**一切正常
### 扩展适配
修改了'lib.element.content.lose'/'lib.element.content.gain'/'lib.element.player.$addVirtualEquip'的UI类扩展
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
