### PR TITLE
添加扩展的新方法+扩展武将对象写法bugfix

### DIFF
--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -2084,10 +2084,10 @@ export class Game extends GameCompatible {
 				content = object.content,
 				precontent = object.precontent;
 			extensionPack.code = {
-				arenaReady: arenaReady,
-				content: content,
-				precontent: precontent,
-				help: help,
+				arenaReady,
+				content,
+				precontent,
+				help,
 				config: objectConfig,
 			};
 			try {
@@ -2098,7 +2098,7 @@ export class Game extends GameCompatible {
 					delete _status.extension;
 				}
 			} catch (e1) {
-				console.log(`加载《${name}》扩展的precontent时出现错误。`, e1);
+				console.error(`加载《${name}》扩展的precontent时出现错误。`, e1);
 				if (!lib.config.extension_alert) alert(`加载《${name}》扩展的precontent时出现错误。\n该错误本身可能并不影响扩展运行。您可以在“设置→通用→无视扩展报错”中关闭此弹窗。\n${decodeURI(e1.stack)}`);
 			}
 

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -2080,9 +2080,11 @@ export class Game extends GameCompatible {
 				if (!extensionPackFiles.card) extensionPackFiles.card = [];
 				if (!extensionPackFiles.skill) extensionPackFiles.skill = [];
 			} else extensionPack = lib.extensionPack[name] = {};
-			const content = object.content,
+			const arenaReady = object.arenaReady,
+				content = object.content,
 				precontent = object.precontent;
 			extensionPack.code = {
+				arenaReady: arenaReady,
 				content: content,
 				precontent: precontent,
 				help: help,
@@ -2100,7 +2102,7 @@ export class Game extends GameCompatible {
 				if (!lib.config.extension_alert) alert(`加载《${name}》扩展的precontent时出现错误。\n该错误本身可能并不影响扩展运行。您可以在“设置→通用→无视扩展报错”中关闭此弹窗。\n${decodeURI(e1.stack)}`);
 			}
 
-			if (content) lib.extensions.push([name, content, config, _status.evaluatingExtension, objectPackage || {}, object.connect]);
+			if (content) lib.extensions.push([name, content, config, _status.evaluatingExtension, objectPackage || {}, object.connect, arenaReady]);
 		} catch (e) {
 			console.log(e);
 		}

--- a/noname/init/import.js
+++ b/noname/init/import.js
@@ -109,8 +109,7 @@ function generateImportFunction(type, pathParser) {
 }
 
 async function createEmptyExtension(name) {
-	const extensionInfo = await lib.init.promises.json(`${lib.assetURL}extension/${name}/info.json`) //await import(`../../extension/${name}/info.json`,{assert:{type:'json'}})
-	.then(info => info, () => {
+	const extensionInfo = await lib.init.promises.json(`${lib.assetURL}extension/${name}/info.json`).then(info => info, () => {
 		return {
 			name,
 			intro: `扩展<b>《${name}》</b>尚未开启，请开启后查看信息。（建议扩展添加info.json以在关闭时查看信息）`,

--- a/noname/init/import.js
+++ b/noname/init/import.js
@@ -109,26 +109,23 @@ function generateImportFunction(type, pathParser) {
 }
 
 async function createEmptyExtension(name) {
-	const extensionInfo = await lib.init.promises
-		.json(`${lib.assetURL}extension/${name}/info.json`) //await import(`../../extension/${name}/info.json`,{assert:{type:'json'}})
-		.then(
-			info => info,
-			() => {
-				return {
-					name: name,
-					intro: `扩展<b>《${name}》</b>尚未开启，请开启后查看信息。（建议扩展添加info.json以在关闭时查看信息）`,
-					author: "未知",
-					diskURL: "",
-					forumURL: "",
-					version: "1.0",
-				};
-			}
-		);
+	const extensionInfo = await lib.init.promises.json(`${lib.assetURL}extension/${name}/info.json`) //await import(`../../extension/${name}/info.json`,{assert:{type:'json'}})
+	.then(info => info, () => {
+		return {
+			name,
+			intro: `扩展<b>《${name}》</b>尚未开启，请开启后查看信息。（建议扩展添加info.json以在关闭时查看信息）`,
+			author: "未知",
+			diskURL: "",
+			forumURL: "",
+			version: "1.0",
+		};
+	});
 	return {
 		name: extensionInfo.name,
 		editable: false,
-		content: function (config, pack) {},
-		precontent: function () {},
+		arenaReady () {},
+		content (config, pack) {},
+		precontent () {},
 		config: {},
 		help: {},
 		package: {

--- a/noname/init/loading.js
+++ b/noname/init/loading.js
@@ -287,6 +287,9 @@ export async function loadExtension(extension) {
 					lib.characterGuozhanFilter.add(content.name);
 				}
 				for (const [charaName, character] of Object.entries(content.character)) {
+					if (lib.config.forbidai_user && lib.config.forbidai_user.includes(charaName)) {
+						lib.config.forbidai.add(charaName);
+					}
 					if (Array.isArray(character)) {
 						if (!character[4]) {
 							character[4] = [];
@@ -301,12 +304,9 @@ export async function loadExtension(extension) {
 							character[4].add(audio);
 						}
 
-						const boss = character[4].includes("boss") || character[4].includes("hiddenboss");
-						const userForbidAI = lib.config.forbidai_user?.includes(charaName);
-						if (boss || userForbidAI) {
+						if (character[4].includes("boss") || character[4].includes("hiddenboss")) {
 							lib.config.forbidai.add(charaName);
 						}
-
 						for (const skill of character[3]) {
 							lib.skilllist.add(skill);
 						}

--- a/noname/init/loading.js
+++ b/noname/init/loading.js
@@ -255,6 +255,9 @@ export async function loadExtension(extension) {
 			}
 		}
 
+		if (extension[6]) {
+			if (typeof extension[6] == "function") lib.arenaReady?.push(extension[6]);
+		}
 		if (extension[4]) {
 			if (typeof extension[4].character?.character == "object" && Object.keys(extension[4].character.character).length > 0) {
 				const content = { ...extension[4].character };

--- a/noname/init/loading.js
+++ b/noname/init/loading.js
@@ -311,19 +311,7 @@ export async function loadExtension(extension) {
 							lib.skilllist.add(skill);
 						}
 					} else {
-						if (character.img) {
-							if (!character.img.some(str => typeof str == "string" && /^(?:db:extension-.+?|ext|img):.+/.test(str))) {
-								const i = extension[3] ? `db:extension-${extension[0]}:${charaName}.jpg` : `ext:${extension[0]}/${charaName}.jpg`;
-								character.img.add(i);
-							}
-						}
-						if (character.dieAudios) {
-							if (!character.dieAudios.some(str => typeof str == "string" && /^die:.+/.test(str))) {
-								const audio = `die:ext:${extension[0]}/${charaName}.mp3`;
-								character.dieAudios.add(audio);
-							}
-						}
-
+						// TODO 宝贝，有空看一下这里的原画和语音，绕得我头晕晕的。先睡一觉喵
 						if (character.isBoss || character.isHiddenBoss) {
 							lib.config.forbidai.add(charaName);
 						}

--- a/noname/init/loading.js
+++ b/noname/init/loading.js
@@ -12,6 +12,7 @@ import { gnc } from "../gnc/index.js";
 import { importMode } from "./import.js";
 import { Mutex } from "../util/mutex.js";
 import { load } from "../util/config.js";
+import { isClass } from "../util/index.js";
 
 /**
  * 读取导入的卡牌包信息
@@ -153,7 +154,7 @@ export function loadCharacter(character) {
 			case "character":
 				if (!lib.config.characters.includes(name) && lib.config.mode !== "connect") {
 					if (lib.config.mode === "chess" && get.config("chess_mode") === "leader" && get.config("chess_leader_allcharacter")) {
-						for (let charaName in value) {
+						for (const charaName in value) {
 							// @ts-ignore
 							lib.hiddenCharacters.push(charaName);
 						}
@@ -239,12 +240,6 @@ export function loadCharacter(character) {
 }
 
 export async function loadExtension(extension) {
-	function isClass(func) {//让我查查你是不是类喵
-		if (typeof func !== 'function') return false;
-		const fnStr = Function.prototype.toString.call(func);
-		return /^class\s/.test(fnStr);
-	}
-
 	if (!extension[5] && lib.config.mode === "connect") return;
 
 	try {
@@ -311,7 +306,15 @@ export async function loadExtension(extension) {
 							lib.skilllist.add(skill);
 						}
 					} else {
-						// TODO 宝贝，有空看一下这里的原画和语音，绕得我头晕晕的。先睡一觉喵
+						if (!character.img) {
+							const characterImage = `extension/${extension[0]}/${charaName}.jpg`;
+							character.img = characterImage;
+						}
+						if (!character.dieAudios) {
+							character.dieAudios = [];
+							const characterDieAudio = `ext:${extension[0]}/${charaName}.mp3`;
+							character.dieAudios.push(characterDieAudio);
+						}
 						if (character.isBoss || character.isHiddenBoss) {
 							lib.config.forbidai.add(charaName);
 						}
@@ -471,7 +474,6 @@ export function loadPlay(playConfig) {
 				break;
 			default:
 				for (const [itemName, item] of Object.entries(configItem)) {
-					// lib[j][k+'_play_config']=play[i][j][k];
 					if (configName !== "translate" || itemName !== i) {
 						if (lib[configName][itemName] != null) {
 							console.log(`duplicated ${configName} in play ${i}:\n${itemName}:\nlib.${configName}.${itemName}`, lib[configName][itemName], `\nplay.${i}.${configName}.${itemName}`, item);

--- a/noname/init/loading.js
+++ b/noname/init/loading.js
@@ -311,6 +311,19 @@ export async function loadExtension(extension) {
 							lib.skilllist.add(skill);
 						}
 					} else {
+						if (character.img) {
+							if (!character.img.some(str => typeof str == "string" && /^(?:db:extension-.+?|ext|img):.+/.test(str))) {
+								const i = extension[3] ? `db:extension-${extension[0]}:${charaName}.jpg` : `ext:${extension[0]}/${charaName}.jpg`;
+								character.img.add(i);
+							}
+						}
+						if (character.dieAudios) {
+							if (!character.dieAudios.some(str => typeof str == "string" && /^die:.+/.test(str))) {
+								const audio = `die:ext:${extension[0]}/${charaName}.mp3`;
+								character.dieAudios.add(audio);
+							}
+						}
+
 						if (character.isBoss || character.isHiddenBoss) {
 							lib.config.forbidai.add(charaName);
 						}

--- a/noname/init/loading.js
+++ b/noname/init/loading.js
@@ -182,7 +182,7 @@ export function loadCharacter(character) {
 							if (value2[4].includes("boss") || value2[4].includes("hiddenboss")) {
 								lib.config.forbidai.add(key2);
 							}
-							for (let skill of value2[3]) {
+							for (const skill of value2[3]) {
 								lib.skilllist.add(skill);
 							}
 						} else {
@@ -190,7 +190,7 @@ export function loadCharacter(character) {
 								lib.config.forbidai.add(key2);
 							}
 							if (value2.skills) {
-								for (let skill of value2.skills) {
+								for (const skill of value2.skills) {
 									lib.skilllist.add(skill);
 								}
 							}
@@ -287,27 +287,38 @@ export async function loadExtension(extension) {
 					lib.characterGuozhanFilter.add(content.name);
 				}
 				for (const [charaName, character] of Object.entries(content.character)) {
-					if (!character[4]) {
-						character[4] = [];
-					}
+					if (Array.isArray(character)) {
+						if (!character[4]) {
+							character[4] = [];
+						}
 
-					if (!character[4].some(str => typeof str == "string" && /^(?:db:extension-.+?|ext|img):.+/.test(str))) {
-						const img = extension[3] ? `db:extension-${extension[0]}:${charaName}.jpg` : `ext:${extension[0]}/${charaName}.jpg`;
-						character[4].add(img);
-					}
-					if (!character[4].some(str => typeof str == "string" && /^die:.+/.test(str))) {
-						const audio = `die:ext:${extension[0]}/${charaName}.mp3`;
-						character[4].add(audio);
-					}
+						if (!character[4].some(str => typeof str == "string" && /^(?:db:extension-.+?|ext|img):.+/.test(str))) {
+							const img = extension[3] ? `db:extension-${extension[0]}:${charaName}.jpg` : `ext:${extension[0]}/${charaName}.jpg`;
+							character[4].add(img);
+						}
+						if (!character[4].some(str => typeof str == "string" && /^die:.+/.test(str))) {
+							const audio = `die:ext:${extension[0]}/${charaName}.mp3`;
+							character[4].add(audio);
+						}
 
-					const boss = character[4].includes("boss") || character[4].includes("hiddenboss");
-					const userForbidAI = lib.config.forbidai_user?.includes(charaName);
-					if (boss || userForbidAI) {
-						lib.config.forbidai.add(charaName);
-					}
+						const boss = character[4].includes("boss") || character[4].includes("hiddenboss");
+						const userForbidAI = lib.config.forbidai_user?.includes(charaName);
+						if (boss || userForbidAI) {
+							lib.config.forbidai.add(charaName);
+						}
 
-					for (const skill of character[3]) {
-						lib.skilllist.add(skill);
+						for (const skill of character[3]) {
+							lib.skilllist.add(skill);
+						}
+					} else {
+						if (character.isBoss || character.isHiddenBoss) {
+							lib.config.forbidai.add(charaName);
+						}
+						if (character.skills) {
+							for (const skill of character.skills) {
+								lib.skilllist.add(skill);
+							}
+						}
 					}
 				}
 				if (typeof content.skill == "object") {

--- a/noname/ui/create/menu/pages/exetensionMenu.js
+++ b/noname/ui/create/menu/pages/exetensionMenu.js
@@ -335,7 +335,7 @@ export const extensionMenu = function (connectMenu) {
 					var ext = {};
 					for (var i in dash4.content) {
 						try {
-							if (i == "content" || i == "precontent") {
+							if (i =="arenaReady" || i == "content" || i == "precontent") {
 								ext[i] = security.exec2(`return (${dash4.content[i]});`).return;
 								if (typeof ext[i] != "function") {
 									throw "err";
@@ -420,17 +420,18 @@ export const extensionMenu = function (connectMenu) {
 					}
 					str += ",files:" + JSON.stringify(files);
 					str += "}";
-					var extension = {
+					const extension = {
 						"extension.js":
-							'import { lib, game, ui, get, ai, _status } from "../../noname.js";\ngame.import("extension",function(){\n\treturn ' +
+							'import { lib, game, ui, get, ai, _status } from "../../noname.js";\nexport const type = "extension";\nexport default function(){\n\treturn ' +
 							str +
-							"\n});",
+							"\n};",
 						"info.json": JSON.stringify({
+							intro: introExtLine.querySelector("input").value ?? "",
 							name: page.currentExtension,
-							author: authorExtLine.querySelector("input").value || "",
-							diskURL: diskExtLine.querySelector("input").value || "",
-							forumURL: forumExtLine.querySelector("input").value || "",
-							version: versionExtLine.querySelector("input").value || ""
+							author: authorExtLine.querySelector("input").value ?? "",
+							diskURL: diskExtLine.querySelector("input").value ?? "",
+							forumURL: forumExtLine.querySelector("input").value ?? "",
+							version: versionExtLine.querySelector("input").value ?? ""
 						}),
 					};
 					for (var i in dash1.content.image) {
@@ -2429,6 +2430,8 @@ export const extensionMenu = function (connectMenu) {
 							dashes[i].node.code = page.content[i] || "";
 						}
 					} else {
+						dashes.arenaReady.node.code =
+							"function(){\n    \n}\n\n/*\n函数执行时机为舞台创建之后\n导出时本段代码中的换行、缩进以及注释将被清除\n*/";
 						dashes.content.node.code =
 							"function(config,pack){\n    \n}\n\n/*\n函数执行时机为游戏数据加载之后、界面加载之前\n参数1扩展选项（见选项代码）；参数2为扩展定义的武将、卡牌和技能等（可在此函数中修改）\n导出时本段代码中的换行、缩进以及注释将被清除\n*/";
 						dashes.precontent.node.code =
@@ -2457,7 +2460,7 @@ export const extensionMenu = function (connectMenu) {
 							code = container.textarea.value;
 						}
 						try {
-							if (link == "content" || link == "precontent") {
+							if (link == "arenaReady" || link == "content" || link == "precontent") {
 								var { func } = security.exec2(`func = ${code}`);
 								if (typeof func != "function") {
 									throw "err";
@@ -2532,6 +2535,14 @@ export const extensionMenu = function (connectMenu) {
 					}
 				};
 				page.content = {};
+				createCode(
+					"辅",
+					"辅助代码",
+					page,
+					clickCode,
+					"arenaReady",
+					"function(){\n    \n}\n\n/*\n函数执行时机为游戏舞台创建之后\n导出时本段代码中的换行、缩进以及注释将被清除\n*/"
+				);
 				createCode(
 					"主",
 					"主代码",

--- a/noname/ui/create/menu/pages/exetensionMenu.js
+++ b/noname/ui/create/menu/pages/exetensionMenu.js
@@ -335,7 +335,7 @@ export const extensionMenu = function (connectMenu) {
 					var ext = {};
 					for (var i in dash4.content) {
 						try {
-							if (i =="arenaReady" || i == "content" || i == "precontent") {
+							if (["arenaReady", "content", "precontent"].includes(i)) {
 								ext[i] = security.exec2(`return (${dash4.content[i]});`).return;
 								if (typeof ext[i] != "function") {
 									throw "err";
@@ -364,47 +364,35 @@ export const extensionMenu = function (connectMenu) {
 					for (var i = 0; i < dash2.pile.childNodes.length; i++) {
 						dash2.content.pack.list.push(dash2.pile.childNodes[i].link);
 					}
-					str +=
-						",package:" +
-						get.stringify({
-							//替换die audio，加上扩展名
-							//TODO: 创建扩展这部分更是重量级
-							character: ((pack) => {
-								var character = pack.character;
-								for (var key in character) {
-									var info = character[key];
-									if (Array.isArray(info[4])) {
-										var tag = info[4].find((tag) => /^die:.+$/.test(tag));
-										if (tag) {
-											info[4].remove(tag);
-											if (typeof game.readFile == "function") {
-												info[4].push(
-													"die:ext:" +
-													page.currentExtension +
-													"/audio/die/" +
-													tag.slice(tag.lastIndexOf("/") + 1)
-												);
-											} else {
-												info[4].push(
-													"die:db:extension-" +
-													page.currentExtension +
-													":audio/die/" +
-													tag.slice(tag.lastIndexOf("/") + 1)
-												);
-											}
+					str += ",package:" + get.stringify({
+						//替换die audio，加上扩展名
+						//TODO: 创建扩展这部分更是重量级
+						character: ((pack) => {
+							var character = pack.character;
+							for (var key in character) {
+								var info = character[key];
+								if (Array.isArray(info[4])) {
+									var tag = info[4].find((tag) => /^die:.+$/.test(tag));
+									if (tag) {
+										info[4].remove(tag);
+										if (typeof game.readFile == "function") {
+											info[4].push("die:ext:" + page.currentExtension + "/audio/die/" + tag.slice(tag.lastIndexOf("/") + 1));
+										} else {
+											info[4].push("die:db:extension-" + page.currentExtension + ":audio/die/" + tag.slice(tag.lastIndexOf("/") + 1));
 										}
 									}
 								}
-								return pack;
-							})(dash1.content.pack),
-							card: dash2.content.pack,
-							skill: dash3.content.pack,
-							intro: introExtLine.querySelector("input").value || "",
-							author: authorExtLine.querySelector("input").value || "",
-							diskURL: diskExtLine.querySelector("input").value || "",
-							forumURL: forumExtLine.querySelector("input").value || "",
-							version: versionExtLine.querySelector("input").value || "",
-						});
+							}
+							return pack;
+						})(dash1.content.pack),
+						card: dash2.content.pack,
+						skill: dash3.content.pack,
+						intro: introExtLine.querySelector("input").value || "",
+						author: authorExtLine.querySelector("input").value || "",
+						diskURL: diskExtLine.querySelector("input").value || "",
+						forumURL: forumExtLine.querySelector("input").value || "",
+						version: versionExtLine.querySelector("input").value || "",
+					});
 					var files = { character: [], card: [], skill: [], audio: [] };
 					for (var i in dash1.content.image) {
 						files.character.push(i);
@@ -419,6 +407,7 @@ export const extensionMenu = function (connectMenu) {
 						files.skill.push(i);
 					}
 					str += ",files:" + JSON.stringify(files);
+					str += ",connect:false"//不写的话，这里会变成undefined喵，所以默认是不能联机的哦
 					str += "}";
 					const extension = {
 						"extension.js":
@@ -2430,16 +2419,11 @@ export const extensionMenu = function (connectMenu) {
 							dashes[i].node.code = page.content[i] || "";
 						}
 					} else {
-						dashes.arenaReady.node.code =
-							"function(){\n    \n}\n\n/*\n函数执行时机为舞台创建之后\n导出时本段代码中的换行、缩进以及注释将被清除\n*/";
-						dashes.content.node.code =
-							"function(config,pack){\n    \n}\n\n/*\n函数执行时机为游戏数据加载之后、界面加载之前\n参数1扩展选项（见选项代码）；参数2为扩展定义的武将、卡牌和技能等（可在此函数中修改）\n导出时本段代码中的换行、缩进以及注释将被清除\n*/";
-						dashes.precontent.node.code =
-							"function(){\n    \n}\n\n/*\n函数执行时机为游戏数据加载之前，联机模式亦可加载\n除添加模式外请慎用\n导出时本段代码中的换行、缩进以及注释将被清除\n*/";
-						dashes.config.node.code =
-							'config={\n    \n}\n\n/*\n示例：\nconfig={\n    switcher_example:{\n    name:"示例列表选项",\n        init:"3",\n        item:{"1":"一","2":"二","3":"三"}\n    },\n    toggle_example:{\n        name:"示例开关选项",\n        init:true\n    }\n}\n此例中传入的主代码函数的默认参数为{switcher_example:"3",toggle_example:true}\n导出时本段代码中的换行、缩进以及注释将被清除\n*/';
-						dashes.help.node.code =
-							'help={\n    \n}\n\ns/*\n示例：\nhelp={\n    "帮助条目":"<ul><li>列表1-条目1<li>列表1-条目2</ul><ol><li>列表2-条目1<li>列表2-条目2</ul>"\n}\n帮助内容将显示在菜单－选项－帮助中\n导出时本段代码中的换行、缩进以及注释将被清除\n*/';
+						dashes.arenaReady.node.code = "function(){\n    \n}\n\n/*\n函数执行时机为界面创建之后\n导出时本段代码中的换行、缩进以及注释将被清除\n*/";
+						dashes.content.node.code = "function(config,pack){\n    \n}\n\n/*\n函数执行时机为游戏数据加载之后、界面加载之前\n参数1扩展选项（见选项代码）；参数2为扩展定义的武将、卡牌和技能等（可在此函数中修改）\n导出时本段代码中的换行、缩进以及注释将被清除\n*/";
+						dashes.precontent.node.code = "function(){\n    \n}\n\n/*\n函数执行时机为游戏数据加载之前，联机模式亦可加载\n除添加模式外请慎用\n导出时本段代码中的换行、缩进以及注释将被清除\n*/";
+						dashes.config.node.code = 'config={\n    \n}\n\n/*\n示例：\nconfig={\n    switcher_example:{\n    name:"示例列表选项",\n        init:"3",\n        item:{"1":"一","2":"二","3":"三"}\n    },\n    toggle_example:{\n        name:"示例开关选项",\n        init:true\n    }\n}\n此例中传入的主代码函数的默认参数为{switcher_example:"3",toggle_example:true}\n导出时本段代码中的换行、缩进以及注释将被清除\n*/';
+						dashes.help.node.code = 'help={\n    \n}\n\ns/*\n示例：\nhelp={\n    "帮助条目":"<ul><li>列表1-条目1<li>列表1-条目2</ul><ol><li>列表2-条目1<li>列表2-条目2</ul>"\n}\n帮助内容将显示在菜单－选项－帮助中\n导出时本段代码中的换行、缩进以及注释将被清除\n*/';
 					}
 				};
 				var dashes = {};
@@ -2460,7 +2444,7 @@ export const extensionMenu = function (connectMenu) {
 							code = container.textarea.value;
 						}
 						try {
-							if (link == "arenaReady" || link == "content" || link == "precontent") {
+							if (["arenaReady", "content", "precontent"].includes(link)) {
 								var { func } = security.exec2(`func = ${code}`);
 								if (typeof func != "function") {
 									throw "err";
@@ -2541,7 +2525,7 @@ export const extensionMenu = function (connectMenu) {
 					page,
 					clickCode,
 					"arenaReady",
-					"function(){\n    \n}\n\n/*\n函数执行时机为游戏舞台创建之后\n导出时本段代码中的换行、缩进以及注释将被清除\n*/"
+					"function(){\n    \n}\n\n/*\n函数执行时机为游戏界面创建之后\n导出时本段代码中的换行、缩进以及注释将被清除\n*/"
 				);
 				createCode(
 					"主",

--- a/noname/util/index.js
+++ b/noname/util/index.js
@@ -78,3 +78,14 @@ export function leaveCompatibleEnvironment() {
 export function jumpToCatchBlock() {
 	throw new Error("");
 }
+
+/**
+ *
+ * @return {boolean}
+ * @param {function}
+ */
+export function isClass(func) {
+	if (typeof func !== 'function') return false;
+	const fnStr = Function.prototype.toString.call(func);
+	return /^class\s/.test(fnStr);
+}


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->

所有的喵
### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
来自和R喵8月份的谈话内容，最近看到R喵活了又想起来了哦😘
以及狂神喵的提醒

### PR描述
<!-- 详细描述您的更改 -->

为扩展直接添加一个arenaReady方法
过去经常需要在content()/precontent()里手动添加，现在可以直接写了
现在extension.package.character.character
里面的写法可以为最新的对象形式；

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
主要使用了多个用到了arenaReady时机的扩展进行测试（如十周年UI,千幻，炉石等等）



### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
喵喵！不需要强制适配，但扩展作者可以迁移出在自己扩展里手动添加的该方法喵（如果有😘
（以及可以不要用牢数组了🥺（小声））


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
