### PR TITLE
扑克牌点数接口开放，简化繁琐的特定点数列举

### DIFF
--- a/character/extra/skill.js
+++ b/character/extra/skill.js
@@ -4705,7 +4705,7 @@ const skills = {
 			if (result.bool) {
 				var card = result.cards[0];
 				var num = get.number(card);
-				if ([1, 11, 12, 13].includes(num)) {
+				if (typeof get.strNumber(num) === "string") {
 					if (lib.filter.canBeGained(card, player, target)) player.gain(card, target, "give", "bySelf");
 				} else if (lib.filter.canBeDiscarded(card, player, target)) target.discard(card);
 			} else event.finish();
@@ -4909,7 +4909,7 @@ const skills = {
 				audio: 2,
 				mod: {
 					cardname(card, player) {
-						if (player.storage.yuheng && [1, 11, 12, 13].includes(card.number)) {
+						if (player.storage.yuheng && typeof get.strNumber(card.number) === "string") {
 							var list = ["rezhiheng", "jiexun", "reanxu"];
 							for (var i of list) {
 								if (!player.storage.yuheng.includes(i)) return;

--- a/character/jsrg/skill.js
+++ b/character/jsrg/skill.js
@@ -11231,7 +11231,7 @@ const skills = {
 						} else break;
 					} else break;
 				}
-			} else if (numx < num) {
+			} else {
 				await player.drawTo(num);
 				player.addTempSkill("jsrgcuibing_keji");
 			}

--- a/character/sixiang/skill.js
+++ b/character/sixiang/skill.js
@@ -1405,16 +1405,16 @@ const skills = {
 			aiValue: (player, card, val) => {
 				if (card.name == "wuxie") return 0;
 				var num = get.number(card);
-				if ([1, 11, 12, 13].includes(num)) return 0;
+				if (typeof get.strNumber(num) === "string") return 0;
 			},
 			aiUseful: (player, card, val) => {
 				if (card.name == "wuxie") return 0;
 				var num = get.number(card);
-				if ([1, 11, 12, 13].includes(num)) return 0;
+				if (typeof get.strNumber(num) === "string") return 0;
 			},
 			aiOrder: (player, card, order) => {
 				var num = get.number(card);
-				if ([1, 11, 12, 13].includes(num)) return 0;
+				if (typeof get.strNumber(num) === "string") return 0;
 				return order;
 			},
 		},
@@ -1422,7 +1422,7 @@ const skills = {
 			player: "useCard",
 		},
 		filter(event, player) {
-			return [1, 11, 12, 13].includes(get.number(event.card));
+			return typeof get.strNumber(get.number(event.card)) === "string";
 		},
 		forced: true,
 		async content(event, trigger, player) {

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -5459,17 +5459,17 @@ const skills = {
 			aiValue: (player, card, val) => {
 				if (card.name == "wuxie") return 0;
 				var num = get.number(card);
-				if ([1, 11, 12, 13].includes(num)) return val * 1.1;
+				if (typeof get.strNumber(num) === "string") return val * 1.1;
 			},
 			aiUseful: (player, card, val) => {
 				if (card.name == "wuxie") return 0;
 				var num = get.number(card);
-				if ([1, 11, 12, 13].includes(num)) return val * 1.1;
+				if (typeof get.strNumber(num) === "string") return val * 1.1;
 			},
 			aiOrder: (player, card, order) => {
 				if (get.name(card) == "sha" && player.hasSkill("oltuishi_unlimit")) order += 9;
 				var num = get.number(card);
-				if ([1, 11, 12, 13].includes(num)) order += 3;
+				if (typeof get.strNumber(num) === "string") order += 3;
 				return order;
 			},
 		},
@@ -5489,7 +5489,7 @@ const skills = {
 						.indexOf(event) >= 2
 				);
 			}
-			return [1, 11, 12, 13].includes(get.number(event.card));
+			return typeof get.strNumber(get.number(event.card)) === "string";
 		},
 		forced: true,
 		content: function () {

--- a/character/xianding/skill.js
+++ b/character/xianding/skill.js
@@ -4751,22 +4751,7 @@ const skills = {
 			trigger.targets = [player, ...trigger.targets.remove(player)];
 			evtx.targets = [player, ...evtx.targets.remove(player)];
 			evtx.triggeredTargets4 = [player, ...evtx.triggeredTargets4.remove(player)];
-			player
-				.when({
-					global: "eventNeutralized",
-					target: ["useCardToBegin", "useCardToExcluded", "useCardToIgnored"],
-				})
-				.filter((evt, _, name) => {
-					if (evt.getParent().targets.length <= 1) return false;
-					if (name === "evtNeutralized") {
-						if (evt._neutralize_event.type != "card" || evt.type != "card") return false;
-						return evt._neutralize_event.card === trigger.card;
-					}
-					return evt.getParent() == trigger.getParent();
-				})
-				.then(() => {
-					player.draw(trigger.getParent().targets.length - 1);
-				});
+			await player.draw(evtx.targets.length - 1);
 		},
 	},
 	dczengou: {

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -2842,10 +2842,7 @@ export class Get extends GetCompatible {
 	 */
 	strNumber(num, forced) {
 		if (typeof num !== "number") return;
-		let result = lib.numstrList.entries().reduce((map, list) => {
-			map[list[0]] = list[1];
-			return map;
-		}, {})[num];
+		let result = lib.numstrList.get(num);
 		if (result === undefined && forced) result = num.toString();
 		return result;
 	}

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -2770,10 +2770,7 @@ export class Get extends GetCompatible {
 					}
 				}
 				if ((str.suit && str.number) || str.isCard) {
-					var cardnum = get.number(str, false) || "";
-					if ([1, 11, 12, 13].includes(cardnum)) {
-						cardnum = { 1: "A", 11: "J", 12: "Q", 13: "K" }[cardnum];
-					}
+					var cardnum = get.strNumber(get.number(str, false), true) || "";
 					if (arg == "viewAs" && str.viewAs != str.name && str.viewAs) {
 						str2 += "（" + get.translation(str) + "）";
 					} else {
@@ -2840,40 +2837,32 @@ export class Get extends GetCompatible {
 	/**
 	 * 返回数字在扑克牌中的表示形式
 	 * @param { number } num
+	 * @param { boolean } [forced] 未获取点数字母对应元素时是否返回字符串格式
 	 * @returns { string }
 	 */
-	strNumber(num) {
-		switch (num) {
-			case 1:
-				return "A";
-			case 11:
-				return "J";
-			case 12:
-				return "Q";
-			case 13:
-				return "K";
-			default:
-				return num.toString();
-		}
+	strNumber(num, forced) {
+		if (typeof num !== "number") return;
+		let result = lib.numstrList.entries().reduce((map, list) => {
+			map[list[0]] = list[1];
+			return map;
+		}, {})[num];
+		if (result === undefined && forced) result = num.toString();
+		return result;
 	}
 	/**
 	 * 返回扑克牌中的表示形式对应的数字
 	 * @param { string } str
+	 * @param { boolean } [forced] 未获取字母点数对应元素时是否返回数字格式
 	 * @returns { number }
 	 */
-	numString(str) {
-		switch (str) {
-			case "A":
-				return 1;
-			case "J":
-				return 11;
-			case "Q":
-				return 12;
-			case "K":
-				return 13;
-			default:
-				return parseInt(str);
-		}
+	numString(str, forced) {
+		if (typeof str !== "string") return;
+		let result = lib.numstrList.entries().reduce((map, list) => {
+			map[list[1]] = list[0];
+			return map;
+		}, {})[str];
+		if (result === undefined && forced) result = parseInt(str);
+		return result;
 	}
 	/**
 	 * 将阿拉伯数字转换为中文的表达形式

--- a/noname/library/element/card.js
+++ b/noname/library/element/card.js
@@ -311,23 +311,7 @@ export class Card extends HTMLDivElement {
 		var info = lib.card[card[2]];
 		var cardnum = card[1] || "";
 		if (parseInt(cardnum) == cardnum) cardnum = parseInt(cardnum);
-		if (cardnum > 0 && cardnum < 14) {
-			cardnum = [
-				"A",
-				"2",
-				"3",
-				"4",
-				"5",
-				"6",
-				"7",
-				"8",
-				"9",
-				"10",
-				"J",
-				"Q",
-				"K",
-			][cardnum - 1];
-		}
+		cardnum = get.strNumber(cardnum, true) || "";
 		if (this.name) {
 			this.classList.remove("epic");
 			this.classList.remove("legend");

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -13490,6 +13490,13 @@ export class Library {
 			},
 		},
 	};
+	//为lib.numstrList属性set数字对应花色，即可在get.strNumber和get.numString中获取使用
+	numstrList = new Map([
+		[1, "A"],
+		[11, "J"],
+		[12, "Q"],
+		[13, "K"],
+	]);
 	suit = ["club", "spade", "diamond", "heart"];
 	suits = ["club", "spade", "diamond", "heart", "none"];
 	color = {


### PR DESCRIPTION
添加new Map类型`lib.numstrList`，存储特定点数的扑克牌花色显示
修改`get.strNumber`和`get.numString`函数适配`lib.numstrList`，函数见下
```
	/**
	 * 返回数字在扑克牌中的表示形式
	 * @param { number } num
	 * @param { boolean } [forced] 未获取点数字母对应元素时是否返回字符串格式
	 * @returns { string }
	 */
	strNumber(num, forced) {
		if (typeof num !== "number") return;
		let result = lib.numstrList.get(num);
		if (result === undefined && forced) result = num.toString();
		return result;
	}
	/**
	 * 返回扑克牌中的表示形式对应的数字
	 * @param { string } str
	 * @param { boolean } [forced] 未获取字母点数对应元素时是否返回数字格式
	 * @returns { number }
	 */
	numString(str, forced) {
		if (typeof str !== "string") return;
		let result = lib.numstrList.entries().reduce((map, list) => {
			map[list[1]] = list[0];
			return map;
		}, {})[str];
		if (result === undefined && forced) result = parseInt(str);
		return result;
	}
```
修改使用特定数字的列举实现的技能/卡牌init显示