### PR TITLE
修复：【离骚】中玩家回答错误也会结束抢答

### DIFF
--- a/character/collab/skill.js
+++ b/character/collab/skill.js
@@ -1424,20 +1424,22 @@ const skills = {
 				const solve = function (resolve, reject) {
 					return function (result, player) {
 						if (result && result.control && !answer_ok) {
-							resolve();
 							answered.remove(player);
 							if (result.control == sentences[0].split("，")[1 - goon]) {
+								resolve();
 								player.popup("回答正确", "wood");
 								game.log(player, "回答正确");
 								answer_ok = player;
 								gaifa.remove(player);
 							} else {
+								reject();
 								player.popup("回答错误", "fire");
 								game.log(player, "回答错误");
 							}
 						} else reject();
 					};
 				};
+				//等待第一位回答正确（兑现Promise）的玩家，若回答错误（Promise被拒绝）则继续等待
 				await Promise.any(
 					humans.map(current => {
 						return new Promise(async (resolve, reject) => {


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
给别的武将做自定义时间的倒计时，参考离骚的实现的时候，发现即使回答错误也会结束抢答，就顺便修一下。

### PR描述
<!-- 详细描述您的更改 -->
> 这些角色须同时回答《离骚》的句段填空（抢答题，一名角色回答正确后结束答题）

根据技能描述，如果一名角色答错，另一名角色仍可以在倒计时结束之前进行作答（从[作者使用`Promise.any`而非`Promise.race`](https://github.com/libccy/noname/blob/e18a8256e01ab1357e4c7472349dceb3d0aa1a3a/character/collab/skill.js#L1079C11-L1079C22)中也可基本看出此意图）。
因此，从原先的[只要玩家回答，就兑现Promise](https://github.com/libccy/noname/blob/e18a8256e01ab1357e4c7472349dceb3d0aa1a3a/character/collab/skill.js#L1065)，改为[仅在玩家答对时兑现](https://github.com/bacz00/noname/blob/8e616ae7bd3aab8d925d5e1fef690fc36d0fd58b/character/collab/skill.js#L1429)，[否则拒绝Promise](https://github.com/bacz00/noname/blob/8e616ae7bd3aab8d925d5e1fef690fc36d0fd58b/character/collab/skill.js#L1435)。

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
测试两名玩家分别答对/答错/超时的各种组合，均为正常。（至少和我理解的技能描述一样）

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
