### PR TITLE
武将右键和武将简介展示更多信息

### DIFF
--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -713,7 +713,24 @@ export class Get extends GetCompatible {
 	 * @returns { string }
 	 */
 	characterIntro(name) {
-		if (lib.characterIntro[name]) return lib.characterIntro[name];
+		var str = '';
+		if (lib.characterCopyright[name]) {//版权信息
+			str += lib.characterCopyright[name];
+		}
+		else str += '暂无版权信息';
+		str += '<br>';
+		if (lib.characterCitetext[name]) {//上引文
+			str += lib.characterCitetext[name];
+			str += '<br>';
+		}
+		if (lib.characterUndertext[name]) {//下引文
+			str += lib.characterUndertext[name];
+			str += '<br>';
+		}
+		//正片开始
+		if (lib.characterIntro[name]) {
+			return str + lib.characterIntro[name];
+		}
 		var tags = get.character(name, 4);
 		if (tags) {
 			for (var i = 0; i < tags.length; i++) {
@@ -725,8 +742,8 @@ export class Get extends GetCompatible {
 		while (name.includes("_") && !lib.characterIntro[name]) {
 			name = name.slice(name.indexOf("_") + 1);
 		}
-		if (lib.characterIntro[name]) return lib.characterIntro[name];
-		return "暂无武将介绍";
+		if (lib.characterIntro[name]) return str + lib.characterIntro[name];
+		return str + "暂无武将介绍";
 	}
 	bordergroup(info, raw) {
 		if (typeof info == "string") info = get.character(info);
@@ -3612,6 +3629,9 @@ export class Get extends GetCompatible {
 			if (lib.characterTitle[node.name]) {
 				uiintro.addText(get.colorspan(lib.characterTitle[node.name]));
 			}
+			if (lib.characterCitetext[node.name]) {
+				uiintro.addText(get.colorspan(lib.characterCitetext[node.name]));
+			}
 
 			if (get.characterInitFilter(node.name)) {
 				const initFilters = get.characterInitFilter(node.name).filter(tag => {
@@ -3767,6 +3787,9 @@ export class Get extends GetCompatible {
 			// 		}
 			// 	}
 			// }
+			if (lib.characterUndertext[node.name]) {
+				uiintro.addText(get.colorspan(lib.characterUndertext[node.name]));
+			}
 
 			if (lib.config.right_range && _status.gameStarted) {
 				uiintro.add(ui.create.div(".placeholder"));
@@ -4336,6 +4359,9 @@ export class Get extends GetCompatible {
 			if (lib.characterTitle[node.link]) {
 				uiintro.addText(get.colorspan(lib.characterTitle[node.link]));
 			}
+			if (lib.characterCitetext[node.link]) {
+				uiintro.addText(get.colorspan(lib.characterCitetext[node.link]));
+			}
 
 			if (get.characterInitFilter(node.link)) {
 				const initFilters = get.characterInitFilter(node.link).filter(tag => {
@@ -4538,6 +4564,9 @@ export class Get extends GetCompatible {
 						});
 					}
 				}
+			}
+			if (lib.characterUndertext[node.link]) {
+				uiintro.addText(get.colorspan(lib.characterUndertext[node.link]));
 			}
 		} else if (node.classList.contains("equips") && ui.arena.classList.contains("selecting")) {
 			(function () {

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -716,9 +716,8 @@ export class Get extends GetCompatible {
 		var str = '';
 		if (lib.characterCopyright[name]) {//版权信息
 			str += lib.characterCopyright[name];
+			str += '<br>';
 		}
-		else str += '暂无版权信息';
-		str += '<br>';
 		if (lib.characterCitetext[name]) {//上引文
 			str += lib.characterCitetext[name];
 			str += '<br>';

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -51,6 +51,9 @@ export class Library {
 	connectBanned = [];
 	characterIntro = {};
 	characterTitle = {};
+	characterCopyright = {};
+	characterCitetext = {};
+	characterUndertext = {};
 	characterPack = new Proxy(
 		{},
 		{


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->


### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->



### PR描述
<!-- 详细描述您的更改 -->

为武将包添加了三个键
characterCopyright，版权信息（可以写别的没人管），这里的文字会在武将简介上边展示。
characterCitetext，上引文，在这里写入文字，会在武将右键展示的页面，称号和技能之间显示，同时这里的文字也会在武将简介中展示，在版权信息下方另起一行。
characterUndertext，下引文，在这里写入文字，会在武将右键展示的页面，技能下方显示，同时这里的文字也会在武将简介中展示，在上引文下方另起一行。

三种信息本质上都是同一性质，不同用法，想咋用见仁见智。

用法：如characterIntro般创建和使用。

> 示例：

```JavaScript
{//假装这是一个武将包
	characterIntro:{
		'caocao':'曹操的简介',
	},
	characterCopyright:{
		'caocao':'这一版技能设计于2009年',
		//这段文字将出现在角色简介中，“曹操的简介”上方
	},
	characterCitetext:{
		'caocao':'宁教我负天下人，休教天下人负我',
		//这段文字将出现于武将右键的称号下方，技能上方
		//同时也会出现在角色简介中，“这一版技能设计于2009年”的下方
	},
	characterUndertext:{
		'caocao':'治世之能臣，乱世之奸雄',
		//这段文字将出现于武将右键的技能下方
		//同时也会出现在角色简介中，“宁教我负天下人，休教天下人负我”的下方，“曹操的简介”的上方
	},
}
```

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->



### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->

有修改get.characterIntro()和get.nodeintro()的扩展需要对比抄录一二。
（详细文档我也不会呀）

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [ ] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [ ] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [ ] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [ ] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [ ] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
