### PR TITLE
增加两个方法动画的过度的方法。game.$swapElement()和game.$elementGoto()

### DIFF
--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -117,6 +117,89 @@ export class Game extends GameCompatible {
 			});
 		}
 	})();
+	/**
+	 * 交换两个元素的位置，附带过渡动画
+	 * @param {HTMLDivElement} e1 
+	 * @param {HTMLDivElement} e2 
+	 * @param {number} duration //动画完成的时间 ms
+	 * @param {'linear'|'ease-in-out'} timefun //动画过度的时间曲线,很多，这里只列举两个
+	 * @returns {Promise<void>}
+	 * @author Curpond
+	 */
+	$swapElement(e1, e2, duration = 400, timefun = 'linear') {
+		return new Promise((resolve) => {
+			let e1p = e1.parentElement;
+			let e2p = e2.parentElement;
+			let old1_overflow = e1p.style.overflow
+			let old2_overflow = e2p.style.overflow
+			e1p.style.overflow = 'visible'
+			e2p.style.overflow = 'visible'
+			let e1n = e1.nextElementSibling;
+			let e2n = e2.nextElementSibling;
+
+
+			let originalPosition1 = e1.getBoundingClientRect();
+			let originalPosition2 = e2.getBoundingClientRect();
+
+			e1p.insertBefore(e2, e1n);
+			e2p.insertBefore(e1, e2n);
+
+
+			requestAnimationFrame(() => {
+
+				let newPosition1 = e1.getBoundingClientRect();
+				let newPosition2 = e2.getBoundingClientRect();
+
+				let offsetX1 = newPosition1.x - originalPosition1.x;
+				let offsetY1 = newPosition1.y - originalPosition1.y;
+				let offsetX2 = newPosition2.x - originalPosition2.x;
+				let offsetY2 = newPosition2.y - originalPosition2.y;
+
+
+				e1.style.transition = 'none';
+				e2.style.transition = 'none';
+				e1.style.transform = `translate(${-offsetX1}px, ${-offsetY1}px)`;
+				e2.style.transform = `translate(${-offsetX2}px, ${-offsetY2}px)`;
+
+
+				e1.offsetHeight;
+				e2.offsetHeight;
+
+				e1.style.transition = `transform ${duration}ms ${timefun}`;
+				e2.style.transition = `transform ${duration}ms ${timefun}`;
+				e1.style.transform = 'translate(0, 0)';
+				e2.style.transform = 'translate(0, 0)';
+
+				let transitionEndHandler = () => {
+					e1.removeEventListener('transitionend', transitionEndHandler);
+					e2.removeEventListener('transitionend', transitionEndHandler);
+					e1p.style.overflow = old1_overflow
+					e2p.style.overflow = old2_overflow
+					resolve();
+				};
+
+				e1.addEventListener('transitionend', transitionEndHandler, { once: true });
+				e2.addEventListener('transitionend', transitionEndHandler, { once: true });
+			});
+		});
+	};
+	/**
+	* 元素添加到新的父容器中，附带过渡动画
+	* @param {HTMLDivElement} element 
+	* @param {HTMLDivElement} newParent 
+	* @param {number} duration 动画完成的时间 ms
+	* @param {'linear'|'ease-in-out'} timefun 动画过度的时间曲线,很多，这里只列举两个
+	* @returns {Promise<void>}
+	* @author Curpond
+	*/
+	$elementGoto(element, newParent, duration = 400, timefun = 'linear') {
+		let tempElement = element.cloneNode(true)
+		tempElement.style.visibility = 'hidden'
+		newParent.appendChild(tempElement)
+		return game.$swapElement(element, tempElement, duration, timefun).then(() => {
+			tempElement.remove()
+		})
+	}
 	//Stratagem
 	//谋攻
 	setStratagemBuffCost(cardName, cost) {


### PR DESCRIPTION
game.$swapElement()实现交换两个元素的位置，附带动画
game.$elementGoto()实现一个元素被添加到另一个元素中的动画

<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->


### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
很方便的实现任意两个元素的动画交换，不仅仅限于对话框的观星中，可以是其他的任何两个元素
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->



### PR描述
<!-- 详细描述您的更改 -->



### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->



### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->



### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [ ] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [ ] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [ ] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [ ] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [ ] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [ ] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [ ] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
