### PR TITLE
非1转1装备区继续bugfix

### DIFF
--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -23,12 +23,12 @@ export class Get extends GetCompatible {
 	 * @param { Card[]|VCard[] } cards
 	 * @returns { any[] }
 	 */
-	skillsFromEquips(cards){
+	skillsFromEquips(cards) {
 		return cards.reduce((skills, card) => {
 			const info = get.info(card, false);
 			if (info.skills) skills.addArray(info.skills);
 			return skills;
-		}, [])
+		}, []);
 	}
 	/**
 	 * 将一个传统格式的character转化为Character对象格式
@@ -866,7 +866,7 @@ export class Get extends GetCompatible {
 		let indent = "";
 		for (let i = 0; i < level; i++) indent += "    ";
 		try {
-			if (get.objtype(obj) === "object"/*  || obj instanceof lib.element.GameEvent */) {
+			if (get.objtype(obj) === "object" /*  || obj instanceof lib.element.GameEvent */) {
 				const isMethod = (/** @type {string} */ key) => {
 					const value = obj[key];
 					if (!(typeof value === "function")) return false;
@@ -880,7 +880,7 @@ export class Get extends GetCompatible {
 						reg = new RegExp(`async\\s*${key}[\\s\\S]*?\\(`);
 					} else {
 						// content(){}
-						reg = new RegExp(`${key}[\\s\\S]*?\\(`)
+						reg = new RegExp(`${key}[\\s\\S]*?\\(`);
 					}
 					return reg.exec(value)?.index === 0;
 				};
@@ -894,7 +894,6 @@ export class Get extends GetCompatible {
 				}
 				str += indent + "}";
 				return str;
-
 			} else if (typeof obj === "function") {
 				let str = obj.toString().replace(/\t/g, "    ");
 				let lastLine = str.slice(str.lastIndexOf("\n"));
@@ -906,7 +905,7 @@ export class Get extends GetCompatible {
 				return str;
 			} else if (Array.isArray(obj)) {
 				const rand = parseInt(get.id());
-				obj = obj.map(i => i === Infinity ? rand : i === -Infinity ? -rand : i);
+				obj = obj.map(i => (i === Infinity ? rand : i === -Infinity ? -rand : i));
 				return JSON.stringify(obj).replace(new RegExp(rand.toString(), "g"), "Infinity");
 			} else {
 				if (obj === Infinity) return "Infinity";
@@ -955,11 +954,11 @@ export class Get extends GetCompatible {
 		const target = constructor
 			? Array.isArray(obj) || obj instanceof Map || obj instanceof Set || constructor === Object
 				? // @ts-ignore
-					new constructor()
+				  new constructor()
 				: constructor.name in window && /\[native code\]/.test(constructor.toString())
-					? // @ts-ignore
-						new constructor(obj)
-					: obj
+				? // @ts-ignore
+				  new constructor(obj)
+				: obj
 			: Object.create(null);
 		if (target === obj) return target;
 
@@ -1509,14 +1508,14 @@ export class Get extends GetCompatible {
 			const key = entry[0];
 			// @ts-ignore
 			if (key === "cards") stringifying[key] = get.cardsInfo(entry[1]);
-			else if (entry[1] !== void 0) stringifying[key] = JSON.stringify(entry[1])
+			else if (entry[1] !== void 0) stringifying[key] = JSON.stringify(entry[1]);
 			return stringifying;
-		}, {})
+		}, {});
 	}
 	vcardsInfo(cards = []) {
 		return Array.from(cards).map(get.vcardInfo);
 	}
-	infoVCard(card){
+	infoVCard(card) {
 		// @ts-ignore
 		if (!lib.vcardOL) lib.vcardOL = {};
 		const datas = Object.entries(card).reduce((vcard, entry) => {
@@ -1537,14 +1536,13 @@ export class Get extends GetCompatible {
 			Object.keys(vcard).forEach(entry => {
 				delete vcard[entry];
 			});
-			Object.keys(datas).forEach((key) => {
+			Object.keys(datas).forEach(key => {
 				const value = datas[key];
 				if (Array.isArray(value)) vcard[key] = value.slice();
 				vcard[key] = value;
 			});
 			return vcard;
-		}
-		else {
+		} else {
 			const card = new lib.element.VCard(datas);
 			// @ts-ignore
 			lib.vcardOL[vid] = card;
@@ -1838,7 +1836,7 @@ export class Get extends GetCompatible {
 						} else if (!lib.element.GameEvent.prototype[key] && key != "content" && get.itemtype(entry[1]) != "event") stringifying[key] = get.stringifiedResult(entry[1], null, false);
 						return stringifying;
 					}, {})
-				)}`
+			  )}`
 			: "";
 	}
 	/**
@@ -1857,11 +1855,16 @@ export class Get extends GetCompatible {
 		return evt || item;
 	}
 	vcardInfoOL(item) {
-		return "_noname_vcard:" + JSON.stringify(Object.entries(item).reduce((stringifying, entry) => {
-			const key = entry[0];
-			stringifying[key] = get.stringifiedResult(entry[1]);
-			return stringifying;
-		}, {}));
+		return (
+			"_noname_vcard:" +
+			JSON.stringify(
+				Object.entries(item).reduce((stringifying, entry) => {
+					const key = entry[0];
+					stringifying[key] = get.stringifiedResult(entry[1]);
+					return stringifying;
+				}, {})
+			)
+		);
 	}
 	vcardsInfoOL(cards) {
 		return Array.from(cards || []).map(get.vcardInfoOL);
@@ -1874,7 +1877,7 @@ export class Get extends GetCompatible {
 			vcard[key] = get.parsedResult(entry[1]);
 			return vcard;
 		}, {});
-		
+
 		const vid = datas.vcardID;
 		// @ts-ignore
 		if (!vid || !lib.vcardOL) return new lib.element.VCard(datas);
@@ -1886,14 +1889,13 @@ export class Get extends GetCompatible {
 			Object.keys(vcard).forEach(entry => {
 				delete vcard[entry];
 			});
-			Object.keys(datas).forEach((key) => {
+			Object.keys(datas).forEach(key => {
 				const value = datas[key];
 				if (Array.isArray(value)) vcard[key] = value.slice();
 				vcard[key] = value;
 			});
 			return vcard;
-		}
-		else {
+		} else {
 			const card = new lib.element.VCard(datas);
 			// @ts-ignore
 			lib.vcardOL[vid] = card;
@@ -2113,7 +2115,7 @@ export class Get extends GetCompatible {
 	 * @overload
 	 * @param { Card } obj
 	 * @returns { 'card' }
-	 * 
+	 *
 	 * @overload
 	 * @param { VCard } obj
 	 * @returns { 'vcard' }
@@ -2172,7 +2174,7 @@ export class Get extends GetCompatible {
 		if (lib.experimental.symbol.itemType in obj) return obj[lib.experimental.symbol.itemType];
 	}
 	equipNum(card) {
-		const subtypes = get.subtypes(card)
+		const subtypes = get.subtypes(card);
 		if (subtypes.length) {
 			return parseInt(subtypes[0].slice(5));
 		}
@@ -3715,9 +3717,9 @@ export class Get extends GetCompatible {
 				}
 			}
 			if (!simple || get.is.phoneLayout()) {
-				var es = node.getVCards("e");
+				var es = node.getCards("e");
 				for (var i = 0; i < es.length; i++) {
-					const special = es[i].cards?.find(j => lib.card[j.name]?.cardPrompt);
+					const special = [es[i]].concat(es[i].cards || []).find(j => j.name == es[i].name && lib.card[j.name]?.cardPrompt);
 					var str = special ? lib.card[special.name].cardPrompt(special) : lib.translate[es[i].name + "_info"];
 					uiintro.add('<div><div class="skill">' + game.createCard(es[i]).outerHTML + "</div><div>" + str + "</div></div>");
 					uiintro.content.lastChild.querySelector(".skill>.card").style.transform = "";
@@ -4035,12 +4037,13 @@ export class Get extends GetCompatible {
 			var cardPosition = get.position(node);
 			if ((cardPosition === "e" || cardPosition === "j") && node.viewAs && node.viewAs != name) {
 				uiintro.add(get.translation(node.viewAs));
-				var cardInfo = lib.card[node.viewAs], showCardIntro = true;
+				var cardInfo = lib.card[node.viewAs],
+					showCardIntro = true;
 				var cardOwner = get.owner(node);
 				if (cardInfo.blankCard) {
 					if (cardOwner && !cardOwner.isUnderControl(true)) showCardIntro = false;
 				}
-				if(cardOwner){
+				if (cardOwner) {
 					var sourceVCard = cardOwner.getVCards(cardPosition).find(card => card.cards?.includes(node));
 					if (showCardIntro && sourceVCard) uiintro.add('<div class="text center">（' + get.translation(get.translation(sourceVCard.cards)) + "）</div>");
 				}
@@ -4138,9 +4141,17 @@ export class Get extends GetCompatible {
 						} else if (lib.card[name] && lib.card[name].type && lib.translate[lib.card[name].type]) {
 							typeinfo += get.translation(lib.card[name].type) + "牌";
 						}
-						let vcard = get.owner(node)?.getVCards(get.position(node))?.find(card => card.cards?.includes(node));
+						let vcard = get
+							.owner(node)
+							?.getVCards(get.position(node))
+							?.find(card => card.cards?.includes(node));
 						if (get.subtypes(vcard || node, get.owner(node))?.length) {
-							typeinfo += "-" + get.subtypes(vcard || node, get.owner(node)).map(type => get.translation(type)).join("/");
+							typeinfo +=
+								"-" +
+								get
+									.subtypes(vcard || node, get.owner(node))
+									.map(type => get.translation(type))
+									.join("/");
 						}
 						if (typeinfo) {
 							uiintro.add('<div class="text center">' + typeinfo + "</div>");
@@ -4744,14 +4755,14 @@ export class Get extends GetCompatible {
 		let card = name;
 		if (typeof name === "string") {
 			card = { name };
-		}
-		else {
+		} else {
 			const itemtype = get.itemtype(card);
 			if (itemtype !== "card" && itemtype !== "vcard") {
 				card = get.card();
 			}
 		}
-		let value1 = get.equipValue(card, target), value2 = 0;
+		let value1 = get.equipValue(card, target),
+			value2 = 0;
 		if (!target.canEquip(card)) {
 			if (!target.canEquip(card, true)) return 0;
 			let current = target.getVEquip(card);

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -3721,7 +3721,7 @@ export class Get extends GetCompatible {
 				for (var i = 0; i < es.length; i++) {
 					const special = [es[i]].concat(es[i].cards || []).find(j => j.name == es[i].name && lib.card[j.name]?.cardPrompt);
 					var str = special ? lib.card[special.name].cardPrompt(special) : lib.translate[es[i].name + "_info"];
-					uiintro.add('<div><div class="skill">' + game.createCard(es[i]).outerHTML + "</div><div>" + str + "</div></div>");
+					uiintro.add('<div><div class="skill">' + es[i].outerHTML + "</div><div>" + str + "</div></div>");
 					uiintro.content.lastChild.querySelector(".skill>.card").style.transform = "";
 
 					if (lib.translate[es[i].name + "_append"]) {

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -8518,7 +8518,7 @@ export const Content = {
 		}
 		"step 2";
 		if (num < cards.length) {
-			if (event.es.includes(cards[num]) || card.cards?.some(i => event.es.includes(i))) {
+			if (event.es.includes(cards[num]) || cards[num].cards?.some(i => event.es.includes(i))) {
 				event.loseEquip = true;
 				const VEquip = cards[num].card;
 				if (VEquip) {

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -8370,10 +8370,12 @@ export const Content = {
 			} else if (cards[i].parentNode) {
 				if (cards[i].parentNode.classList.contains("equips")) {
 					cards[i].original = "e";
-					es.push(cards[i]);
 					let loseCards = cards[i].cards ? cards[i].cards : [cards[i]];
 					cardx.addArray(loseCards);
-					event.vcard_map.set(loseCards, cards[i].card || get.autoViewAs(cards[i], void 0, false));
+					loseCards.forEach(cardi => {
+						es.push(cardi);
+						event.vcard_map.set(cardi, cards[i].card || get.autoViewAs(cards[i], void 0, false));
+					});
 				} else if (cards[i].parentNode.classList.contains("judges")) {
 					cards[i].original = "j";
 					js.push(cards[i]);

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -8518,7 +8518,7 @@ export const Content = {
 		}
 		"step 2";
 		if (num < cards.length) {
-			if (event.es.includes(cards[num])) {
+			if (event.es.includes(cards[num]) || card.cards?.some(i => event.es.includes(i))) {
 				event.loseEquip = true;
 				const VEquip = cards[num].card;
 				if (VEquip) {
@@ -8574,6 +8574,7 @@ export const Content = {
 		event.num++;
 		event.goto(2);
 		"step 4";
+		event.cards = cards.map(i => i.cards ? i.cards : [i]).flat();
 		if (event.toRenku) {
 			_status.renku.addArray(
 				cards.filter(function (card) {

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -11039,13 +11039,6 @@ export class Player extends HTMLDivElement {
 	}
 	$addVirtualEquip(card, cards) {
 		const player = this;
-		let beforeCards = [];
-		const disableEquips = Array.from(player.node.equips.childNodes).filter(cardx => {
-			return cardx.name?.startsWith("feichu_");
-		});
-		if (disableEquips.length) {
-			for (const cardx of disableEquips) player.node.equips.removeChild(cardx);
-		}
 		const isViewAsCard = cards.length !== 1 || cards[0].name !== card.name,
 			info = get.info(card, false);
 		let cardShownName = get.translation(card.name);
@@ -11057,6 +11050,7 @@ export class Player extends HTMLDivElement {
 		const cardx = isViewAsCard ? game.createCard(card) : cards[0];
 		cardx.fix();
 		cardx.card = card;
+		if (card.subtypes) cardx.subtypes = card.subtypes;
 		cardx.style.transform = "";
 		cardx.classList.remove("drawinghidden");
 		delete cardx._transform;
@@ -11072,42 +11066,19 @@ export class Player extends HTMLDivElement {
 			cardx.node.name2.innerHTML = `${suit}${number} ${cardShownName}`;
 			cardx.classList.remove("fakeequip");
 		}
-		this.vcardsMap?.equips.some(card2 => {
-			if (card2 === card) return true;
-			beforeCards.add(card);
-		});
-		let equipped = false;
-		for (let i = 0; i < player.node.equips.childNodes.length; i++) {
-			if (beforeCards.length === 0) {
-				equipped = true;
-				player.node.equips.insertBefore(cardx, player.node.equips.childNodes[i]);
-				break;
-			} else {
-				beforeCards.remove(player.node.equips.childNodes[i]);
+		let equipped = false, equipNum = get.equipNum(cardx);
+		if (player.node.equips.childNodes.length) {
+			for (let i = 0; i < player.node.equips.childNodes.length; i++) {
+				if (get.equipNum(player.node.equips.childNodes[i]) >= equipNum) {
+					equipped = true;
+					player.node.equips.insertBefore(cardx, player.node.equips.childNodes[i]);
+					break;
+				}
 			}
 		}
 		if (equipped === false) {
 			player.node.equips.appendChild(cardx);
 			if (cards?.length && _status.discarded) _status.discarded.removeArray(cards);
-		}
-		if (disableEquips.length) {
-			for (const cardx of disableEquips) {
-				const equipNum = get.equipNum(cardx);
-				let equipped = false;
-				for (let j = 0; j < player.node.equips.childNodes.length; j++) {
-					const card2 = player.vcardsMap.equips.find(i => i.cards?.includes(player.node.equips.childNodes[j]));
-					const card3 = card2 ? card2 : player.node.equips.childNodes[j];
-					if (get.equipNum(card3) >= equipNum) {
-						player.node.equips.insertBefore(cardx, player.node.equips.childNodes[j]);
-						equipped = true;
-						break;
-					}
-				}
-				if (!equipped) {
-					player.node.equips.appendChild(cardx);
-					if (_status.discarded) _status.discarded.remove(cardx);
-				}
-			}
 		}
 	}
 	$equip(card) {


### PR DESCRIPTION
### PR受影响的平台
无
### 诱因和背景
针对昨天的非1转1装备区修改的补充修改
### PR描述
兼容上个版本的lose的实体卡传入写法，es属性改为传入实体牌
更改`lib.element.player.$addVirtualEquip`的写法，使得存在废除装备栏的装备区卡牌变更不再会闪烁
修改武将信息页装备区写法
### PR测试
上述测试通过，仍需进一步测试
### 扩展适配
更改了更改`lib.element.content.lose`或`lib.element.player.$addVirtualEquip`的UI类扩展
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
