### PR TITLE
临时修复新建牌堆的一个bug；非杀卡牌属性调整

### DIFF
--- a/card/extra.js
+++ b/card/extra.js
@@ -227,7 +227,7 @@ game.import("card", function () {
 				fullskin: true,
 				type: "trick",
 				enable: true,
-				//cardnature:'fire',
+				cardnature:'fire',
 				filterTarget: function (card, player, target) {
 					//if(player!=game.me&&player.countCards('h')<2) return false;
 					return target.countCards("h") > 0;
@@ -498,7 +498,6 @@ game.import("card", function () {
 				fullskin: true,
 				type: "equip",
 				subtype: "equip1",
-				//cardnature:'fire',
 				distance: { attackFrom: -3 },
 				ai: {
 					basic: {
@@ -523,7 +522,6 @@ game.import("card", function () {
 				fullskin: true,
 				type: "equip",
 				subtype: "equip2",
-				//cardnature:'fire',
 				ai: {
 					value: function (card, player, index, method) {
 						if (player.isDisabled(2)) return 0.01;
@@ -1006,7 +1004,6 @@ game.import("card", function () {
 					trigger.num++;
 				},
 				ai: {
-					fireAttack: true,
 					effect: {
 						target: function (card, player, target, current) {
 							if (card.name == "sha") {

--- a/card/guozhan.js
+++ b/card/guozhan.js
@@ -516,6 +516,7 @@ game.import("card", function () {
 				audio: "shuiyanqijun",
 				fullskin: true,
 				type: "trick",
+				cardnature: "thunder",
 				filterTarget: function (card, player, target) {
 					return (
 						target != player &&
@@ -1026,6 +1027,7 @@ game.import("card", function () {
 				fullskin: true,
 				audio: true,
 				type: "trick",
+				cardnature: "fire",
 				filterTarget: function (card, player, target) {
 					if (get.mode() == "guozhan") {
 						var next = player.getNext();

--- a/card/hearth.js
+++ b/card/hearth.js
@@ -6,6 +6,7 @@ game.import("card", function () {
 			linghunzhihuo: {
 				fullskin: true,
 				type: "trick",
+				cardnature: "fire",
 				enable: true,
 				filterTarget: true,
 				content: function () {
@@ -623,6 +624,7 @@ game.import("card", function () {
 			yuansuhuimie: {
 				fullskin: true,
 				type: "trick",
+				cardnature: "thunder",
 				enable: true,
 				selectTarget: -1,
 				filterTarget: true,

--- a/card/swd.js
+++ b/card/swd.js
@@ -637,6 +637,7 @@ game.import("card", function () {
 			jiguantong: {
 				fullskin: true,
 				type: "jiguan",
+				cardnature: "fire",
 				enable: true,
 				wuxieable: true,
 				selectTarget: -1,

--- a/card/xianxia.js
+++ b/card/xianxia.js
@@ -35,6 +35,7 @@ game.import("card", function () {
 				audio: true,
 				fullskin: true,
 				type: "trick",
+				cardnature: "fire",
 				derivation: "ty_luxun",
 				cardimage: "huoshaolianying",
 				enable: true,

--- a/card/yunchou.js
+++ b/card/yunchou.js
@@ -822,9 +822,9 @@ game.import("card", function () {
 						},
 					},
 					tag: {
-						// damage:1,
-						// natureDamage:1,
-						// fireDamage:1,
+						damage: 0.15,
+						natureDamage: 0.15,
+						fireDamage: 0.15,
 					},
 				},
 			},

--- a/character/mobile/card.js
+++ b/character/mobile/card.js
@@ -104,7 +104,6 @@ const cards = {
 		fullskin: true,
 		type: "equip",
 		subtype: "equip2",
-		//cardnature:"fire",
 		ai: {
 			equipValue: function (card, player) {
 				if (player.hasSkillTag("maixie") && player.hp > 1) return 0;

--- a/noname/init/onload.js
+++ b/noname/init/onload.js
@@ -167,18 +167,25 @@ export async function onload() {
 		}
 
 		lib.card.list = lib.card.list
-			.filter(cardData => cardData[2] && !lib.card[cardData[2]].mode?.includes(lib.config.mode))
-			.map(cardData => {
+			.filter(cardData => {
+				if (!cardData[2]) return false;
 				if (cardData[2] === "huosha") {
-					cardData = cardData.slice(0);
 					cardData[2] = "sha";
 					cardData[3] = "fire";
 				} else if (cardData[2] === "leisha") {
-					cardData = cardData.slice(0);
 					cardData[2] = "sha";
 					cardData[3] = "thunder";
+				} else if (cardData[2] === "icesha") {
+					cardData[2] = "sha";
+					cardData[3] = "ice";
+				} else if (cardData[2] === "cisha") {
+					cardData[2] = "sha";
+					cardData[3] = "stab";
+				} else if (cardData[2] === "kamisha") {
+					cardData[2] = "sha";
+					cardData[3] = "kami";
 				}
-				return cardData;
+				return lib.card[cardData[2]] && !lib.card[cardData[2]].mode?.includes(lib.config.mode);
 			});
 	}
 


### PR DESCRIPTION
 ### PR受影响的平台
无


### 诱因和背景
群友反馈



### PR描述
临时修复新建牌堆的一个bug，**但未能修复**添加属性杀不显示对应属性的问题；
为能造成属性伤害的卡牌增补了cardnature（目前只会在game.createCard里调用）；
调整了【火山】【浮雷】等属性伤害延时锦囊的tag

### PR测试
无



### 扩展适配
无



### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
