### PR TITLE
爆改GameEvent.start和window.onerror

### DIFF
--- a/noname/init/index.js
+++ b/noname/init/index.js
@@ -924,8 +924,11 @@ async function setOnError() {
 		const match = version.match(reg) != null;
 		str += "\n" + `${match ? "游戏" : "无名杀"}版本: ${version || "未知版本"}`;
 		if (match) str += "\n⚠️您使用的游戏代码不是源于libccy/noname无名杀官方仓库，请自行寻找您所使用的游戏版本开发者反馈！";
-		if (_status && _status.event) {
-			let evt = _status.event;
+		if (_status && (_status.errEvent || _status.event)) {
+			let evt = _status.errEvent;
+			if (!evt) {
+				evt = _status.event
+			}
 			str += `\nevent.name: ${evt.name}\nevent.step: ${evt.step}`;
 			// @ts-ignore
 			if (evt.parent) str += `\nevent.parent.name: ${evt.parent.name}\nevent.parent.step: ${evt.parent.step}`;

--- a/noname/status/index.js
+++ b/noname/status/index.js
@@ -16,6 +16,10 @@ export class status {
 	set event(event) {
 		this.eventManager.setStatusEvent(event);
 	}
+	/**
+	 * @type { GameEvent | undefined }
+	 */
+	errEvent = undefined;
 	ai = {};
 	lastdragchange = [];
 	/**


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
事件处理机制重写后，出现错误弹窗时的_status.event并非是真正出错的事件。

### PR描述
<!-- 详细描述您的更改 -->
改动了GameEvent.start，使其出现错误时，会将真正错误的事件设置到_status.errEvent。
另外也改动了window.onerror，在存在_status.errEvent时，会优先显示_status.errEvent对应事件的信息。


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
爆改前：
![image](https://github.com/user-attachments/assets/5adc3ae5-a728-4d03-a2ae-c65b38685523)
爆改后：
![image](https://github.com/user-attachments/assets/c1bbb4c7-b0a1-416f-b42a-5eeb6a8c7e02)
符合期望结果


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
不需要


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
