### PR TITLE
usable添加类别注释；触发技支持非number的usable类型

### DIFF
--- a/node_modules/@types/noname-typings/Skill.d.ts
+++ b/node_modules/@types/noname-typings/Skill.d.ts
@@ -612,13 +612,15 @@ declare interface Skill {
 	/** 
 	 * 每回合限制使用次数
 	 * 
-	 * （若限制使用次数为变量时需写在filter内，即通过filter与变量动态判断） 
-	 * 
 	 * 主要在createTrigger，step3中触发计数。
 	 * 
-	 * 触发计数，会在玩家身上添加“counttrigger”技能，计数记录在：player.storage.counttrigger[当前技能名]
+	 * enable类技能触发后，若当前技能事件的addCount属性不为false，会在玩家的stat[玩家最新stat属性于stat位数].skill属性中添加此技能的发动计数，获取方式为：player.stat[获取所需回合数].skill[当前技能名]
+	 * 
+	 * trigger类技能触发后，若此技能设有此属性，会在玩家身上添加“counttrigger”技能，计数记录在：player.storage.counttrigger[当前技能名]
+	 * @param skill 获取发动次数的技能
+	 * @param player 
 	 */
-	usable?: number;
+	usable?:((skill: string, player: Player) => number) | number;
 	/** 
 	 * 每一轮的使用次数
 	 * 

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -3340,7 +3340,7 @@ export const Content = {
 			player.logSkill(popup_info, info.logLine === false ? false : targets, info.line, null, args);
 		}
 		var next = game.createEvent(event.skill);
-		if (typeof info.usable == "number") {
+		if (info.usable !== undefined) {
 			player.addSkill("counttrigger");
 			if (!player.storage.counttrigger) player.storage.counttrigger = {};
 			if (!player.storage.counttrigger[event.skill]) player.storage.counttrigger[event.skill] = 1;


### PR DESCRIPTION
### PR受影响的平台
无
### 诱因和背景
动态usable内容补充
### PR描述
见标题
### PR测试
我和无名杀有一个能跑
### 扩展适配
无
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码