### PR TITLE
【酒】、属性【杀】传导ai再修；bugfix

### DIFF
--- a/card/extra.js
+++ b/card/extra.js
@@ -138,7 +138,7 @@ game.import("card", function () {
 						let usable = player.getCardUsable("sha");
 						if (usable < 2 && player.hasCard(i => {
 							return get.name(i, player) == "zhuge";
-						}, "h")) usable = Infinity;
+						}, "hs")) usable = Infinity;
 						let shas = Math.min(usable, player.mayHaveSha(player, "use", item, "count"));
 						if (
 							shas != 1 ||

--- a/card/extra.js
+++ b/card/extra.js
@@ -131,25 +131,28 @@ game.import("card", function () {
 							return 3;
 						},
 					},
-					order: () => {
+					order(item, player) {
 						if (_status.event.dying) return 9;
 						let sha = get.order({ name: "sha" });
-						if (sha > 0) return sha + 0.2;
-						return 0;
+						if (sha <= 0) return 0;
+						let usable = player.getCardUsable("sha");
+						if (usable < 2 && player.hasCard(i => {
+							return get.name(i, player) == "zhuge";
+						}, "h")) usable = Infinity;
+						let shas = Math.min(usable, player.mayHaveSha(player, "use", item, "count"));
+						if (
+							shas != 1 ||
+							(lib.config.mode === "stone" &&
+								!player.isMin() &&
+								player.getActCount() + 1 >= player.actcount)
+						)
+							return 0;
+						return sha + 0.2;
 					},
 					result: {
 						target: (player, target, card) => {
 							if (target && target.isDying()) return 2;
 							if (!target || target._jiu_temp || !target.isPhaseUsing()) return 0;
-							let usable = target.getCardUsable("sha");
-							if (
-								!usable ||
-								(lib.config.mode === "stone" &&
-									!player.isMin() &&
-									player.getActCount() + 1 >= player.actcount) ||
-								!target.mayHaveSha(player, "use", card)
-							)
-								return 0;
 							let effs = { order: 0 },
 								temp;
 							target.getCards("hs", (i) => {
@@ -194,15 +197,16 @@ game.import("card", function () {
 										},
 										true
 									) ||
-									(usable === 1 &&
-										(target.needsToDiscard() > Math.max(0, 3 - target.hp) ||
-											!effs[i].target.mayHaveShan(
-												player,
-												"use",
-												effs[i].target.getCards((i) => {
-													return i.hasGaintag("sha_notshan");
-												})
-											)))
+									//(Math.min(target.getCardUsable("sha"), target.mayHaveSha(player, "use", item, "count")) === 1 && (
+									target.needsToDiscard() > Math.max(0, 3 - target.hp) ||
+									!effs[i].target.mayHaveShan(
+										player,
+										"use",
+										effs[i].target.getCards((i) => {
+											return i.hasGaintag("sha_notshan");
+										})
+									)
+									//))
 								) {
 									delete target._jiu_temp;
 									return 1;

--- a/card/standard.js
+++ b/card/standard.js
@@ -416,7 +416,7 @@ game.import("card", function () {
 									target.hasSkillTag("filterDamage", null, {
 										player: player,
 										card: card,
-										jiu: true,
+										jiu: player.hasSkill("jiu")
 									})
 								) num = 1;
 								return odds * eff * num;
@@ -432,7 +432,7 @@ game.import("card", function () {
 									target.hasSkillTag("filterDamage", null, {
 										player: player,
 										card: card,
-										jiu: true,
+										jiu: player.hasSkill("jiu")
 									})
 								)
 									eff = -0.5;

--- a/card/standard.js
+++ b/card/standard.js
@@ -345,7 +345,7 @@ game.import("card", function () {
 						}
 						return base;
 					},
-					canLink: function (player, target, card) {
+					canLink(player, target, card) {
 						if (!target.isLinked() && !player.hasSkill("wutiesuolian_skill")) return false;
 						if (
 							player.hasSkill("jueqing") ||
@@ -353,7 +353,33 @@ game.import("card", function () {
 							target.hasSkill("gangzhi")
 						)
 							return false;
-						return true;
+						let obj = { };
+						if (get.attitude(player, target) > 0 && get.attitude(target, player) > 0) {
+							if (
+								(
+									player.hasSkill("jiu") ||
+									player.hasSkillTag("damageBonus", true, {
+										target: target,
+										card: card
+									})
+								) &&
+								!target.hasSkillTag("filterDamage", null, {
+									player: player,
+									card: card,
+									jiu: player.hasSkill("jiu")
+								})
+							) obj.num = 2;
+							if (target.hp > obj.num) obj.odds = 1;
+						}
+						if (!obj.odds) obj.odds = 1 - target.mayHaveShan(
+							player,
+							"use",
+							target.getCards("h", (i) => {
+								return i.hasGaintag("sha_notshan");
+							}),
+							"odds"
+						);
+						return obj;
 					},
 					basic: {
 						useful: [5, 3, 1],
@@ -382,11 +408,18 @@ game.import("card", function () {
 								odds = 1.35,
 								num = 1;
 							if (isLink) {
-								let cache = _status.event.getTempCache("sha_result", "eff");
-								if (typeof cache !== "object" || cache.card !== ai.getCacheKey(card, true))
-									return eff;
-								if (cache.odds < 1.35 && cache.bool) return 1.35 * cache.eff;
-								return cache.odds * cache.eff;
+								eff = isLink.eff || -2;
+								odds = isLink.odds || 0.65;
+								num = isLink.num || 1;
+								if (
+									num > 1 &&
+									target.hasSkillTag("filterDamage", null, {
+										player: player,
+										card: card,
+										jiu: true,
+									})
+								) num = 1;
+								return odds * eff * num;
 							}
 							if (
 								player.hasSkill("jiu") ||

--- a/character/extra/skill.js
+++ b/character/extra/skill.js
@@ -350,8 +350,39 @@ const skills = {
 			let result = await player
 				.chooseControlList(list)
 				.set("ai", function () {
-					//等157优化）
-					return Math.random();
+					let player = get.event("player"), damaged = player.getDamagedHp();
+					if (damaged) damaged += 0.6 * (player.countCard("hs", card => {
+						if (card.name == "sha" || !get.tag(card, "damage")) return 0;
+						let info = get.info(card);
+						if (!info || info.type != "trick") return false;
+						if (info.notarget) return false;
+						if (info.selectTarget != undefined) {
+							if (Array.isArray(info.selectTarget)) {
+								if (info.selectTarget[1] == -2) return 1;
+								if (info.selectTarget[1] == -1) {
+									let func = info.filterTarget;
+									if (typeof func != "function") func = () => true;
+									return game.countPlayer(cur => {
+										return func(card, player, cur);
+									});
+								}
+								return Math.max(1, info.selectTarget[0], info.selectTarget[1]);
+							} else {
+								if (info.selectTarget == -2) return 1;
+								if (info.selectTarget == -1) {
+									let func = info.filterTarget;
+									if (typeof func != "function") func = () => true;
+									return game.countPlayer(cur => {
+										return func(card, player, cur);
+									});
+								}
+								return Math.max(1, info.selectTarget);
+							}
+						}
+						return 1;
+					}) + Math.max(player.getCardUsable("sha"), player.countCards("hs", "sha")));
+					if (damaged > player.hp) return "选项二";
+					return "选项一";
 				})
 				.forResult();
 			event.result = {

--- a/character/refresh/skill.js
+++ b/character/refresh/skill.js
@@ -6310,7 +6310,7 @@ const skills = {
 				return num;
 			},
 		},
-		trigger: { player: "phaseDiscardBegin" },
+		trigger: { player: "phaseDiscardEnd" },
 		forced: true,
 		charlotte: true,
 		filter: function (event, player) {

--- a/node_modules/@types/noname-typings/Skill.d.ts
+++ b/node_modules/@types/noname-typings/Skill.d.ts
@@ -1947,11 +1947,12 @@ declare interface SkillAI {
 	 * 是否要对“连锁”状态下的目标处理；
 	 * 
 	 * 新增，在get.effect中使用；
-	 * @param player 
-	 * @param target 
-	 * @param card 
+	 * @param player 使用者
+	 * @param target 目标（伤害传导的起点）
+	 * @param card 所使用卡牌
+	 * @returns 返回是否处理(boolean)，或在确定要处理时返回一个存放所需数据的字典（默认设返回值.source为target）
 	 */
-	canLink?(player: Player, target: Player, card: Card): boolean;
+	canLink?(player: Player, target: Player, card: Card): boolean | object;
 
 	//日后还有很多属性要添加的
 	[key: string]: any;

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -5069,12 +5069,18 @@ export class Get extends GetCompatible {
 			if (!info || !info.ai || !info.ai.canLink) {
 				if (target.isLinked())
 					game.players.forEach(function (current) {
-						if (current != target && current.isLinked()) final += cache.get.effect(current, card, player, player2, true);
+						if (current != target && current.isLinked()) final += cache.get.effect(current, card, player, player2, { source: target });
 					});
-			} else if (info.ai.canLink(player, target, card)) {
-				game.players.forEach(function (current) {
-					if (current != target && current.isLinked()) final += cache.get.effect(current, card, player, player2, true);
-				});
+			}
+			else {
+				let canLink = info.ai.canLink(player, target, card);
+				if (canLink) {
+					if (typeof canLink !== "object") canLink = {};
+					canLink.source = target;
+					game.players.forEach(function (current) {
+						if (current != target && current.isLinked()) final += cache.get.effect(current, card, player, player2, canLink);
+					});
+				}
 			}
 		}
 		return final;
@@ -5234,12 +5240,18 @@ export class Get extends GetCompatible {
 			if (!info || !info.ai || !info.ai.canLink) {
 				if (target.isLinked())
 					game.players.forEach(function (current) {
-						if (current != target && current.isLinked()) final += cache.get.effect(current, card, player, player2, true);
+						if (current != target && current.isLinked()) final += cache.get.effect(current, card, player, player2, { source: target });
 					});
-			} else if (info.ai.canLink(player, target, card)) {
-				game.players.forEach(function (current) {
-					if (current != target && current.isLinked()) final += cache.get.effect(current, card, player, player2, true);
-				});
+			}
+			else {
+				let canLink = info.ai.canLink(player, target, card);
+				if (canLink) {
+					if (typeof canLink !== "object") canLink = {};
+					canLink.source = target;
+					game.players.forEach(function (current) {
+						if (current != target && current.isLinked()) final += cache.get.effect(current, card, player, player2, canLink);
+					});
+				}
 			}
 		}
 		return final;


### PR DESCRIPTION
### PR受影响的平台
无


### 诱因和背景
吧友、群友&好友反馈



### PR描述
见commits标题。
此次修复了人机未装备连弩时因次数上限不足贸然酒杀的问题；
将”还能使用几张【杀】“放至order内判断；
暂时注释掉了result中考虑”只能杀一次“的前提；
拓展了info.ai.canLink函数返回值，计算传导伤害时info.ai.result下面的函数将得到”{ source: target }“为基础模板的传参isLink。isLink.source即为伤害传导的起点目标，以便于后续计算


### info.ai.canLink函数补充内容
现支持将该函数的返回值传入到计算传导收益中的get.effect(arguments)的第五个参数（isLink）了
具体案例请参看lib.card.sha.ai.canLink（返回值）和lib.card.sha.ai.result.target（isLink参数）
若无对应的info.ai.canLink函数，则isLink = { source: target }，其中target为伤害传导的起点


### PR测试
交给群友测试了



### 扩展适配
无



### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [ ] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
