### PR TITLE
修复移动动画被遮挡问题，并让样式和原来的尽量一致

### DIFF
--- a/layout/others/dialog.css
+++ b/layout/others/dialog.css
@@ -1,11 +1,9 @@
 .dialog:has(.row-container) {
     --bgColor: #2f2f3557;
     width: 80%;
-    background: var(--bgColor);
+    /* background: var(--bgColor); */
     left: 10%;
     border-radius: 10px;
-
-
 }
 
 .dialog:has(.row-container):not(.fullheight) {
@@ -15,11 +13,11 @@
 
 .dialog:has(.row-container)>.content-container {
     border-radius: 10px;
-    background-color: var(--bgColor);
+    /* background-color: var(--bgColor); */
 }
 
 .dialog:has(.row-container)>.content-container>.content {
-    background-color: var(--bgColor);
+    /* background-color: var(--bgColor); */
 
 }
 
@@ -48,7 +46,7 @@
 }
 
 .item-container {
-    border: solid 2px #a5a29db5;
+    /* border: solid 2px #a5a29db5; */
     width: 90%;
     height: 95%;
     margin: auto;

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -134,8 +134,7 @@ export class Game extends GameCompatible {
 			let old2_overflow = e2p.style.overflow
 			/**@type {HTMLDivElement[]} */
 			let watchedElements = [...e1p.children, ...e2p.children].unique()
-			e1p.style.overflow = 'auto'
-			e2p.style.overflow = 'auto'
+
 			let e1n = e1.nextElementSibling;
 			let e2n = e2.nextElementSibling;
 
@@ -156,6 +155,8 @@ export class Game extends GameCompatible {
 			}))
 
 			//invert
+			e1p.style.overflow = 'visible'
+			e2p.style.overflow = 'visible'
 			change.forEach(({ dx, dy }, e) => {
 				e.style.transition = `none`;
 				e.style.transform = `translate(${dx}px, ${dy}px)`
@@ -165,6 +166,7 @@ export class Game extends GameCompatible {
 			e1.offsetHeight;
 			//play
 			requestAnimationFrame(() => {
+
 				change.forEach(({ dx, dy }, e) => {
 					e.style.transition = `${duration}ms ${timefun}`;
 					e.style.removeProperty('transform')
@@ -197,8 +199,7 @@ export class Game extends GameCompatible {
 			let old2_overflow = e2p.style.overflow
 			/**@type {HTMLDivElement[]} */
 			let watchedElements = [...e1p.children, ...e2p.children].unique()
-			e1p.style.overflow = 'auto'
-			e2p.style.overflow = 'auto'
+
 			//first
 			let originalPosition = new Map(watchedElements.map(e => [e, e.getBoundingClientRect()]))
 			//last
@@ -228,6 +229,8 @@ export class Game extends GameCompatible {
 			}))
 
 			//invert
+			e2p.style.overflow = 'visible'
+			e1p.style.overflow = 'visible'
 			change.forEach(({ dx, dy }, e) => {
 				e.style.transition = `none`;
 				e.style.transform = `translate(${dx}px, ${dy}px)`
@@ -236,6 +239,7 @@ export class Game extends GameCompatible {
 
 			//play
 			requestAnimationFrame(() => {
+
 				change.forEach(({ dx, dy }, e) => {
 					e.style.transition = `${duration}ms ${timefun}`;
 					e.style.removeProperty('transform')

--- a/noname/library/element/dialog.js
+++ b/noname/library/element/dialog.js
@@ -183,7 +183,10 @@ export class Dialog extends HTMLDivElement {
 				if (L < n * W) {
 					const ml = Math.min(((n * W - L + 75) / (n - 1)), 70)
 					itemContainer.style.setProperty('--ml', "-" + ml + 'px')
+				} else {
+					itemContainer.style.removeProperty('--ml')
 				}
+
 			}
 		}
 		function parameterNormolize() {
@@ -225,19 +228,18 @@ export class Dialog extends HTMLDivElement {
 		}
 		//添加元素到子容器中，并返回添加后的元素
 		function addItemToItemContainer(item, itemContainer, itemOption) {
-			if (!item) return
+			if (!item) {
+				itemContainer.classList.add('popup')
+				return
+			}
 			/**@type {HTMLDivElement[]} */
 			let items = []
 			if (typeof item == 'string') {
 				let caption = ui.create.caption(item, itemContainer)
 				caption.css(itemOption.itemCss ?? {})
 				items.push(caption)
-			} else if (typeof item == 'function') {
-				let item = item()
-				itemContainer.links = item
-				itemContainer.append(item)
-				items.push(item)
 			} else if (!Array.isArray(item)) {
+				itemContainer.classList.add('popup')
 				let button = ui.create.button(item, get.itemtype(item), itemContainer, itemOption.ItemNoclick)
 				button.css(itemOption.itemCss ?? {})
 				items.push(button)


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->


### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->



### PR描述
<!-- 详细描述您的更改 -->



### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->



### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->



### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [ ] 我没有把该PR提交到`master`分支
- [ ] commit中没有无用信息，和没有具体内容的“bugfix”
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [ ] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [ ] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [ ] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [ ] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [ ] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [ ] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [ ] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
