### PR TITLE
弃牌阶段弃牌可以连续弃置

### DIFF
--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -5885,6 +5885,18 @@ export const Content = {
 				event.result = "ai";
 			}
 		}
+        var range = get.select(event.selectCard);
+        if (range[1] > 1 && typeof event.selectCard != 'function') {
+            event.promptdiscard = ui.create.control('AI代选', function () {
+                ai.basic.chooseCard(event.ai);
+                if (_status.event.custom && _status.event.custom.add.card) {
+                    _status.event.custom.add.card();
+                }
+                for (var i = 0; i < ui.selected.cards.length; i++) {
+                    ui.selected.cards[i].updateTransform(true);
+                }
+            });
+        }
 		"step 1";
 		if (event.result == "ai") {
 			game.check();
@@ -5908,6 +5920,7 @@ export const Content = {
 			}
 		}
 		if (event.dialog) event.dialog.close();
+        if (event.promptdiscard) event.promptdiscard.close();
 	},
 	chooseTarget: function () {
 		"step 0";

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -4034,6 +4034,7 @@ export const Content = {
 	},
     async phaseDiscard(event, trigger, player) {
         game.log(player, '进入了弃牌阶段');
+        await event.trigger('phaseDiscard');
         let discardCount = player.needsToDiscard();
         if (discardCount <= 0) {
             event.finish();
@@ -4057,7 +4058,6 @@ export const Content = {
             }
         }
         player.discard(event.cards);
-        event.trigger('phaseDiscard');
     },
 	phaseJieshu: function () {
 		event.trigger(event.name);


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台

无

### 诱因和背景 

弃牌阶段如果卡牌过多则可能过于累赘

### PR描述

修改了可以连续弃置，目前使用的是lose，同时设置为null不触发事件

### PR测试

测试了没问题

### 扩展适配

对于已经写过类似代码的可以删除，也不会产生影响

### 检查清单

<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->

- [X]  我没有把该PR提交到`master`分支
- [X]  commit中没有无用信息，和没有具体内容的“bugfix”
- [X]  我已经进行了充足的测试，且现有的测试都已通过
- [x]  如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x]  如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x]  如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x]  如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x]  如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [X]  我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [X]  我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码