### PR TITLE
修复一些武将包前缀去除的问题

### DIFF
--- a/extension/boss/extension.js
+++ b/extension/boss/extension.js
@@ -11,12 +11,12 @@ game.import("play", function () {
 				storage = {};
 			}
 			if (get.mode() != "boss") {
-				lib.characterPack.mode_extension_boss = storage.boss || {};
-				for (var i in lib.characterPack.mode_extension_boss) {
-					lib.characterPack.mode_extension_boss[i][4].push(
+				lib.characterPack.boss = storage.boss || {};
+				for (var i in lib.characterPack.boss) {
+					lib.characterPack.boss[i][4].push(
 						"mode:boss"
 					);
-					lib.character[i] = lib.characterPack.mode_extension_boss[i];
+					lib.character[i] = lib.characterPack.boss[i];
 					if (
 						typeof lib.character[i][2] != "number" &&
 						(typeof lib.character[i][2] != "string" ||
@@ -34,12 +34,12 @@ game.import("play", function () {
 				get.mode() != "versus" ||
 				get.config("versus_mode") != "jiange"
 			) {
-				lib.characterPack.mode_extension_jiange = list2;
-				for (var i in lib.characterPack.mode_extension_jiange) {
-					lib.characterPack.mode_extension_jiange[i][4].push(
+				lib.characterPack.jiange = list2;
+				for (var i in lib.characterPack.jiange) {
+					lib.characterPack.jiange[i][4].push(
 						"mode:versus"
 					);
-					lib.character[i] = lib.characterPack.mode_extension_jiange[i];
+					lib.character[i] = lib.characterPack.jiange[i];
 					if (typeof lib.character[i][2] != "number") {
 						lib.character[i][2] = Infinity;
 					}
@@ -71,8 +71,8 @@ game.import("play", function () {
 				}
 			}
 			var list = storage.translate || {};
-			list.mode_extension_boss_character_config = "挑战武将";
-			list.mode_extension_jiange_character_config = "剑阁武将";
+			list.boss_character_config = "挑战武将";
+			list.jiange_character_config = "剑阁武将";
 
 			for (var i in list) {
 				lib.translate[i] = lib.translate[i] || list[i];

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -4766,7 +4766,7 @@ export class Game extends GameCompatible {
 			character = [information.sex, information.group, information.hp, information.skills || [], [_status.evaluatingExtension ? `db:extension-${extensionName}:${name}.jpg` : `ext:${extensionName}/${name}.jpg`, `die:ext:${extensionName}/${name}.mp3`]];
 		if (information.tags) character[4] = character[4].concat(information.tags);
 		lib.character[name] = character;
-		const packName = `mode_extension_${extensionName}`;
+		const packName = extensionName;
 		if (!lib.characterPack[packName]) lib.characterPack[packName] = {};
 		lib.translate[name] = information.translate;
 		lib.characterPack[packName][name] = character;
@@ -4829,7 +4829,7 @@ export class Game extends GameCompatible {
 				}
 			}
 		}
-		let packname = "mode_extension_" + packagename;
+		let packname = packagename;
 		lib.characterPack[packname] = pack.character;
 		lib.translate[packname + "_character_config"] = packagename;
 		if (gzFlag) lib.characterGuozhanFilter.add(packname);
@@ -4873,7 +4873,7 @@ export class Game extends GameCompatible {
 				lib.card.list.push([suits[Math.floor(Math.random() * suits.length)], Math.ceil(Math.random() * 13), name]);
 			}
 		}
-		let packname = "mode_extension_" + extname;
+		let packname = extname;
 		if (!lib.cardPack[packname]) {
 			lib.cardPack[packname] = [];
 			lib.translate[packname + "_card_config"] = extname;
@@ -4887,7 +4887,7 @@ export class Game extends GameCompatible {
 	addCardPack(pack, packagename) {
 		let extname = _status.extension || "扩展";
 		packagename = packagename || extname;
-		let packname = "mode_extension_" + packagename;
+		let packname = packagename;
 		lib.cardPack[packname] = [];
 		lib.cardPackInfo[packname] = pack;
 		lib.translate[packname + "_card_config"] = packagename;

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -124,6 +124,12 @@ export class Library {
 	cardPack = new Proxy(
 		{},
 		{
+			get(target, prop, receiver) {
+				if (typeof prop == "string" && prop.startsWith("mode_extension_")) {
+					prop = prop.slice("mode_extension_".length);
+				}
+				return Reflect.get(target, prop, receiver);
+			},
 			set(target, prop, newValue) {
 				if (typeof prop == "string") {
 					if (!Reflect.has(target, prop)) {
@@ -132,7 +138,16 @@ export class Library {
 						});
 					}
 				}
+				if (prop.startsWith("mode_extension_")) {
+					prop = prop.slice("mode_extension_".length);
+				}
 				return Reflect.set(target, prop, newValue);
+			},
+			defineProperty(target, prop, descriptor) {
+				if (typeof prop == "string" && prop.startsWith("mode_extension_")) {
+					prop = prop.slice("mode_extension_".length);
+				}
+				return Reflect.defineProperty(target, prop, descriptor);
 			},
 		}
 	);


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
由于当初的扩展包改变过于激进，有些细节部分并未考虑，导致部分翻译为空



### PR描述
<!-- 详细描述您的更改 -->
将`诸神降临`的武将包去除前缀

将`game.addCharacterPack`和`game.addCardPack`的前缀去除

为`lib.cardPack`提供去除`mode_extension_`前缀的Proxy


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
将`诸神降临`打开后，武将界面的名称正常

此处的`渣作集合`扩展用的是`game.addCharacterPack`添加的武将包，此时也正常显示
![图片](https://github.com/user-attachments/assets/c8a55400-6541-4b7c-9610-0b906b28acce)


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需适配，但由于`lib.translate`不确定应不应该套层Proxy，故如果直接往`lib.characterPack`/`lib.cardPack`和`lib.translate`添加武将包/卡牌包信息，则仍然会出现翻译问题。

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
