### PR TITLE
$handleEquipChange写法回调；uninit取消vcardsMap属性重置

### DIFF
--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -2952,11 +2952,13 @@ export class Player extends HTMLDivElement {
 		this.expandedSlots = {};
 		this.disabledSlots = {};
 		this.ai = { friend: [], enemy: [], neutral: [] };
+		/*
 		this.vcardsMap = {
 			handcards: [],
 			equips: [],
 			judges: [],
 		};
+		*/
 
 		this.$uninit();
 
@@ -4885,10 +4887,10 @@ export class Player extends HTMLDivElement {
 			if (!this.forced) return false;
 			if (typeof this.selectCard == "function") return false;
 			if (this.complexCard || this.complexSelect || this.filterOk) return false;
-			let evt=this.getParent();
-			while(evt?.name){
-				if(evt.name.startsWith("chooseToCompare")) return false;
-				evt=evt.getParent();
+			let evt = this.getParent();
+			while (evt?.name) {
+				if (evt.name.startsWith("chooseToCompare")) return false;
+				evt = evt.getParent();
 			}
 			var cards = this.player.getCards(this.position);
 			if (cards.some(card => !this.filterCard(card, this.player, this))) return false;
@@ -6818,7 +6820,7 @@ export class Player extends HTMLDivElement {
 		if (!card.expired) {
 			let target = this.getNext();
 			const name = card.viewAs || card.name;
-			const cards = get.itemtype(card) == "card" ? [card] : (card.cards ?? []);
+			const cards = get.itemtype(card) == "card" ? [card] : card.cards ?? [];
 			//if (get.itemtype(cards) != "cards") return;
 			let bool = false;
 			if (
@@ -7648,7 +7650,7 @@ export class Player extends HTMLDivElement {
 	 * @param { Player } target
 	 * @param { false } [distance] false：无距离限制
 	 * @param { boolean | GameEvent } [includecard] 是否受使用次数限制，可以填入用于检测的事件
-	 * @returns 
+	 * @returns
 	 */
 	canUse(card, target, distance, includecard) {
 		if (typeof card == "string") card = { name: card, isCard: true };
@@ -9750,7 +9752,7 @@ export class Player extends HTMLDivElement {
 		return false;
 	}
 	/**
-	 * 
+	 *
 	 * @overload
 	 * @param { string } name
 	 * @returns { boolean} 返回玩家判定区是否有某(种牌名的)牌
@@ -10928,43 +10930,63 @@ export class Player extends HTMLDivElement {
 		}
 	}
 	$handleEquipChange() {
-		let player = this;
+		const player = this;
 		const cards = Array.from(player.node.equips.childNodes);
-		for (const cardx of cards) {
-			if (cardx.name.indexOf("empty_equip") == 0) {
-				player.node.equips.removeChild(cardx);
+		const cardsResume = cards.slice(0);
+		cards.forEach(card => {
+			if (card.name.indexOf("empty_equip") == 0) {
+				let num = get.equipNum(card);
+				let remove = false;
+				if ((num == 4 || num == 3) && get.is.mountCombined()) {
+					remove = !player.hasEmptySlot("equip3_4") || player.getEquips("equip3_4").length;
+				} else if (!player.hasEmptySlot(num) || player.getEquips(num).length) {
+					remove = true;
+				}
+				if (remove) {
+					player.node.equips.removeChild(card);
+					cardsResume.remove(card);
+				}
 			}
-		}
+		});
 		for (let i = 1; i <= 5; i++) {
-			const goon = (i == 4 || i == 3) && get.is.mountCombined();
-			if (player.hasEmptySlot(goon ? "equip3_4" : i)) {
-				let sum = player.countEmptySlot(goon ? "equip3_4" : i);
-				while (sum > 0) {
-					sum--;
-					const card = game.createCard("empty_equip" + i, "", "");
-					card.fix();
-					//console.log('add '+card.name);
-					card.style.transform = "";
-					card.classList.remove("drawinghidden");
-					card.classList.add("emptyequip");
-					card.classList.add("hidden");
-					delete card._transform;
-					const equipNum = get.equipNum(card);
-					let equipped = false;
-					for (let j = 0; j < player.node.equips.childNodes.length; j++) {
-						const card2 = player.vcardsMap.equips.find(i => i.cards?.includes(player.node.equips.childNodes[j]));
-						const cardx = card2 ? card2 : player.node.equips.childNodes[j];
-						if (get.equipNum(cardx) >= equipNum) {
-							player.node.equips.insertBefore(card, player.node.equips.childNodes[j]);
-							equipped = true;
-							break;
-						}
+			let add = false;
+			if ((i == 4 || i == 3) && get.is.mountCombined()) {
+				add = player.hasEmptySlot("equip3_4") && !player.getEquips("equip3_4").length;
+			} else {
+				add = player.hasEmptySlot(i) && !player.getEquips(i).length;
+			}
+			if (
+				add &&
+				!cardsResume.some(card => {
+					let num = get.equipNum(card);
+					if ((i == 4 || i == 3) && get.is.mountCombined()) {
+						return num == 4 || num == 3;
+					} else {
+						return num == i;
 					}
-					if (!equipped) {
-						player.node.equips.appendChild(card);
-						if (_status.discarded) {
-							_status.discarded.remove(card);
-						}
+				})
+			) {
+				const card = game.createCard("empty_equip" + i, "", "");
+				card.fix();
+				//console.log('add '+card.name);
+				card.style.transform = "";
+				card.classList.remove("drawinghidden");
+				card.classList.add("emptyequip");
+				card.classList.add("hidden");
+				delete card._transform;
+				const equipNum = get.equipNum(card);
+				let equipped = false;
+				for (let j = 0; j < player.node.equips.childNodes.length; j++) {
+					if (get.equipNum(player.node.equips.childNodes[j]) >= equipNum) {
+						player.node.equips.insertBefore(card, player.node.equips.childNodes[j]);
+						equipped = true;
+						break;
+					}
+				}
+				if (!equipped) {
+					player.node.equips.appendChild(card);
+					if (_status.discarded) {
+						_status.discarded.remove(card);
 					}
 				}
 			}
@@ -11066,7 +11088,8 @@ export class Player extends HTMLDivElement {
 			cardx.node.name2.innerHTML = `${suit}${number} ${cardShownName}`;
 			cardx.classList.remove("fakeequip");
 		}
-		let equipped = false, equipNum = get.equipNum(cardx);
+		let equipped = false,
+			equipNum = get.equipNum(cardx);
 		if (player.node.equips.childNodes.length) {
 			for (let i = 0; i < player.node.equips.childNodes.length; i++) {
 				if (get.equipNum(player.node.equips.childNodes[i]) >= equipNum) {
@@ -11408,10 +11431,10 @@ export class Player extends HTMLDivElement {
 		game.animate.flame(left + this.offsetWidth / 2, top + this.offsetHeight - 30, 700, "recover");
 	}
 	/**
-	 * @param {*} str 
-	 * @param {*} [nature] 
-	 * @param {*} [avatar] 
-	 * @param { false } [broadcast] 
+	 * @param {*} str
+	 * @param {*} [nature]
+	 * @param {*} [avatar]
+	 * @param { false } [broadcast]
 	 */
 	$fullscreenpop(str, nature, avatar, broadcast) {
 		if (broadcast !== false)


### PR DESCRIPTION
### PR受影响的平台
无
### 诱因和背景
因`lib.element.player.$addVirtualEquip`现在装入的均为单一卡牌，故将`lib.element.player.$handleEquipChange`调整为v1.10.13版本以减少装备区显示刷新次数
鬼神易反馈的uninit重置vcardsMap问题
### PR描述
`lib.element.player.$handleEquipChange`写法回调
`lib.element.player.uninit`取消`Player.vcardsMap`属性重置
### PR测试
目前未测试出问题，装备区修改/优化仍需进一步测试
### 扩展适配
无
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
