### PR TITLE
优化议事机制显示，增加两套议事结果流程

### DIFF
--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -1033,7 +1033,7 @@ export const Content = {
 			.slice()
 			.filter(i => i != "others")
 			.sort((a, b) => event[b].length - event[a].length);
-		opinion = event[event.opinions[0]].length > event[event.opinions[1]].length ? event.opinions[0] : null;
+		opinion = event[opinions[0]].length > event[opinions[1]].length ? opinions[0] : null;
 		if (opinion) game.log(player, "本次发起的议事结果为", opinion == "red" ? '<span class="firetext">红色</span>' : "#g" + get.translation(opinion));
 		else game.log(player, "本次发起的议事无结果");
 		event.result = {

--- a/noname/library/element/dialog.js
+++ b/noname/library/element/dialog.js
@@ -198,6 +198,7 @@ export class Dialog extends HTMLDivElement {
 				itemContainer.classList.add("popup");
 				let button = ui.create.button(item, get.itemtype(item), itemContainer, itemOption.ItemNoclick);
 				button.css(itemOption.itemCss ?? {});
+				if(item._custom) item._custom(button);
 				items.push(button);
 			} else {
 				for (let i of item) {


### PR DESCRIPTION
### PR受影响的平台
无
### 诱因和背景
你说得对，但是本PR是由打完复活赛后的萌新（转型中）自主研发的一项全新的开放式议事流程，议事发生在一个叫做《无名杀》的游戏对局之中。在这里，被选中的人将被授予选牌能力，导引票选之力。你将扮演一名威震华夏的名将或历史角落的无名小卒，在自由的游戏对局中邂逅技能各异机制独特的武将，和他们一起开展议事，引出最后的议事结果。
### PR描述
修改江山如故的六个议事技能的非黑即红技能写法
若`lib.element.content.chooseToDebate`中赋予`event.debateIgnore`属性为`false`，则依据大家议事结果中颜色唯一最多的为结果（dialog显示为红色一行，黑色一行，若有其他意见则开启第三行并放入其中）；否则只统计红色和黑色的议事结果，且其余意见作废（dialog显示为所有角色的议事情卡牌放在同一个button之中）
为`lib.element.dialog.addNewRow`添加对非`string`元素的`_custom`接口
### PR测试
测了，十分甚至九分能跑的动
### 扩展适配
无
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码