### PR TITLE
修复Linux下的路径判断

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -101,7 +101,7 @@
 	// 处理Node环境下的http情况
 	if (typeof window.require == "function" && typeof window.process == "object" && typeof window.__dirname == "string") {
 		// 在http环境下修改__dirname和require的逻辑
-		if (window.__dirname.endsWith("electron.asar\\renderer")) {
+		if (window.__dirname.endsWith("electron.asar\\renderer") || window.__dirname.endsWith("electron.asar/renderer")) {
 			const path = require("path");
 			window.__dirname = path.join(path.resolve(), "resources/app");
 			const oldData = Object.entries(window.require);


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
Linux

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
判断__dirname的路径没有考虑路径分隔符和Windows不同导致修改失败



