### PR TITLE
将第一批幼龄化的技能恢复为原来的标记

### DIFF
--- a/character/clan/skill.js
+++ b/character/clan/skill.js
@@ -208,7 +208,8 @@ const skills = {
 				if (result.bool) {
 					const lose = result.moved[1].slice();
 					const gain = result.moved[0].slice().filter(i => !get.owner(i));
-					if (lose.some(i => get.owner(i))) await game.cardsGotoOrdering(lose.filter(i => get.owner(i)));
+					if (lose.some(i => get.owner(i)))
+						await game.cardsGotoOrdering(lose.filter(i => get.owner(i)));
 					for (let i = lose.length - 1; i--; i >= 0) {
 						ui.cardPile.insertBefore(lose[i], ui.cardPile.firstChild);
 					}
@@ -1658,12 +1659,9 @@ const skills = {
 				charlotte: true,
 				trigger: { global: "phaseEnd" },
 				filter(event, player) {
-					if (
-						!Object.keys(event.player.storage).some(skill => {
-							return skill.startsWith("clanmingjiex_" + player.playerid + "_") && event.player.storage[skill] == 1;
-						})
-					)
-						return false;
+					if (!Object.keys(event.player.storage).some(skill => {
+						return skill.startsWith("clanmingjiex_" + player.playerid + "_") && event.player.storage[skill] == 1;
+					})) return false;
 					return player.getStorage("clanmingjie_record").someInD("d");
 				},
 				forced: true,
@@ -2741,30 +2739,19 @@ const skills = {
 	//族荀谌
 	clansankuang: {
 		audio: 2,
-		trigger: { player: ["useCardAfter", "useCard1"] },
+		trigger: { player: "useCardAfter" },
 		direct: true,
 		forced: true,
-		filter(event, player, name) {
+		filter(event, player) {
+			if (!game.hasPlayer(current => current != player)) return false;
 			const type = get.type2(event.card);
-			if (player.getRoundHistory("useCard", evt => get.type2(evt.card) == type).indexOf(event) !== 0) return false;
-			if (name === "useCard1") {
-				lib.skill.clansankuang.init(player);
-				return false;
-			}
-			return game.hasPlayer(current => current != player);
+			return player.getRoundHistory("useCard", evt => get.type2(evt.card) == type).indexOf(event) == 0;
 		},
 		getNum(player) {
 			return (player.countCards("ej") > 0) + player.isDamaged() + (Math.max(0, player.hp) < player.countCards("h"));
 		},
 		content() {
 			"step 0";
-			var func = function (player) {
-				game.countPlayer(function (target) {
-					if (target != player) target.prompt("三恇" + lib.skill.clansankuang.getNum(target));
-				});
-			};
-			if (event.player == game.me) func(player);
-			else if (event.isOnline()) player.send(func, player);
 			var cards = trigger.cards.filterInD("oe");
 			player
 				.chooseTarget("三恇：选择一名其他角色", "令其交给你至少X张牌" + (cards.length ? "，然后其获得" + get.translation(cards) : "") + "（X为以下条件中其满足的项数：场上有牌、已受伤、体力值小于手牌数）", true, lib.filter.notMe)
@@ -2825,18 +2812,6 @@ const skills = {
 				},
 			},
 			threaten: 1.6,
-		},
-		init(player) {
-			const types = player
-				.getRoundHistory("useCard")
-				.reduce((list, evt) => {
-					return list.add(get.type2(evt.card));
-				}, [])
-				.map(type => get.translation(type)[0] || "");
-			if (types.length) player.addTip("clansankuang", "三恇 " + types.slice().join(" "), "roundStart");
-		},
-		onremove(player, skill) {
-			player.removeTip(skill);
 		},
 	},
 	clanbeishi: {

--- a/character/clan/skill.js
+++ b/character/clan/skill.js
@@ -3326,16 +3326,16 @@ const skills = {
 	},
 	clandianzhan: {
 		audio: 2,
-		trigger: { player: ["useCard1", "useCardAfter"] },
+		intro: {
+			content: "已使用过的花色：$",
+			onunmark: true,
+		},
+		trigger: { player: "useCardAfter" },
 		forced: true,
-		filter(event, player, name) {
+		filter(event, player) {
 			if (!lib.suit.includes(get.suit(event.card))) return false;
 			const suit = get.suit(event.card);
 			if (player.getRoundHistory("useCard", evt => get.suit(evt.card) == suit).indexOf(event) != 0) return false;
-			if (name === "useCard1") {
-				lib.skill.clandianzhan.init(player);
-				return false;
-			}
 			return (event.targets && event.targets.length == 1 && !event.targets[0].isLinked()) || player.hasCard(card => get.suit(card) == get.suit(event.card) && player.canRecast(card), "h");
 		},
 		content() {
@@ -3352,11 +3352,34 @@ const skills = {
 			"step 1";
 			if (event.link && event.recast) player.draw();
 		},
+		group: "clandianzhan_count",
 		subSkill: {
 			count: {
 				charlotte: true,
-				onremove(player, skill) {
-					player.removeTip(skill);
+				trigger: { player: "useCardAfter" },
+				filter(event, player) {
+					let suit = get.suit(event.card);
+					return lib.suits.includes(suit) && !player.getStorage("clandianzhan").includes(suit);
+				},
+				forced: true,
+				silent: true,
+				content() {
+					let suits = player
+						.getRoundHistory("useCard", evt => {
+							return lib.suits.includes(get.suit(evt.card));
+						})
+						.reduce((list, evt) => {
+							return list.add(get.suit(evt.card));
+						}, [])
+						.sort((a, b) => lib.suits.indexOf(a) - lib.suits.indexOf(b));
+					if (!player.storage.clandianzhan) {
+						player.when({ global: "roundStart" }).then(() => {
+							delete player.storage.clandianzhan;
+							player.unmarkSkill("clandianzhan");
+						});
+					}
+					player.storage.clandianzhan = suits;
+					player.markSkill("clandianzhan");
 				},
 			},
 		},
@@ -3368,11 +3391,17 @@ const skills = {
 				.reduce((list, evt) => {
 					return list.add(get.suit(evt.card));
 				}, [])
-				.sort((a, b) => lib.suits.indexOf(b) - lib.suits.indexOf(a));
-			if (suits.length) player.addTip("clandianzhan", "点盏 " + suits.reduce((str, suit) => str + get.translation(suit), ""), "roundStart");
-		},
-		onremove(player, skill) {
-			player.removeTip(skill);
+				.sort((a, b) => lib.suits.indexOf(a) - lib.suits.indexOf(b));
+			if (suits.length) {
+				if (!player.storage.clandianzhan) {
+					player.when({ global: "roundStart" }).then(() => {
+						delete player.storage.clandianzhan;
+						player.unmarkSkill("clandianzhan");
+					});
+				}
+				player.storage.clandianzhan = suits;
+				player.markSkill("clandianzhan");
+			}
 		},
 	},
 	clanhuanyin: {

--- a/character/diy/skill.js
+++ b/character/diy/skill.js
@@ -2024,14 +2024,10 @@ const skills = {
 	//手杀削弱版许攸
 	junkshicai: {
 		audio: "nzry_shicai_2",
-		trigger: { player: ["useCardAfter", "useCard1"] },
-		filter(event, player, name) {
-			if (player.getHistory("useCard", evt => get.type2(evt.card) == get.type2(event.card)).indexOf(event) !== 0) return false;
-			if (name === "useCard1") {
-				lib.skill.nzry_shicai.init(player);
-				return false;
-			}
-			return event.cards.someInD("oe");
+		trigger: { player: "useCardAfter" },
+		filter(event, player) {
+			if (!event.cards.filterInD("oe").length) return false;
+			return player.getHistory("useCard", evt => get.type2(evt.card) == get.type2(event.card)).indexOf(event) == 0;
 		},
 		prompt2(event, player) {
 			const cards = event.cards.filterInD("oe");
@@ -2073,12 +2069,6 @@ const skills = {
 			game.cardsGotoPile(cards, "insert");
 			game.log(player, "将", cards, "置于了牌堆顶");
 			player.draw();
-		},
-		init(player) {
-			lib.skill.nzry_shicai.init(player);
-		},
-		onremove(player) {
-			player.removeSkill("nzry_shicai_2");
 		},
 		ai: {
 			reverseOrder: true,

--- a/character/extra/skill.js
+++ b/character/extra/skill.js
@@ -475,7 +475,7 @@ const skills = {
 				},
 				async content(event, trigger, player) {
 					const { target, position } = event;
-					target.addTempSkill("new_dclieqiong_abdomen", {player: "phaseEnd"});
+					target.addTempSkill("new_dclieqiong_abdomen", { player: "phaseEnd" });
 				}
 			},
 		},
@@ -3389,49 +3389,36 @@ const skills = {
 		prompt2: () => lib.translate.shelie_info,
 		group: "twshelie_jingce",
 		//什么精策技能啊喂！
-		init(player) {
-			if (player.hasSkill("twshelie_round") || player !== _status.currentPhase) return;
-			var list = [];
-			player.getHistory("useCard", function (evt) {
-				if (lib.suit.includes(get.suit(evt.card)) && !list.includes(get.suit(evt.card))) list.push(get.suit(evt.card));
-			});
-			if (list.length) {
-				list.sort(function (a, b) {
-					return lib.suit.indexOf(b) - lib.suit.indexOf(a);
-				});
-				player.addTip("twshelie", "涉猎 " + list.reduce((str, suit) => str + get.translation(suit), ""), true);
-			}
-		},
-		onremove(player, skill) {
-			player.removeTip(skill);
-		},
 		subSkill: {
 			round: { charlotte: true },
 			count: {
 				charlotte: true,
-				onremove(player, skill) {
-					player.removeTip(skill);
+				onremove: true,
+				intro: {
+					markcount(storage) {
+						return storage.length;
+					},
+					content: "本回合已使用$花色的牌",
 				},
 			},
 			jingce: {
 				audio: "shelie",
 				trigger: { player: ["phaseJieshuBegin", "useCard1"] },
 				filter(event, player) {
-					if (player.hasSkill("twshelie_round") || player !== _status.currentPhase) return false;
+					if (player.hasSkill("twshelie_round") || player != _status.currentPhase) return false;
 					var list = [];
 					player.getHistory("useCard", function (evt) {
 						if (lib.suit.includes(get.suit(evt.card)) && !list.includes(get.suit(evt.card))) list.push(get.suit(evt.card));
 					});
-					if (event.name == "useCard") {
-						if (list.length) {
-							list.sort(function (a, b) {
-								return lib.suit.indexOf(b) - lib.suit.indexOf(a);
-							});
-							player.addTip("twshelie", "涉猎 " + list.reduce((str, suit) => str + get.translation(suit), ""), true);
-						}
-						return false;
+					if (list.length) {
+						player.addTempSkill("twshelie_count");
+						player.storage.twshelie_count = list.sort(function (a, b) {
+							return lib.suit.indexOf(b) - lib.suit.indexOf(a);
+						});
+						player.markSkill("twshelie_count");
+						player.syncStorage("twshelie_count");
 					}
-					return list.length >= 4;
+					return event.name != "useCard" && list.length >= 4;
 				},
 				forced: true,
 				locked: false,

--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -7575,8 +7575,8 @@ const skills = {
 			},
 			result: { player: 7 },
 		},
-		group: ["xinjianying_draw"],
-		init(player) {
+		group: ["xinjianying_draw", "jianying_mark"],
+		init: function (player) {
 			if (player.isPhaseUsing()) {
 				var evt = _status.event.getParent("phaseUse");
 				var history = player.getHistory("useCard", function (evt2) {
@@ -7584,13 +7584,25 @@ const skills = {
 				});
 				if (history.length) {
 					var trigger = history[history.length - 1];
-					if (get.suit(trigger.card) == "none" || typeof get.number(trigger.card) != "number") return;
-					player.addTip("jianying", "渐营 " + lib.skill.jianying.getTranslation(trigger.card), "phaseUseAfter");
+					player.storage.jianying_mark = trigger.card;
+					player.markSkill("jianying_mark");
+					game.broadcastAll(
+						function (player, suit) {
+							if (player.marks.jianying_mark) player.marks.jianying_mark.firstChild.innerHTML = get.translation(suit);
+						},
+						player,
+						get.suit(trigger.card, player)
+					);
+					player.when("phaseUseAfter").then(() => {
+						player.unmarkSkill("jianying_mark");
+						delete player.storage.jianying_mark;
+					});
 				}
 			}
 		},
-		onremove(player) {
-			player.removeTip("jianying");
+		onremove: function (player) {
+			player.unmarkSkill("jianying_mark");
+			delete player.storage.jianying_mark;
 		},
 		subSkill: {
 			draw: { inherit: "jianying", audio: "xinjianying" },

--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -361,13 +361,11 @@ const skills = {
 						game.log(cards, "被移出了游戏");
 					} else if (trigger.name == "equip") {
 						if (event.triggername == "equipBefore") trigger.cancel();
-						else
-							await player.discard(
-								player.getCards("e", card => {
-									return !trigger.cards.includes(card) && lib.filter.cardDiscardable(card, player);
-								})
-							);
-					} else {
+						else await player.discard(player.getCards("e", card => {
+							return !trigger.cards.includes(card) && lib.filter.cardDiscardable(card, player);
+						}));
+					}
+					else {
 						const cards = player.getCards("e", card => {
 							if (!trigger.cards.includes(card)) return false;
 							return card.name.startsWith("dagongche_") && card.storage?.mbquchong > 0;
@@ -375,7 +373,7 @@ const skills = {
 						trigger.cards.removeArray(cards);
 						for (const card of cards) {
 							card.storage.mbquchong--;
-							game.log(card, "减少了", "#y1点", "#g耐久值");
+							game.log(card, '减少了', '#y1点', '#g耐久值');
 							lib.skill.mbquchong.broadcast(card);
 						}
 						await event.trigger("mbquchongOnRemove");
@@ -418,7 +416,7 @@ const skills = {
 			});
 			for (const card of cards) {
 				card.storage.mbquchong--;
-				game.log(card, "减少了", "#y1点", "#g耐久值");
+				game.log(card, '减少了', '#y1点', '#g耐久值');
 				lib.skill.mbquchong.broadcast(card);
 			}
 			await event.trigger("mbquchongOnRemove");
@@ -446,7 +444,7 @@ const skills = {
 				const num = Math.min(trigger.num, card.storage.mbquchong);
 				trigger.num -= num;
 				card.storage.mbquchong -= num;
-				game.log(card, "减少了", "#y" + num + "点", "#g耐久值");
+				game.log(card, '减少了', '#y' + num + '点', '#g耐久值');
 				lib.skill.mbquchong.broadcast(card);
 				if (trigger.num <= 0) break;
 			}
@@ -2409,7 +2407,8 @@ const skills = {
 					const targets = game.filterPlayer(current => !player.getStorage("mbweiming").includes(current) && current != player);
 					if (targets.length == 1) {
 						event.result = { bool: true, targets: targets };
-					} else {
+					}
+					else {
 						event.result = await player
 							.chooseTarget("威命：记录一名未记录过的其他角色", "当你杀死没有被记录过的角色后，则〖威命〗使命成功；如果在你杀死这些角色中的一名之前，有被记录过的角色死亡，则你〖威命〗使命失败。", true)
 							.set("filterTarget", (card, player, target) => {
@@ -3228,8 +3227,7 @@ const skills = {
 				},
 				forced: true,
 				getIndex(event, player) {
-					let list = [],
-						players = game.filterPlayer().sortBySeat();
+					let list = [], players = game.filterPlayer().sortBySeat();
 					for (const current of players) {
 						let bool = ["useCard", "respond"].includes(event.getParent().name);
 						if (current == player) continue;
@@ -5953,7 +5951,7 @@ const skills = {
 					if (card.name == "lebu" || card.name == "bingliang") return 0.5;
 				},
 			},
-			combo: "fenli",
+			combo: "fenli"
 		},
 	},
 	// 彭羕
@@ -8286,8 +8284,8 @@ const skills = {
 	//毛玠
 	bingqing: {
 		audio: 2,
-		trigger: { player: ["useCardAfter", "useCard1"] },
-		filter(event, player, name) {
+		trigger: { player: "useCardAfter" },
+		filter(event, player) {
 			const evt = event.getParent("phaseUse");
 			if (!evt || !evt.player || evt.player != player) return false;
 			const suit = get.suit(event.card);
@@ -8300,10 +8298,6 @@ const skills = {
 					.indexOf(event) != 0
 			)
 				return false;
-			if (name === "useCard1") {
-				lib.skill.bingqing.init(player);
-				return false;
-			}
 			return Array.from({ length: 3 })
 				.map((_, i) => i + 2)
 				.includes(
@@ -8386,27 +8380,6 @@ const skills = {
 					await target.damage();
 					break;
 			}
-		},
-		init(player) {
-			if (player.isPhaseUsing()) {
-				const evt = _status.event.getParent("phaseUse");
-				let suits = player
-					.getHistory("useCard", evtx => {
-						const suit = get.suit(evtx.card);
-						if (!lib.suit.includes(suit)) return false;
-						return evtx.getParent("phaseUse") == evt;
-					})
-					.slice()
-					.map(evtx => get.suit(evtx.card))
-					.unique();
-				if (suits.length) {
-					suits.sort((a, b) => lib.suit.indexOf(b) - lib.suit.indexOf(a));
-					player.addTip("bingqing", "秉清 " + suits.reduce((str, suit) => str + get.translation(suit), ""), "phaseUseAfter");
-				}
-			}
-		},
-		onremove(player, skill) {
-			player.removeTip(skill);
 		},
 	},
 	yingfeng: {
@@ -11518,12 +11491,9 @@ const skills = {
 			let es = event.source.getEquips(1).filter(card => {
 				return lib.filter.canBeGained(card, player, event.source);
 			});
-			if (get.attitude(player, event.source) > 0)
-				return (
-					es.reduce((acc, card) => {
-						return acc + get.value(card, event.source);
-					}, 0) < 0 || event.source.hasSkillTag("noe")
-				);
+			if (get.attitude(player, event.source) > 0) return es.reduce((acc, card) => {
+				return acc + get.value(card, event.source);
+			}, 0) < 0 || event.source.hasSkillTag("noe");
 			return es.reduce((acc, card) => {
 				return acc + get.value(card, player);
 			}, 0);
@@ -15416,7 +15386,7 @@ const skills = {
 			},
 		},
 		ai: {
-			notemp: true,
+			notemp: true
 		},
 		group: ["rebiaozhao2", "rebiaozhao3"],
 	},
@@ -17336,18 +17306,14 @@ const skills = {
 			var bool = get.position(card) == "e";
 			if (bool) player.removeEquipTrigger(card.card || card);
 			game.addVideo("skill", player, ["xinfu_jingxie", [bool, get.cardInfo(card)]]);
-			game.broadcastAll(
-				function (card, bool) {
-					card.init([card.suit, card.number, "rewrite_" + card.name]);
-					if (bool && card.card && player.vcardsMap?.equips) {
-						const cardx = game.createCard("rewrite_" + card.card.name, card.card.suit, card.card.number);
-						player.vcardsMap.equips[player.vcardsMap.equips.indexOf(card.card)] = cardx;
-						card.card = cardx;
-					}
-				},
-				card,
-				bool
-			);
+			game.broadcastAll(function (card, bool) {
+				card.init([card.suit, card.number, "rewrite_" + card.name]);
+				if (bool && card.card && player.vcardsMap?.equips) {
+					const cardx = game.createCard("rewrite_" + card.card.name, card.card.suit, card.card.number);
+					player.vcardsMap.equips[player.vcardsMap.equips.indexOf(card.card)] = cardx;
+					card.card = cardx;
+				}
+			}, card, bool);
 			if (bool) player.addEquipTrigger(card.card || card);
 		},
 		ai: {

--- a/character/shenhua/skill.js
+++ b/character/shenhua/skill.js
@@ -2260,32 +2260,28 @@ const skills = {
 				return 20 * val;
 			},
 		},
-		trigger: { player: ["useCardAfter", "useCardToTargeted", "useCard1"] },
+		trigger: { player: ["useCardAfter", "useCardToTargeted"] },
 		prompt2(event, player) {
 			const cards = event.cards.filterInD("oe");
 			return "你可以将" + get.translation(cards) + (cards.length > 1 ? "以任意顺序" : "") + "置于牌堆顶，然后摸一张牌";
 		},
-		filter(event, player, name) {
-			let evt = event.name == "useCard" ? event : event.getParent();
-			let type = get.type2(evt.card, false);
-			if (
-				player.hasHistory(
-					"useCard",
-					evtx => {
-						return evtx != evt && get.type2(evtx.card, false) == type;
-					},
-					evt
-				)
-			)
-				return false;
-			if (name === "useCard1") {
-				lib.skill.nzry_shicai.init(player);
-				return false;
-			}
-			if (!event.cards.someInD("oe")) return false;
+		filter(event, player) {
+			if (!event.cards.someInD()) return false;
+			let evt = event,
+				type = get.type2(evt.card, false);
 			if (event.name == "useCardToTargeted") {
-				return type == "equip" && player == event.target;
-			} else return type !== "equip";
+				if (type != "equip" || player != event.target) return false;
+				evt = evt.getParent();
+			} else {
+				if (type == "equip") return false;
+			}
+			return !player.hasHistory(
+				"useCard",
+				evtx => {
+					return evtx != evt && get.type2(evtx.card, false) == type;
+				},
+				evt
+			);
 		},
 		check(event, player) {
 			if (get.type(event.card) == "equip") {
@@ -2323,28 +2319,7 @@ const skills = {
 			game.log(player, "将", cards, "置于了牌堆顶");
 			await player.draw();
 		},
-		init(player) {
-			const types = player
-				.getHistory("useCard")
-				.slice()
-				.map(evt => get.translation(get.type2(evt.card, false))[0] || "")
-				.unique();
-			if (types.length) {
-				player.addTip("nzry_shicai", "恃才 " + types.slice().join(" "), true);
-			}
-		},
-		onremove(player, skill) {
-			player.removeTip(skill);
-		},
-		subSkill: {
-			2: {
-				audio: 2,
-				charlotte: true,
-				onremove(player, skill) {
-					player.removeTip(skill);
-				},
-			},
-		},
+		subSkill: { 2: { audio: 2 } },
 		ai: {
 			reverseOrder: true,
 			skillTagFilter(player) {
@@ -2400,7 +2375,7 @@ const skills = {
 		},
 		group: ["nzry_mingren_1", "nzry_mingren_2"],
 		ai: {
-			notemp: true,
+			notemp: true
 		},
 		subSkill: {
 			1: {
@@ -2624,13 +2599,10 @@ const skills = {
 					player.changeZhuanhuanji("nzry_shenshi");
 					await player.give(event.cards, target);
 					await target.damage("nocard");
-					if (
-						!game.getGlobalHistory("everything", evt => {
-							if (evt.name != "die" || evt.player != target) return false;
-							return evt.reason?.getParent() == event;
-						}).length
-					)
-						return;
+					if (!game.getGlobalHistory("everything", evt => {
+						if (evt.name != "die" || evt.player != target) return false;
+						return evt.reason?.getParent() == event;
+					}).length) return;
 					const { result } = await player
 						.chooseTarget("令一名角色将手牌摸至四张", function (card, player, target) {
 							return target.countCards("h") < 4;
@@ -3713,7 +3685,7 @@ const skills = {
 			},
 			nodiscard: true,
 			nolose: true,
-			notemp: true,
+			notemp: true
 		},
 	},
 	zaoxian: {
@@ -6281,7 +6253,7 @@ const skills = {
 			}
 		},
 		ai: {
-			combo: "moon_jushou",
+			combo: "moon_jushou"
 		},
 	},
 	releiji: {

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -677,7 +677,7 @@ const skills = {
 						for (const t of types) await player.disableEquip(t);
 						const num = Math.min(target.hasDisabledSlot() + target.isDamaged() + 1, types.length),
 							selected = [];
-						while(selected.length < num) {
+						while (selected.length < num) {
 							const result = await target
 								.chooseButton(
 									[
@@ -695,7 +695,7 @@ const skills = {
 								.set("forceAuto", true)
 								.set("filterButton", button => {
 									const player = get.event().player;
-									if(get.event("selected").includes(button.link)) return false;
+									if (get.event("selected").includes(button.link)) return false;
 									switch (button.link) {
 										case "equip":
 											return player.hasDisabledSlot();
@@ -5211,7 +5211,7 @@ const skills = {
 				var info = lib.skill.olgangshu.getInfo(player);
 				info[result.index] = Math.min(5, info[result.index] + 1);
 				game.log(player, "的", result.control.slice(0, result.control.indexOf("(")), "#y+1");
-				lib.skill.olgangshu.init(player);
+				player.markSkill("olgangshu_buff");
 			}
 		},
 		ai: {
@@ -5221,10 +5221,7 @@ const skills = {
 			buff: {
 				trigger: { player: "phaseDrawBegin2" },
 				charlotte: true,
-				onremove(player, skill) {
-					delete player.storage[skill];
-					lib.skill.olgangshu.init(player);
-				},
+				onremove: true,
 				forced: true,
 				filter: function (event, player) {
 					var info = lib.skill.olgangshu.getInfo(player);
@@ -5235,7 +5232,7 @@ const skills = {
 					var info = lib.skill.olgangshu.getInfo(player);
 					trigger.num += info[1];
 					info[1] = 0;
-					lib.skill.olgangshu.init(player);
+					player.markSkill("olgangshu_buff");
 				},
 				mod: {
 					attackRange: function (player, range) {
@@ -5248,6 +5245,7 @@ const skills = {
 						if (info) return num + info[2];
 					},
 				},
+				mark: true,
 				intro: {
 					markcount: function (storage, player) {
 						var info = lib.skill.olgangshu.getInfo(player);
@@ -11800,8 +11798,8 @@ const skills = {
 		audio: 2,
 		init(player, name) {
 			let list = [1, 2, 3, 4];
-			if(!player.storage[name]) player.storage[name] = list;
-			player.addTip("shanduan", "善断 " +  player.storage[name].slice().join(" "));
+			if (!player.storage[name]) player.storage[name] = list;
+			player.addTip("shanduan", "善断 " + player.storage[name].slice().join(" "));
 		},
 		onremove(player, name) {
 			player.removeTip(name);
@@ -18996,20 +18994,11 @@ const skills = {
 		locked: false,
 		preHidden: true,
 		filter: function (event, player) {
-			let all = player.getHistory("useCard").length + player.getHistory("respond").length;
-			player.addTip("gzjili", "蒺藜 " + all.toString(), true);
-			return all == player.getAttackRange();
+			return player.getHistory("useCard").length + player.getHistory("respond").length == player.getAttackRange();
 		},
 		audio: 2,
 		content: function () {
 			player.draw(player.getHistory("useCard").length + player.getHistory("respond").length);
-		},
-		init(player) {
-			let all = player.getHistory("useCard").length + player.getHistory("respond").length;
-			if (all) player.addTip("gzjili", "蒺藜 " + all.toString(), true);
-		},
-		onremove(player, skill) {
-			player.removeTip(skill);
 		},
 		ai: {
 			threaten: 1.8,
@@ -19059,14 +19048,6 @@ const skills = {
 					} else if (get.tag(card, "respondSha") > 0) {
 						if (current < 0 && used == target.getAttackRange() - 1 && target.mayHaveSha(player)) return [1, (used + 1) / 2];
 					}
-				},
-			},
-		},
-		subSkill: {
-			count: {
-				charlotte: true,
-				onremove(player, skill) {
-					player.removeTip(skill);
 				},
 			},
 		},

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -6676,10 +6676,10 @@ const skills = {
 			return targets.length == 3 && targets.includes(player);
 		},
 		content: function () {
-			"step 0"
+			"step 0";
 			player.awakenSkill("olhuiqi");
-			if(player.isDamaged()) player.recover();
-			"step 1"
+			if (player.isDamaged()) player.recover();
+			"step 1";
 			player.addSkills("olxieju");
 		},
 	},
@@ -11782,13 +11782,8 @@ const skills = {
 	//周处
 	shanduan: {
 		audio: 2,
-		init(player, name) {
-			let list = [1, 2, 3, 4];
-			if (!player.storage[name]) player.storage[name] = list;
-			player.addTip("shanduan", "善断 " + player.storage[name].slice().join(" "));
-		},
-		onremove(player, name) {
-			player.removeTip(name);
+		init: function (player, name) {
+			player.storage[name] = [1, 2, 3, 4];
 		},
 		trigger: { player: "damageEnd" },
 		filter: (event, player) => player != _status.currentPhase,
@@ -11810,7 +11805,6 @@ const skills = {
 					break;
 				}
 			}
-			lib.skill.shanduan.init(player, "shanduan");
 			game.delayx();
 		},
 		group: ["shanduan_draw", "shanduan_use", "shanduan_discard"],
@@ -11833,7 +11827,6 @@ const skills = {
 					if (!list) {
 						trigger.getParent()._shanduan = (player.storage.shanduan || [1, 2, 3, 4]).slice(0);
 						player.storage.shanduan = [1, 2, 3, 4];
-						player.addTip("shanduan", "善断 " + trigger.getParent()._shanduan.slice().join(" "));
 					}
 					"step 1";
 					var list = trigger.getParent()._shanduan;
@@ -11849,7 +11842,6 @@ const skills = {
 					var num = list[result.index];
 					trigger.num = num;
 					list.remove(num);
-					player.addTip("shanduan", "善断 " + (list.length ? list : player.storage.shanduan).slice().join(" "));
 					game.log(player, "给", "#g摸牌阶段的摸牌数", "分配的数值是", "#y" + num);
 				},
 			},
@@ -11912,7 +11904,6 @@ const skills = {
 					player.storage.shanduan_effect.range = num;
 					player.addTempSkill("shanduan_effect");
 					list.remove(num);
-					player.addTip("shanduan", "善断 " + (list.length ? list : player.storage.shanduan).slice().join(" "));
 					game.log(player, "给", "#g攻击范围的基数", "分配的数值是", "#y" + num);
 					if (list.length == 0) event.finish();
 					else if (list.length == 1) event._result = { index: 0 };
@@ -11942,9 +11933,8 @@ const skills = {
 					var num = list[result.index];
 					if (!player.storage.shanduan_effect) player.storage.shanduan_effect = {};
 					player.storage.shanduan_effect.sha = num;
-					list.remove(num);
-					player.addTip("shanduan", "善断 " + (list.length ? list : player.storage.shanduan).slice().join(" "));
 					game.log(player, "给", "#g使用【杀】的次数上限", "分配的数值是", "#y" + num);
+					list.remove(num);
 				},
 			},
 			discard: {
@@ -11978,7 +11968,6 @@ const skills = {
 					player.storage.shanduan_effect.limit = num;
 					player.addTempSkill("shanduan_effect");
 					list.remove(num);
-					player.addTip("shanduan", "善断 " + (list.length ? list : player.storage.shanduan).slice().join(" "));
 					game.log(player, "给", "#g手牌上限的基数", "分配的数值是", "#y" + num);
 				},
 			},
@@ -27782,7 +27771,7 @@ const skills = {
 					"摸一张牌" + (player == trigger.player ? "" : "，将所有手牌交给" + get.translation(player) + "，然后其交给你等量张牌")
 				)
 				.set("ai", () => get.event("choice"))
-				.set("choice", function() {
+				.set("choice", function () {
 					let num = player.countCards("h"), att = get.attitude(trigger.player, player);
 					if (num == 0) return true;
 					if (num == 1) return att > -1;

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -39,26 +39,25 @@ const skills = {
 				audio: "olrenxia",
 				async content(event, trigger, player) {
 					while (true) {
-						await player.chooseToDiscard(2, "he", true).set("ai", card => {
-							let player = get.player();
-							let bool = card => get.type(card) == "trick" && get.tag(card, "damage");
-							if (player.countCards("h", bool) == 1 && bool(card)) return 10 - get.value(card);
-							else if (card.name == "sha") return 9 - get.value(card);
-							return 5 - get.value(card);
-						});
+						await player
+							.chooseToDiscard(2, "he", true)
+							.set("ai", card => {
+								let player = get.player();
+								let bool = card => get.type(card) == "trick" && get.tag(card, "damage");
+								if (player.countCards("h", bool) == 1 && bool(card)) return 10 - get.value(card);
+								else if (card.name == "sha") return 9 - get.value(card);
+								return 5 - get.value(card);
+							});
 						if (!player.countCards("h", card => card.name == "sha")) break;
 						if (!player.countCards("h", card => get.type(card) == "trick" && get.tag(card, "damage"))) break;
 					}
 					const evt = event.getParent("phaseUse", true);
 					if (!evt || event.name == "renxia_discard") return;
-					player
-						.when("phaseUseEnd")
-						.filter(evtx => evtx == evt)
-						.then(() => {
-							const next = game.createEvent("renxia_draw", false);
-							next.player = player;
-							next.setContent(lib.skill.olrenxia_draw.content);
-						});
+					player.when("phaseUseEnd").filter(evtx => evtx == evt).then(() => {
+						const next = game.createEvent("renxia_draw", false);
+						next.player = player;
+						next.setContent(lib.skill.olrenxia_draw.content);
+					});
 				},
 			},
 			draw: {
@@ -71,14 +70,11 @@ const skills = {
 					}
 					const evt = event.getParent("phaseUse", true);
 					if (!evt || event.name == "renxia_draw") return;
-					player
-						.when("phaseUseEnd")
-						.filter(evtx => evtx == evt)
-						.then(() => {
-							const next = game.createEvent("renxia_discard", false);
-							next.player = player;
-							next.setContent(lib.skill.olrenxia_discard.content);
-						});
+					player.when("phaseUseEnd").filter(evtx => evtx == evt).then(() => {
+						const next = game.createEvent("renxia_discard", false);
+						next.player = player;
+						next.setContent(lib.skill.olrenxia_discard.content);
+					});
 				},
 			},
 		},
@@ -438,16 +434,14 @@ const skills = {
 			return target?.isIn();
 		},
 		getIndex(event, player) {
-			return game
-				.filterPlayer(target => {
-					if (target == player) return false;
-					if (!player.storage.oljinghua && target.isHealthy()) return false;
-					const cards = event.getg(target);
-					if (!cards.length) return false;
-					if (event.giver === player) return true;
-					return event.getl && event.getl(player)?.cards2?.some(card => cards.includes(card));
-				})
-				.sortBySeat();
+			return game.filterPlayer(target => {
+				if (target == player) return false;
+				if (!player.storage.oljinghua && target.isHealthy()) return false;
+				const cards = event.getg(target);
+				if (!cards.length) return false;
+				if (event.giver === player) return true;
+				return event.getl && event.getl(player)?.cards2?.some(card => cards.includes(card));
+			}).sortBySeat();
 		},
 		logTarget(event, player, triggername, target) {
 			return target;
@@ -6682,10 +6676,10 @@ const skills = {
 			return targets.length == 3 && targets.includes(player);
 		},
 		content: function () {
-			"step 0";
+			"step 0"
 			player.awakenSkill("olhuiqi");
-			if (player.isDamaged()) player.recover();
-			"step 1";
+			if(player.isDamaged()) player.recover();
+			"step 1"
 			player.addSkills("olxieju");
 		},
 	},
@@ -7451,32 +7445,24 @@ const skills = {
 				});
 			}
 			event.map = map;
-			var func = function (map) {
-				game.countPlayer(function (target) {
-					var str = "";
-					str += "体力值";
-					if (player.getStorage("olzhuyan_false").includes(target)) str += "--<br>";
-					else {
-						var num = lib.skill.olzhuyan.getNum(target, false);
-						str += (num >= 0 ? "+" : "") + num + "<br>";
-					}
-					str += "手牌数";
-					if (player.getStorage("olzhuyan_true").includes(target)) str += "--<br>";
-					else {
-						var num = lib.skill.olzhuyan.getNum(target, true);
-						str += (num >= 0 ? "+" : "") + num + "<br>";
-					}
-					target.prompt(str);
-				});
-			};
-			if (event.player == game.me) func(map);
-			else if (event.isOnline()) player.send(func, map);
 			player
 				.chooseTarget(get.prompt("olzhuyan"), "令一名角色将{体力值/手牌数}调整至与其上个结束阶段相同(“--”表示已对其发动过该分支)", (card, player, target) => {
 					var list = _status.event.map[target.playerid];
 					return list && (list[0] || list[1]);
 				})
 				.set("map", map)
+				.set("targetprompt", target => {
+					var list = _status.event.map[target.playerid];
+					var str = "";
+					for (var i = 0; i < 2; i++) {
+						if (list[i] === undefined) str += "--";
+						else {
+							str += (list[i] > 0 ? "+" : "") + list[i];
+						}
+						str += "/";
+					}
+					return str.slice(0, -1);
+				})
 				.set("ai", target => {
 					var list = _status.event.map[target.playerid];
 					var att = get.attitude(_status.event.player, target);
@@ -17103,7 +17089,7 @@ const skills = {
 		},
 		intro: { content: "mark" },
 		ai: {
-			notemp: true,
+			notemp: true
 		},
 		group: ["reluanzhan_add", "reluanzhan_remove"],
 	},
@@ -24656,7 +24642,7 @@ const skills = {
 					if (hs > target.hp && target.hp > 3 && (card.name === "shan" || card.name === "wuxie")) return "zeroplayertarget";
 				},
 			},
-			combo: "new_rewusheng",
+			combo: "new_rewusheng"
 		},
 	},
 	nuzhan: {
@@ -25099,7 +25085,9 @@ const skills = {
 			let num = 1,
 				evt = trigger.getParent();
 			if (evt.qirang_num) num += evt.qirang_num;
-			const result = await player.chooseToGuanxing(Math.min(5, num)).set("prompt", "观星：点击或拖动将牌移动到牌堆顶或牌堆底").forResult();
+			const result = await player.chooseToGuanxing(Math.min(5, num))
+				.set("prompt", "观星：点击或拖动将牌移动到牌堆顶或牌堆底")
+				.forResult();
 			if ((!result.bool || !result.moved[0].length) && event.triggername == "phaseZhunbeiBegin") {
 				player.addTempSkill("guanxing_fail");
 			}
@@ -25115,8 +25103,8 @@ const skills = {
 			},
 		},
 		ai: {
-			guanxing: true,
-		},
+			guanxing: true
+		}
 	},
 	chenqing: {
 		audio: 2,
@@ -25623,7 +25611,7 @@ const skills = {
 		},
 		ai: {
 			combo: "biluan",
-			halfneg: true,
+			halfneg: true
 		},
 	},
 	olbiluan: {
@@ -25704,7 +25692,7 @@ const skills = {
 		},
 		ai: {
 			combo: "rebiluan",
-			halfneg: true,
+			halfneg: true
 		},
 	},
 	rebiluan2: {
@@ -25846,7 +25834,7 @@ const skills = {
 		},
 		ai: {
 			combo: "olbiluan",
-			halfneg: true,
+			halfneg: true
 		},
 	},
 	guiming: {
@@ -27789,19 +27777,18 @@ const skills = {
 		},
 		async cost(event, trigger, player) {
 			event.result = await trigger.player
-				.chooseBool(player == trigger.player ? get.prompt("rejunbing") : "是否响应" + get.translation(player) + "的【郡兵】？", "摸一张牌" + (player == trigger.player ? "" : "，将所有手牌交给" + get.translation(player) + "，然后其交给你等量张牌"))
-				.set("ai", () => get.event("choice"))
-				.set(
-					"choice",
-					(function () {
-						let num = player.countCards("h"),
-							att = get.attitude(trigger.player, player);
-						if (num == 0) return true;
-						if (num == 1) return att > -1;
-						if (num == 2) return att > 0;
-						return att > 1;
-					})()
+				.chooseBool(
+					player == trigger.player ? get.prompt("rejunbing") : "是否响应" + get.translation(player) + "的【郡兵】？",
+					"摸一张牌" + (player == trigger.player ? "" : "，将所有手牌交给" + get.translation(player) + "，然后其交给你等量张牌")
 				)
+				.set("ai", () => get.event("choice"))
+				.set("choice", function() {
+					let num = player.countCards("h"), att = get.attitude(trigger.player, player);
+					if (num == 0) return true;
+					if (num == 1) return att > -1;
+					if (num == 2) return att > 0;
+					return att > 1;
+				}())
 				.forResult();
 		},
 		async content(event, trigger, player) {
@@ -27813,27 +27800,28 @@ const skills = {
 				return;
 			}
 			await target.give(cards, player);
-			let num = cards.length,
-				result;
-			if (player.countCards("he") > num)
-				result = await player
-					.chooseCard("郡兵：请还给" + get.translation(target) + get.translation(num) + "张牌", "he", true, num)
-					.set("ai", card => {
-						let player = _status.event.player,
-							target = get.event("target");
-						if (get.attitude(player, target) <= 0) {
-							if (card.name == "du") return 30;
-							return -get.value(card);
-						}
-						return 6 - get.value(card);
-					})
-					.set("target", target)
-					.forResult();
-			else
-				result = {
-					bool: player.hasCard(i => true, "he"),
-					cards: player.getCards("he"),
-				};
+			let num = cards.length, result;
+			if (player.countCards("he") > num) result = await player
+				.chooseCard(
+					"郡兵：请还给" + get.translation(target) + get.translation(num) + "张牌",
+					"he",
+					true,
+					num
+				)
+				.set("ai", card => {
+					let player = _status.event.player, target = get.event("target");
+					if (get.attitude(player, target) <= 0) {
+						if (card.name == "du") return 30;
+						return -get.value(card);
+					}
+					return 6 - get.value(card);
+				})
+				.set("target", target)
+				.forResult();
+			else result = {
+				bool: player.hasCard(i => true, "he"),
+				cards: player.getCards("he")
+			};
 			if (result.bool) await player.give(result.cards, target);
 		},
 	},
@@ -29002,13 +28990,9 @@ const skills = {
 						return;
 					await game.delay();
 					const { targets } = await player
-						.chooseTarget(
-							true,
-							function (card, player, target) {
-								return get.distance(_status.event.thisTarget, target) <= 1 && target.countCards("hej");
-							},
-							"选择一名与" + get.translation(target) + "距离1以内的角色，弃置其一张牌"
-						)
+						.chooseTarget(true, function (card, player, target) {
+							return get.distance(_status.event.thisTarget, target) <= 1 && target.countCards("hej");
+						}, "选择一名与" + get.translation(target) + "距离1以内的角色，弃置其一张牌")
 						.set("ai", function (target) {
 							var attitude = get.attitude(_status.event.player, target);
 							if (attitude > 0 && target.countCards("j")) {
@@ -29622,8 +29606,8 @@ const skills = {
 			}
 		},
 		ai: {
-			combo: "xinfu_xionghuo",
-		},
+			combo: "xinfu_xionghuo"
+		}
 	},
 	xinfu_jianjie: { audio: 3 },
 	jianjie: {

--- a/character/xianding/skill.js
+++ b/character/xianding/skill.js
@@ -249,10 +249,10 @@ const skills = {
 						if (!owner) return false;
 						let att = get.attitude(player, owner);
 						if (get.position(card) == "j" && (card.viewAs || card.name) == "jsrg_xumou") att *= -1;
-						if (get.position(card) == "e" && get.equipValue(card, owner) > 0) att*= -1;
+						if (get.position(card) == "e" && get.equipValue(card, owner) > 0) att *= -1;
 						return att > 0;
 					});
-					if(valueCards.length * 2 >= cards.length) return "场上";
+					if (valueCards.length * 2 >= cards.length) return "场上";
 					return "牌堆";
 				})
 				.set("prompt", get.prompt2("dcchaozhen"))
@@ -313,7 +313,7 @@ const skills = {
 		},
 		check(event, player) {
 			if (player.countCards("h") < 2 || !player.isPhaseUsing()) return true;
-			if (player.countCards("h", card => player.hasValueTarget(card) && !player.countCards("h", cardx =>{
+			if (player.countCards("h", card => player.hasValueTarget(card) && !player.countCards("h", cardx => {
 				return get.number(cardx, player) < get.number(card, player);
 			}) && !player.getStorage("dclianjie_used").includes(get.number(card, player)))) return false;
 			return true;
@@ -15911,13 +15911,12 @@ const skills = {
 				}).setContent("gaincardMultiple");
 			}
 		},
-		init(player) {
-			var list = lib.skill.yuqi.getInfo(player);
-			player.addTip("yuqi", "隅泣 " + list.slice().join(" "));
-		},
-		onremove(player, name) {
-			player.removeTip(name);
-			delete player.storage[name];
+		mark: true,
+		intro: {
+			content: function (storage, player) {
+				var info = lib.skill.yuqi.getInfo(player);
+				return '<div class="text center"><span class=thundertext>蓝色：' + info[0] + "</span>　<span class=firetext>红色：" + info[1] + "</span><br><span class=greentext>绿色：" + info[2] + "</span>　<span class=yellowtext>黄色：" + info[3] + "</span></div>";
+			},
 		},
 		ai: {
 			threaten: 8.8,
@@ -15964,7 +15963,7 @@ const skills = {
 				var list = lib.skill.yuqi.getInfo(player);
 				list[result.index] = Math.min(5, list[result.index] + 2);
 				game.log(player, "将", result.control, "数字改为", "#y" + list[result.index]);
-				player.addTip("yuqi", "隅泣 " + list.slice().join(" "));
+				player.markSkill("yuqi");
 				if (event.goon) player.recover();
 			}
 		},
@@ -16010,7 +16009,7 @@ const skills = {
 				var list = lib.skill.yuqi.getInfo(player);
 				list[result.index] = Math.min(5, list[result.index] + 1);
 				game.log(player, "将", result.control, "数字改为", "#y" + list[result.index]);
-				player.addTip("yuqi", "隅泣 " + list.slice().join(" "));
+				player.markSkill("yuqi");
 				if (player.isDamaged()) event.finish();
 			} else event.finish();
 			"step 2";
@@ -16044,7 +16043,7 @@ const skills = {
 				var list = lib.skill.yuqi.getInfo(player);
 				list[result.index] = Math.min(5, list[result.index] + 1);
 				game.log(player, "将", result.control, "数字改为", "#y" + list[result.index]);
-				player.addTip("yuqi", "隅泣 " + list.slice().join(" "));
+				player.markSkill("yuqi");
 			}
 		},
 		ai: {
@@ -16151,7 +16150,7 @@ const skills = {
 			const list = ["选项一：摸两张牌", "选项二：对一名其他角色造成1点伤害，且本回合对其使用【杀】无距离和次数限制", "选项三：本回合手牌上限视为无限", "选项四：获得一名其他角色区域内的一张牌", "选项五：令一名其他角色将手牌数摸至体力上限（至多摸至五张）"],
 				num = Math.min(5, player.getDamagedHp() + 1),
 				selected = [];
-			while(selected.length < num) {
+			while (selected.length < num) {
 				const result = await player
 					.chooseButton([
 						"玉陨：是否选择一项执行？",
@@ -16234,7 +16233,7 @@ const skills = {
 										return get.damageEffect(target, player, player);
 									})
 									.forResult();
-								if(result2.bool) {
+								if (result2.bool) {
 									const target = result2.targets[0];
 									player.line(target, "green");
 									await target.damage();
@@ -16268,7 +16267,7 @@ const skills = {
 						}
 						case 4: {
 							if (game.hasPlayer(function (current) {
-									return current != player && current.countCards("h") < Math.min(5, current.maxHp);
+								return current != player && current.countCards("h") < Math.min(5, current.maxHp);
 							})) {
 								const result2 = await player
 									.chooseTarget(true, "令一名其他角色将手牌数摸至体力上限", function (card, player, current) {

--- a/character/yijiang/skill.js
+++ b/character/yijiang/skill.js
@@ -526,17 +526,17 @@ const skills = {
 								todis = source.countCards("h") - source.needsToDiscard();
 							if (
 								todis <=
-									Math.max(
-										Math.min(
-											2 + (source.hp <= 1 ? 1 : 0),
-											player.countCards("he", function (card) {
-												return get.value(card, player) < Math.max(5.5, 8 - todis);
-											})
-										),
+								Math.max(
+									Math.min(
+										2 + (source.hp <= 1 ? 1 : 0),
 										player.countCards("he", function (card) {
-											return get.value(card, player) <= 0;
+											return get.value(card, player) < Math.max(5.5, 8 - todis);
 										})
-									) &&
+									),
+									player.countCards("he", function (card) {
+										return get.value(card, player) <= 0;
+									})
+								) &&
 								get.damageEffect(source, player, player) > 0
 							)
 								return false;
@@ -825,13 +825,13 @@ const skills = {
 			var func = function () {
 				game.countPlayer(function (target) {
 					var list = ["摸牌", "弃牌", "制衡"].filter(function (control) {
-							var storage = player.getStorage("xinyaoming_kanon");
-							if (storage.includes(control)) return false;
-							if (control == "摸牌" && target != player) return true;
-							if (control == "弃牌" && target != player && target.countCards("h")) return true;
-							if (control == "制衡") return true;
-							return false;
-						}),
+						var storage = player.getStorage("xinyaoming_kanon");
+						if (storage.includes(control)) return false;
+						if (control == "摸牌" && target != player) return true;
+						if (control == "弃牌" && target != player && target.countCards("h")) return true;
+						if (control == "制衡") return true;
+						return false;
+					}),
 						str = "";
 					for (var i of list) str += i + "<br>";
 					str = str.slice(0, -4);
@@ -5367,7 +5367,7 @@ const skills = {
 		filter: function (event, player) {
 			return event.card.name == "sha" && !event.skill && event.cards.length == 1 && event.cards[0].name == "jiu";
 		},
-		content: function () {},
+		content: function () { },
 	},
 	xinxianzhen: {
 		audio: "xianzhen",
@@ -6007,7 +6007,7 @@ const skills = {
 		filter: function (event, player) {
 			return player.isPhaseUsing();
 		},
-		content: function () {},
+		content: function () { },
 		mod: {
 			globalFrom: function (from, to, distance) {
 				if (_status.currentPhase == from) {
@@ -6888,7 +6888,7 @@ const skills = {
 		filter: function (event, player) {
 			return event.card.name == "sha" && !event.skill && event.cards.length == 1 && event.cards[0].name == "shan";
 		},
-		content: function () {},
+		content: function () { },
 	},
 	wurong: {
 		enable: "phaseUse",
@@ -7089,7 +7089,7 @@ const skills = {
 				player(player, target) {
 					let td = get.damageEffect(target, player, target);
 					if (!td) return 0;
-					let hs = player.getCards("h"), 
+					let hs = player.getCards("h"),
 						val = hs.reduce((acc, i) => acc - get.value(i, player), 0) / 6 + 1;
 					if (td > 0) return val;
 					if (player.hasSkillTag(
@@ -7945,11 +7945,11 @@ const skills = {
 				case "red":
 					if (event.target.hp < event.target.maxHp) event.target.recover();
 					break;
-			
+
 				case "black":
 					event.target.draw(trigger.num);
 					break;
-					
+
 				default:
 					break;
 			}
@@ -9556,7 +9556,7 @@ const skills = {
 				case "red":
 					player.turnOver();
 					break;
-				
+
 				default:
 					break;
 			}
@@ -10794,9 +10794,9 @@ const skills = {
 			event._forcing = false;
 			event.aicheck = (function () {
 				let res = {
-						bool: true,
-						cards: [],
-					},
+					bool: true,
+					cards: [],
+				},
 					cards = player.getCards("he"),
 					tars = game.filterPlayer(i => player !== i);
 				cards.forEach(i => {
@@ -12637,12 +12637,9 @@ const skills = {
 		trigger: { player: "useCard" },
 		frequent: true,
 		filter: function (event, player) {
-			if (!player.isPhaseUsing()) return false;
-			if (get.suit(event.card) !== "none" && typeof get.number(event.card) === "number") {
-				player.addTip("jianying", "渐营 " + lib.skill.jianying.getTranslation(event.card), "phaseUseAfter");
-			}
 			var evt = player.getLastUsed(1);
 			if (!evt || !evt.card) return false;
+			if (!player.isPhaseUsing()) return false;
 			var evt2 = evt.getParent("phaseUse");
 			if (!evt2 || evt2.name != "phaseUse" || evt2 !== event.getParent("phaseUse")) return false;
 			return (get.suit(evt.card) != "none" && get.suit(evt.card) == get.suit(event.card)) || (typeof get.number(evt.card, false) == "number" && get.number(evt.card, false) == get.number(event.card));
@@ -12650,10 +12647,8 @@ const skills = {
 		content: function () {
 			player.draw();
 		},
-		getTranslation(card) {
-			return get.translation(get.suit(card)) + get.strNumber(get.number(card));
-		},
-		init(player) {
+		group: "jianying_mark",
+		init: function (player) {
 			if (player.isPhaseUsing()) {
 				var evt = _status.event.getParent("phaseUse");
 				var history = player.getHistory("useCard", function (evt2) {
@@ -12661,13 +12656,68 @@ const skills = {
 				});
 				if (history.length) {
 					var trigger = history[history.length - 1];
-					if (get.suit(trigger.card) == "none" || typeof get.number(trigger.card) != "number") return;
-					player.addTip("jianying", "渐营 " + lib.skill.jianying.getTranslation(trigger.card), "phaseUseAfter");
+					if (get.suit(trigger.card, player) == "none" || typeof get.number(trigger.card, player) != "number") return;
+					player.storage.jianying_mark = trigger.card;
+					player.markSkill("jianying_mark");
+					game.broadcastAll(
+						function (player, suit) {
+							if (player.marks.jianying_mark) player.marks.jianying_mark.firstChild.innerHTML = get.translation(suit);
+						},
+						player,
+						get.suit(trigger.card, player)
+					);
+					player.when("phaseUseAfter").then(() => {
+						player.unmarkSkill("jianying_mark");
+						delete player.storage.jianying_mark;
+					});
 				}
 			}
 		},
-		onremove(player, skill) {
-			player.removeTip(skill);
+		onremove: function (player) {
+			player.unmarkSkill("jianying_mark");
+			delete player.storage.jianying_mark;
+		},
+		subSkill: {
+			mark: {
+				charlotte: true,
+				trigger: { player: "useCard1" },
+				filter: function (event, player) {
+					return player.isPhaseUsing();
+				},
+				forced: true,
+				popup: false,
+				firstDo: true,
+				content: function () {
+					if (get.suit(trigger.card, player) == "none" || typeof get.number(trigger.card, player) != "number") player.unmarkSkill("jianying_mark");
+					else {
+						player.storage.jianying_mark = trigger.card;
+						player.markSkill("jianying_mark");
+						game.broadcastAll(
+							function (player, suit) {
+								if (player.marks.jianying_mark) player.marks.jianying_mark.firstChild.innerHTML = get.translation(suit);
+							},
+							player,
+							get.suit(trigger.card, player)
+						);
+						player.when("phaseUseAfter").then(() => {
+							player.unmarkSkill("jianying_mark");
+							delete player.storage.jianying_mark;
+						});
+					}
+				},
+				intro: {
+					markcount(card, player) {
+						return get.strNumber(get.number(card, player));
+					},
+					content: function (card, player) {
+						var suit = get.suit(card, player);
+						var num = get.number(card, player);
+						var str = "<li>上一张牌的花色：" + get.translation(suit);
+						str += "<br><li>上一张牌的点数：" + get.strNumber(num);
+						return str;
+					},
+				},
+			},
 		},
 	},
 	zzhenggong: {


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->


### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->

      因为第一批技能幼龄化的过程中，删除了技能原有的mark,只保留了tip.
      讨论决定，将tip定位为辅助标记。还是以mark为主，tip针对需要醒目提示的关键信息，增强玩家的游戏体验，不能替代原有的mark的地位。
     后面会在原有mark的基础上逐步增加tip,以增加玩家的游戏体验，即使关掉tip，也不会对玩家造成影响。

<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->



### PR描述
<!-- 详细描述您的更改 -->



### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->



### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->



### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [ ] 我没有把该PR提交到`master`分支
- [ ] commit中没有无用信息，和没有具体内容的“bugfix”
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [ ] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [ ] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [ ] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [ ] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [ ] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [ ] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [ ] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
